### PR TITLE
Improved error messages.

### DIFF
--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -39,7 +39,7 @@ class Extender {
     private static final String ANDROID_STL_LIB_PATH = System.getenv("ANDROID_STL_LIB");
     private static final String ANDROID_SYSROOT_PATH = System.getenv("ANDROID_SYSROOT");
 
-    Extender(String platform, File extensionSource, File sdk, String buildDirectory) throws IOException {
+    Extender(String platform, File extensionSource, File sdk, String buildDirectory) throws IOException, ExtenderException {
         // Read config from SDK
         InputStream configFileInputStream = Files.newInputStream(new File(sdk.getPath() + "/extender/build.yml").toPath());
         this.config = new Yaml().loadAs(configFileInputStream, Configuration.class);
@@ -54,7 +54,7 @@ class Extender {
         this.build = Files.createTempDirectory(buildPath, "build").toFile();
 
         if (this.platformConfig == null) {
-            throw new IllegalArgumentException(String.format("Unsupported platform %s", platform));
+            throw new ExtenderException(String.format("Unsupported platform %s", platform));
         }
 
         this.manifestValidator = new ExtensionManifestValidator(new WhitelistConfig(), this.platformConfig.allowedFlags, this.platformConfig.allowedLibs);

--- a/server/src/main/java/com/defold/extender/ExtenderController.java
+++ b/server/src/main/java/com/defold/extender/ExtenderController.java
@@ -63,11 +63,15 @@ public class ExtenderController {
     }
 
     @RequestMapping(method = RequestMethod.POST, value = "/build/{platform}")
-    public void buildEngineLocal(MultipartHttpServletRequest req, HttpServletResponse resp,
+    public void buildEngineLocal(MultipartHttpServletRequest request, HttpServletResponse response,
                                  @PathVariable("platform") String platform)
             throws URISyntaxException, IOException, ExtenderException {
 
-        buildEngine(req, resp, platform, null);
+        if (defoldSdkService.isLocalSdkSupported()) {
+            buildEngine(request, response, platform, null);
+        }
+
+        throw new ExtenderException("No SDK version specified.");
     }
 
     @RequestMapping(method = RequestMethod.POST, value = "/build/{platform}/{sdkVersion}")

--- a/server/src/main/java/com/defold/extender/services/DefoldSdkService.java
+++ b/server/src/main/java/com/defold/extender/services/DefoldSdkService.java
@@ -98,4 +98,8 @@ public class DefoldSdkService {
         LOGGER.info("Using local Defold SDK at {}", dynamoHome.toString());
         return dynamoHome;
     }
+
+    public boolean isLocalSdkSupported() {
+        return dynamoHome != null;
+    }
 }


### PR DESCRIPTION
* Now responds with a sane error message instead of crashing with a NPE when
not passing SDK version to a production server.

* Now responds with a sane error message when trying to build with an unsupported
platform.