### PR TITLE
Updates to make CI work.

### DIFF
--- a/client/src/main/java/com/defold/extender/client/ExtenderClient.java
+++ b/client/src/main/java/com/defold/extender/client/ExtenderClient.java
@@ -3,6 +3,7 @@ package com.defold.extender.client;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.mime.MultipartEntity;
 import org.apache.http.entity.mime.content.ByteArrayBody;
@@ -15,7 +16,6 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 public class ExtenderClient {
-
     private final String extenderBaseUrl;
     private ExtenderClientCache cache;
 
@@ -23,23 +23,26 @@ public class ExtenderClient {
     public static final String extensionFilename = "ext.manifest";
     public static final Pattern extensionPattern = Pattern.compile(extensionFilename);
 
-    /** Creates a local build cache
-     * @param extenderBaseUrl   The build server url (e.g. https://build.defold.com)
-     * @param cacheDir          A directory where the cache files are located (it must exist beforehand)
+    /**
+     * Creates a local build cache
+     *
+     * @param extenderBaseUrl The build server url (e.g. https://build.defold.com)
+     * @param cacheDir        A directory where the cache files are located (it must exist beforehand)
      */
     public ExtenderClient(String extenderBaseUrl, File cacheDir) throws IOException {
         this.extenderBaseUrl = extenderBaseUrl;
         this.cache = new ExtenderClientCache(cacheDir);
     }
 
-    /** Builds a new engine given a platform and an sdk version plus source files.
+    /**
+     * Builds a new engine given a platform and an sdk version plus source files.
      * The result is a .zip file
      *
-     * @param platform      E.g. "arm64-ios", "armv7-android", "x86_64-osx"
-     * @param sdkVersion    Sha1 of defold version
-     * @param sourceResources   List of resources that should be build on server (.cpp, .a, etc)
-     * @param destination   The output where the returned zip file is copied
-     * @param log           A log file
+     * @param platform        E.g. "arm64-ios", "armv7-android", "x86_64-osx"
+     * @param sdkVersion      Sha1 of defold version
+     * @param sourceResources List of resources that should be build on server (.cpp, .a, etc)
+     * @param destination     The output where the returned zip file is copied
+     * @param log             A log file
      * @throws ExtenderClientException
      */
     public void build(String platform, String sdkVersion, List<ExtenderResource> sourceResources, File destination, File log) throws ExtenderClientException {
@@ -87,5 +90,16 @@ public class ExtenderClient {
 
     private static final String getRelativePath(File base, File path) {
         return base.toURI().relativize(path.toURI()).getPath();
+    }
+
+    public boolean health() throws IOException {
+
+        HttpClient client = new DefaultHttpClient();
+        HttpResponse response = client.execute(new HttpGet(extenderBaseUrl));
+
+        if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+            return true;
+        }
+        return false;
     }
 }

--- a/server/docker/Dockerfile
+++ b/server/docker/Dockerfile
@@ -1,7 +1,9 @@
 FROM extender-base
 
+ADD extender-0.1.0.jar app.jar
+RUN chown extender: app.jar
+
 USER extender
 
-ADD extender-0.1.0.jar app.jar
 ENTRYPOINT ["java","-jar","/app.jar"]
 EXPOSE 9000

--- a/server/scripts/build.sh
+++ b/server/scripts/build.sh
@@ -6,4 +6,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 docker build -t extender-base ${DIR}/../docker-base
 
-${DIR}/../../gradlew buildDocker
+${DIR}/../../gradlew clean buildDocker --info

--- a/server/scripts/start-test-server.sh
+++ b/server/scripts/start-test-server.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 
 set -e
+set -x
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 docker build -t extender-base ${DIR}/../docker-base
 
 ${DIR}/../../gradlew buildDocker -x test
+
+chmod -R a+xrw ${DIR}/../test-data || true
 
 docker run -d --rm --name extender -p 9000:9000 -v ${DIR}/../test-data/sdk:/var/extender/sdk extender/extender

--- a/server/src/test/java/com/defold/extender/ExtenderTest.java
+++ b/server/src/test/java/com/defold/extender/ExtenderTest.java
@@ -286,9 +286,20 @@ public class ExtenderTest {
 
     @Test
     public void testCollectJars() {
-        List<String> result = Extender.collectFilesByPath(new File("test-data/ext/lib/armv7-android"), Extender.JAR_RE);
-        assertEquals(2, result.size());
-        assertTrue(result.get(0).endsWith("test-data/ext/lib/armv7-android/Dummy.jar"));
+        List<String> paths = Extender.collectFilesByPath(new File("test-data/ext/lib/armv7-android"), Extender.JAR_RE);
+        assertEquals(2, paths.size());
+
+        String[] suffixes = {"test-data/ext/lib/armv7-android/Dummy.jar", "test-data/ext/lib/armv7-android/JarDep.jar"};
+
+        for (String suffix : suffixes) {
+            boolean exists = false;
+            for (String path : paths) {
+                if (path.endsWith(suffix)) {
+                    exists = true;
+                }
+            }
+            assertTrue(exists);
+        }
     }
 
     @Test

--- a/server/src/test/java/com/defold/extender/IntegrationTest.java
+++ b/server/src/test/java/com/defold/extender/IntegrationTest.java
@@ -141,7 +141,23 @@ public class IntegrationTest {
         System.out.println(processExecutor.getOutput());
 
         // Wait for server to start in container.
-        Thread.sleep(7000);
+        File cacheDir = new File("build");
+        ExtenderClient extenderClient = new ExtenderClient("http://localhost:" + EXTENDER_PORT, cacheDir);
+
+        for (int i  = 0; i < 100; i++) {
+
+            try {
+                if (extenderClient.health()) {
+                    System.out.println("Server started!");
+                    break;
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            System.out.println("Waiting for server to start...");
+            Thread.sleep(2000);
+        }
+
     }
 
     @AfterClass


### PR DESCRIPTION
* Wait until server start before running integration tests by checking server status instead of fixed sleep.

* Ensure extender user has access to app.jar.

* Print more info when building to make debugging easier.

* Ensure mounted test-data directory is accessible for extender user.