### PR TITLE
Validate manifest YAML before parsing.

### DIFF
--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -112,8 +112,15 @@ class Extender {
         return file;
     }
 
-    private ManifestConfiguration loadManifest(File manifest) throws IOException {
-        return new Yaml().loadAs(FileUtils.readFileToString(manifest), ManifestConfiguration.class);
+    private ManifestConfiguration loadManifest(File manifest) throws IOException, ExtenderException {
+        String yaml = FileUtils.readFileToString(manifest);
+
+        if (yaml.contains("\t")) {
+            throw new ExtenderException("Manifest files (ext.manifest) are YAML files and cannot contain tabs. " +
+                    "Indentation should be done with spaces.");
+        }
+
+        return new Yaml().loadAs(yaml, ManifestConfiguration.class);
     }
 
     static List<File> filterFiles(Collection<File> files, String re) {


### PR DESCRIPTION
This checks for tabs in manifest YAML files before parsing in order
to give a better hint to developers that indent manifests with tabs
instead of spaces.