### PR TITLE
Increase Jetty idle timeout 30s -> 60s - attempt 2

### DIFF
--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 
 server:
     port: 9000
+    jetty:
+        http.timeout: 60000
 
 extender:
     sdk-location: /var/extender/sdk


### PR DESCRIPTION
Spring only supports a subset of Jetty configuration props, so configure idle timeout programatically.