### PR TITLE
DEF-3702 Removed 'use-clang' flag.

### DIFF
--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -116,8 +116,8 @@ class Extender {
             try {
                 PlatformConfig alternateConfig = getPlatformConfig(platform.replace("win32", "wine32"));
                 if (alternateConfig != null) {
-                    Boolean use_clang = ExtenderUtil.getAppManifestBoolean(appManifest, platform, "use-clang", true);
-                    if (!use_clang) {
+                    Boolean use_cl = ExtenderUtil.getAppManifestBoolean(appManifest, platform, "legacy-use-cl", true);
+                    if (use_cl) {
                         alternatePlatform = platform.replace("win32", "wine32");
                     }
                 }

--- a/server/src/main/java/com/defold/extender/ExtensionManifestValidator.java
+++ b/server/src/main/java/com/defold/extender/ExtensionManifestValidator.java
@@ -68,7 +68,8 @@ class ExtensionManifestValidator {
                 case "excludeJars":
                 case "excludeJsLibs":
                 case "excludeSymbols":
-                case "use-clang":
+                case "use-clang": // deprecated
+                case "legacy-use-cl": // undocumented, only used if some project needs to use cl.exe in the transition period
                     continue; // no need to whitelist
 
                 default:


### PR DESCRIPTION
Clang is now always used on Win32.
Added an undocumented 'legacy-use-cl' flag for emergencies during the last phasing-out-period