### PR TITLE
Multi-line logging.

### DIFF
--- a/server/scripts/task-definition-template.json
+++ b/server/scripts/task-definition-template.json
@@ -23,7 +23,8 @@
         "options": {
           "awslogs-group": "prod-logs",
           "awslogs-region": "eu-west-1",
-          "awslogs-stream-prefix": "extender"
+          "awslogs-stream-prefix": "extender",
+          "awslogs-datetime-format": "%Y-%m-%d %H:%M:%S.%L"
         }
       }
     }


### PR DESCRIPTION
This configures the Docker AWS log driver to handle multi-line log
statements as single events.

NOTE: This feature hasn't been implemented by AWS ECS yet, but is
supported by the current Docker version. There is no ETA from AWS
when this might be done, but this thread might be updated when it's
done https://github.com/aws/amazon-ecs-agent/issues/872.