### PR TITLE
Update Spring boot to 2.6.6 (fix CVE-2022-22965).

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'io.spring.gradle:dependency-management-plugin:1.0.11.RELEASE'
-        classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.6.1'
+        classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.6.6'
 
 // Updating to gradle 7, means moving from this plugin to something else
         classpath 'se.transmode.gradle:gradle-docker:1.2'
@@ -15,7 +15,7 @@ plugins {
     id 'java'
     id 'idea'
     id 'eclipse'
-    id 'org.springframework.boot' version '2.6.1'
+    id 'org.springframework.boot' version '2.6.6'
 }
 
 apply plugin: 'docker'


### PR DESCRIPTION
https://spring.io/blog/2022/03/31/spring-boot-2-6-6-available-now