### PR TITLE
Fix Docker image name.

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -26,6 +26,9 @@ repositories {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
+// This affects the Docker repo name.
+group = 'extender'
+
 dependencies {
     compile('org.springframework.boot:spring-boot-starter-web') {
         exclude module: 'spring-boot-starter-tomcat'


### PR DESCRIPTION
This fixes an issue with the Docker image naming when running build
scripts from a project directory called something else than "extender".