### PR TITLE
Add a parallel compilation for C/C++ files

### DIFF
--- a/server/src/main/java/com/defold/extender/ProcessExecutor.java
+++ b/server/src/main/java/com/defold/extender/ProcessExecutor.java
@@ -8,7 +8,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class ProcessExecutor {
-    private final StringBuilder output = new StringBuilder();
+    private final StringBuffer output = new StringBuffer();
     private final HashMap<String, String> env = new HashMap<>();
     private File cwd = null;
     private boolean DM_DEBUG_COMMANDS = System.getenv("DM_DEBUG_COMMANDS") != null;


### PR DESCRIPTION
My game has a lot of C++ source files. Extender compiles C++ files one at a time, so every small change in the source code requires about 40-50 seconds to build. That's a lot of time!

This pull request adds a parallel compilation for C/C++ files, and the code uses all available CPU cores/threads. I suppose that it should utilise a single thread by default if only you didn't specify ENV variable with a different setting.

These changes are an example of how this can be done. If you decide to accept this pull request, I will polish it according to your requirements.

**Now Extender builds the game in 10 seconds on my 8-core PC.