### PR TITLE
Use the Android Gradle plugin to migrate dependencies to Android X

### DIFF
--- a/server/docker-base/Dockerfile
+++ b/server/docker-base/Dockerfile
@@ -369,10 +369,15 @@ RUN \
 
 #
 # Android SDK/NDK
+# https://developer.android.com/studio/command-line/variables
 #
 ENV ANDROID_ROOT ${PLATFORMSDK_DIR}/android
 ENV ANDROID_BUILD_TOOLS_VERSION 29.0.3
+# ANDROID_HOME has been replaced with ANDROID_SDK_ROOT
 ENV ANDROID_HOME ${ANDROID_ROOT}/android-sdk-linux
+ENV ANDROID_SDK_ROOT ${ANDROID_HOME}
+# ANDROID_SDK_HOME is the location of the .android folder
+ENV ANDROID_SDK_HOME ${ANDROID_ROOT}
 ENV ANDROID_TARGET_API_LEVEL 23
 ENV ANDROID_MIN_API_LEVEL 9
 ENV ANDROID_GCC_VERSION 4.8
@@ -433,8 +438,13 @@ RUN \
     rm -rf ${ANDROID_NDK20_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-* && \
     rm -rf ${ANDROID_NDK20_PATH}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/x86_64-linux-android && \
     rm -rf ${ANDROID_NDK20_PATH}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/i686-linux-android && \
+# create the .android folder and give read+write permissions (the Android Gradle plugin will write to the folder)
+# It is not enough to give 'user' and 'group'. We unfortunately also need 'others'
+    mkdir ${ANDROID_SDK_HOME}/.android && \
+    chmod ugo+rw -R ${ANDROID_SDK_HOME}/.android && \
 # fix permissions
     chmod +r -R ${ANDROID_ROOT} && \
+    chmod +w -R ${ANDROID_SDK_ROOT} && \
     chmod -R 755 ${ANDROID_ROOT}/android-ndk-r${ANDROID_NDK20_VERSION} && \
 # check that dx installed properly
     ls -la ${ANDROID_SDK_BUILD_TOOLS_PATH}/dx && \
@@ -515,7 +525,7 @@ RUN \
 # until it can be disabled (e.g. by looking for the existance of GRADLE_USER_HOME)
 
 ENV GRADLE_USER_HOME /tmp/.gradle
-ENV GRADLE_VERSION 6.0.1
+ENV GRADLE_VERSION 6.1.1
 ENV PATH ${PATH}:/opt/gradle/gradle-${GRADLE_VERSION}/bin
 RUN \
   echo "Gradle" && \
@@ -526,8 +536,12 @@ RUN \
   which gradle && \
   chown -R extender: /opt/gradle
 
-ENV EXTENSION_GRADLE_TEMPLATE /var/extender/template.build.gradle
-COPY template.build.gradle ${EXTENSION_GRADLE_TEMPLATE}
+ENV EXTENSION_BUILD_GRADLE_TEMPLATE /var/extender/template.build.gradle
+ENV EXTENSION_GRADLE_PROPERTIES_TEMPLATE /var/extender/template.gradle.properties
+ENV EXTENSION_LOCAL_PROPERTIES_TEMPLATE /var/extender/template.local.properties
+COPY template.build.gradle ${EXTENSION_BUILD_GRADLE_TEMPLATE}
+COPY template.gradle.properties ${EXTENSION_GRADLE_PROPERTIES_TEMPLATE}
+COPY template.local.properties ${EXTENSION_LOCAL_PROPERTIES_TEMPLATE}
 
 RUN \
   apt-get remove -y apt-transport-https xvfb && \

--- a/server/docker-base/Dockerfile
+++ b/server/docker-base/Dockerfile
@@ -377,7 +377,7 @@ ENV ANDROID_BUILD_TOOLS_VERSION 29.0.3
 ENV ANDROID_HOME ${ANDROID_ROOT}/android-sdk-linux
 ENV ANDROID_SDK_ROOT ${ANDROID_HOME}
 # ANDROID_SDK_HOME is the location of the .android folder
-ENV ANDROID_SDK_HOME ${ANDROID_ROOT}
+ENV ANDROID_SDK_HOME ${ANDROID_ROOT}/.android
 ENV ANDROID_TARGET_API_LEVEL 23
 ENV ANDROID_MIN_API_LEVEL 9
 ENV ANDROID_GCC_VERSION 4.8
@@ -440,8 +440,8 @@ RUN \
     rm -rf ${ANDROID_NDK20_PATH}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/i686-linux-android && \
 # create the .android folder and give read+write permissions (the Android Gradle plugin will write to the folder)
 # It is not enough to give 'user' and 'group'. We unfortunately also need 'others'
-    mkdir ${ANDROID_SDK_HOME}/.android && \
-    chmod ugo+rw -R ${ANDROID_SDK_HOME}/.android && \
+    mkdir ${ANDROID_SDK_HOME} && \
+    chmod ugo+rw -R ${ANDROID_SDK_HOME} && \
 # fix permissions
     chmod +r -R ${ANDROID_ROOT} && \
     chmod +w -R ${ANDROID_SDK_ROOT} && \

--- a/server/docker-base/template.build.gradle
+++ b/server/docker-base/template.build.gradle
@@ -20,7 +20,7 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion {{compile-sdk-version}}
 }
 
 {{#gradle-files}}

--- a/server/docker-base/template.build.gradle
+++ b/server/docker-base/template.build.gradle
@@ -1,27 +1,41 @@
-apply plugin: 'java'
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:4.0.1'
+    }
+}
 
 allprojects {
-  repositories {
-    google()
-    mavenLocal()
-    jcenter()
-  }
+    repositories {
+        google()
+        mavenLocal()
+        jcenter()
+    }
+}
+
+apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion 29
 }
 
 {{#gradle-files}}
 apply from: "{{{.}}}"
 {{/gradle-files}}
 
-project.configurations.compileClasspath.resolvedConfiguration.resolvedArtifacts.each {
-  println   "PATH: " + it.file + \
-            " EXTENSION: " + it.extension + \
-            " TYPE: " +  it.type + \
-            " MODULE_GROUP: " + it.moduleVersion.id.group + \
-            " MODULE_NAME: " + it.moduleVersion.id.name + \
-            " MODULE_VERSION: " + it.moduleVersion.id.version
-}
-
-task downloadDependencies(type: Exec) {
-  configurations.testRuntimeClasspath.files
-  commandLine 'echo', 'Downloaded all dependencies'
+task downloadDependencies {
+    doLast {
+        project.configurations.releaseRuntimeClasspath.getResolvedConfiguration().getResolvedArtifacts().each {
+            println "PATH: " + it.file + \
+                    " EXTENSION: " + it.extension + \
+                    " TYPE: " +  it.type + \
+                    " MODULE_GROUP: " + it.moduleVersion.id.group + \
+                    " MODULE_NAME: " + it.moduleVersion.id.name + \
+                    " MODULE_VERSION: " + it.moduleVersion.id.version
+        }
+    }
 }

--- a/server/docker-base/template.gradle.properties
+++ b/server/docker-base/template.gradle.properties
@@ -1,0 +1,2 @@
+android.enableJetifier={{android-enable-jetifier}}
+android.useAndroidX={{android-enable-jetifier}}

--- a/server/docker-base/template.gradle.properties
+++ b/server/docker-base/template.gradle.properties
@@ -1,2 +1,5 @@
+# Gradle will use the Jetifier tool to migrate depenencies to Android X if android.enableJetifier is true
 android.enableJetifier={{android-enable-jetifier}}
+
+# Gradle will stop resolving dependencies if android.useAndroidX is false and a dependency is using Android X
 android.useAndroidX={{android-enable-jetifier}}

--- a/server/docker-base/template.local.properties
+++ b/server/docker-base/template.local.properties
@@ -1,0 +1,1 @@
+sdk.dir={{android-sdk-root}}

--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -42,6 +42,7 @@ class Extender {
     private final ProcessExecutor processExecutor = new ProcessExecutor();
     private final Map<String, Object> appManifestContext;
     private final Boolean withSymbols;
+    private final Boolean useJetifier;
 
     private Map<String, Map<String, Object>>    manifestConfigs;
     private Map<String, File>                   manifestFiles;
@@ -54,6 +55,7 @@ class Extender {
 
     static final String APPMANIFEST_BASE_VARIANT_KEYWORD = "baseVariant";
     static final String APPMANIFEST_WITH_SYMBOLS_KEYWORD = "withSymbols";
+    static final String APPMANIFEST_JETIFIER_KEYWORD = "jetifier";
     static final String FRAMEWORK_RE = "(.+)\\.framework";
     static final String JAR_RE = "(.+\\.jar)";
     static final String JS_RE = "(.+\\.js)";
@@ -137,6 +139,7 @@ class Extender {
             }
         }
 
+        this.useJetifier = ExtenderUtil.getAppManifestBoolean(appManifest, platform, APPMANIFEST_JETIFIER_KEYWORD, false);
         this.withSymbols = ExtenderUtil.getAppManifestContextBoolean(appManifest, APPMANIFEST_WITH_SYMBOLS_KEYWORD, false);
 
         this.platform = platform;
@@ -1671,7 +1674,6 @@ class Extender {
 
     List<File> resolve(GradleService gradleService) throws ExtenderException {
         try {
-            Boolean useJetifier = (Boolean)mergedAppContext.getOrDefault("jetifier", false);
             gradlePackages = gradleService.resolveDependencies(jobDirectory, useJetifier);
         }
         catch (IOException e) {

--- a/server/src/main/java/com/defold/extender/ExtenderController.java
+++ b/server/src/main/java/com/defold/extender/ExtenderController.java
@@ -191,14 +191,15 @@ public class ExtenderController {
                 final File sdk = defoldSdkService.getSdk(sdkVersion);
                 metricsWriter.measureSdkDownload(sdkVersion);
 
-                List<File> gradlePackages = null;
+                Extender extender = new Extender(platform, sdk, jobDirectory, uploadDirectory, buildDirectory);
+
+                // Resolve Gradle dependencies
                 if (platform.contains("android")) {
-                    gradlePackages = gradleService.resolveDependencies(jobDirectory);
+                    List<File> gradlePackages = extender.resolve(gradleService);
                     metricsWriter.measureGradleDownload(gradlePackages, gradleService.getCacheSize());
                 }
 
                 // Build engine
-                Extender extender = new Extender(platform, sdk, jobDirectory, uploadDirectory, buildDirectory, gradlePackages);
                 List<File> outputFiles = extender.build();
                 metricsWriter.measureEngineBuild(platform);
 

--- a/server/src/main/java/com/defold/extender/ExtensionManifestValidator.java
+++ b/server/src/main/java/com/defold/extender/ExtensionManifestValidator.java
@@ -108,6 +108,7 @@ class ExtensionManifestValidator {
                 case "excludeFrameworks":
                 case "aaptExtraPackages":
                 case "objectFiles":
+                case "jetifier":
                 case "use-clang": // deprecated
                     continue; // no need to whitelist
 

--- a/server/src/main/java/com/defold/extender/services/GradleService.java
+++ b/server/src/main/java/com/defold/extender/services/GradleService.java
@@ -43,7 +43,10 @@ import java.util.regex.Pattern;
 @Service
 public class GradleService {
     private static final Logger LOGGER = LoggerFactory.getLogger(GradleService.class);
-    private static final String TEMPLATE_PATH = System.getenv("EXTENSION_GRADLE_TEMPLATE");
+    private static final String ANDROID_SDK_ROOT = System.getenv("ANDROID_SDK_ROOT");
+    private static final String BUILD_GRADLE_TEMPLATE_PATH = System.getenv("EXTENSION_BUILD_GRADLE_TEMPLATE");
+    private static final String GRADLE_PROPERTIES_TEMPLATE_PATH = System.getenv("EXTENSION_GRADLE_PROPERTIES_TEMPLATE");
+    private static final String LOCAL_PROPERTIES_TEMPLATE_PATH = System.getenv("EXTENSION_LOCAL_PROPERTIES_TEMPLATE");
     private static final String GRADLE_USER_HOME = System.getenv("GRADLE_USER_HOME");
 
     private final TemplateExecutor templateExecutor = new TemplateExecutor();
@@ -53,7 +56,9 @@ public class GradleService {
     private final File baseDirectory;
     private final CounterService counterService;
     private final GaugeService gaugeService;
-    private final String templateContents;
+    private final String buildGradleTemplateContents;
+    private final String gradlePropertiesTemplateContents;
+    private final String localPropertiesTemplateContents;
 
     @Autowired
     GradleService(@Value("${extender.gradle.cache-size}") int cacheSize,
@@ -70,21 +75,29 @@ public class GradleService {
             Files.createDirectories(this.baseDirectory.toPath());
         }
 
-        this.templateContents = new String( Files.readAllBytes( Paths.get(TEMPLATE_PATH) ) );
+        this.buildGradleTemplateContents = new String( Files.readAllBytes( Paths.get(BUILD_GRADLE_TEMPLATE_PATH) ) );
+        this.gradlePropertiesTemplateContents = new String( Files.readAllBytes( Paths.get(GRADLE_PROPERTIES_TEMPLATE_PATH) ) );
+        this.localPropertiesTemplateContents = new String( Files.readAllBytes( Paths.get(LOCAL_PROPERTIES_TEMPLATE_PATH) ) );
 
         LOGGER.info("GRADLE service using directory {} with cache size {}", GradleService.GRADLE_USER_HOME, cacheSize);
     }
 
     // Resolve dependencies, download them, extract to
-    public List<File> resolveDependencies(File cwd) throws IOException, ExtenderException {
+    public List<File> resolveDependencies(File cwd, Boolean useJetifier) throws IOException, ExtenderException {
+        // create build.gradle
         File mainGradleFile = new File(cwd, "build.gradle");
-
         List<File> gradleFiles = ExtenderUtil.listFilesMatchingRecursive(cwd, "build\\.gradle");
-
         // This file might exist when testing and debugging the extender using a debug job folder
         gradleFiles.remove(mainGradleFile);
-
         createBuildGradleFile(mainGradleFile, gradleFiles);
+
+        // create gradle.properties
+        File gradlePropertiesFile = new File(cwd, "gradle.properties");
+        createGradlePropertiesFile(gradlePropertiesFile, useJetifier);
+
+        // create local.properties
+        File localPropertiesFile = new File(cwd, "local.properties");
+        createLocalPropertiesFile(localPropertiesFile);
 
         return downloadDependencies(cwd);
     }
@@ -100,6 +113,20 @@ public class GradleService {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // Private
 
+    private void createGradlePropertiesFile(File gradlePropertiesFile, Boolean useJetifier) throws IOException {
+        HashMap<String, Object> envContext = new HashMap<>();
+        envContext.put("android-enable-jetifier", useJetifier.toString());
+        String contents = templateExecutor.execute(gradlePropertiesTemplateContents, envContext);
+        Files.write(gradlePropertiesFile.toPath(), contents.getBytes());
+    }
+
+    private void createLocalPropertiesFile(File localPropertiesFile) throws IOException {
+        HashMap<String, Object> envContext = new HashMap<>();
+        envContext.put("android-sdk-root", ANDROID_SDK_ROOT);
+        String contents = templateExecutor.execute(localPropertiesTemplateContents, envContext);
+        Files.write(localPropertiesFile.toPath(), contents.getBytes());
+    }
+
     private void createBuildGradleFile(File mainGradleFile, List<File> gradleFiles) throws IOException {
         List<String> values = new ArrayList<>();
         for (File file : gradleFiles) {
@@ -107,8 +134,7 @@ public class GradleService {
         }
         HashMap<String, Object> envContext = new HashMap<>();
         envContext.put("gradle-files", values);
-        String contents = templateExecutor.execute(templateContents, envContext);
-
+        String contents = templateExecutor.execute(buildGradleTemplateContents, envContext);
         Files.write(mainGradleFile.toPath(), contents.getBytes());
     }
 
@@ -221,7 +247,7 @@ public class GradleService {
         long methodStart = System.currentTimeMillis();
         LOGGER.info("Resolving dependencies");
 
-        String log = execCommand("gradle downloadDependencies --warning-mode all", cwd);
+        String log = execCommand("gradle downloadDependencies --stacktrace --info --warning-mode all", cwd);
 
         // Put it in the log for the end user to see
         LOGGER.info("\n" + log);

--- a/server/src/main/java/com/defold/extender/services/GradleService.java
+++ b/server/src/main/java/com/defold/extender/services/GradleService.java
@@ -44,6 +44,7 @@ import java.util.regex.Pattern;
 public class GradleService {
     private static final Logger LOGGER = LoggerFactory.getLogger(GradleService.class);
     private static final String ANDROID_SDK_ROOT = System.getenv("ANDROID_SDK_ROOT");
+    private static final String ANDROID_SDK_VERSION = System.getenv("ANDROID_SDK_VERSION");
     private static final String BUILD_GRADLE_TEMPLATE_PATH = System.getenv("EXTENSION_BUILD_GRADLE_TEMPLATE");
     private static final String GRADLE_PROPERTIES_TEMPLATE_PATH = System.getenv("EXTENSION_GRADLE_PROPERTIES_TEMPLATE");
     private static final String LOCAL_PROPERTIES_TEMPLATE_PATH = System.getenv("EXTENSION_LOCAL_PROPERTIES_TEMPLATE");
@@ -134,6 +135,7 @@ public class GradleService {
         }
         HashMap<String, Object> envContext = new HashMap<>();
         envContext.put("gradle-files", values);
+        envContext.put("compile-sdk-version", ANDROID_SDK_VERSION);
         String contents = templateExecutor.execute(buildGradleTemplateContents, envContext);
         Files.write(mainGradleFile.toPath(), contents.getBytes());
     }

--- a/server/src/test/java/com/defold/extender/ExtenderTest.java
+++ b/server/src/test/java/com/defold/extender/ExtenderTest.java
@@ -39,7 +39,7 @@ public class ExtenderTest {
         File buildDir = new File(jobDir, "build");
         buildDir.mkdirs();
         File sdk = new File("test-data/sdk/a/defoldsdk");
-        Extender extender = new Extender("x86_64-osx", sdk, jobDir, uploadDir, buildDir, new ArrayList<File>());
+        Extender extender = new Extender("x86_64-osx", sdk, jobDir, uploadDir, buildDir);
 
         uploadDir.delete();
         assertTrue(true);


### PR DESCRIPTION
Migration to Android X will happen if the `jetifier` property is set in the app.manifest:

```
    armv7-android:
        context:
            excludeLibs: []
            excludeJars: []
            excludeSymbols: []
            symbols: []
            libs: []
            linkFlags: []
            jetifier: true
```