### PR TITLE
Fix misprint in ios build endpoint name when configure web security.

### DIFF
--- a/server/src/main/java/com/defold/extender/WebSecurityConfig.java
+++ b/server/src/main/java/com/defold/extender/WebSecurityConfig.java
@@ -29,7 +29,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 					http.authorizeRequests().antMatchers("/build/arm64-android/**").hasRole("ANDROID").and().httpBasic();
 					break;
 				case "ios":
-					http.authorizeRequests().antMatchers("/build/armv7-ios:/**").hasRole("IOS").and().httpBasic();
+					http.authorizeRequests().antMatchers("/build/armv7-ios/**").hasRole("IOS").and().httpBasic();
 					http.authorizeRequests().antMatchers("/build/arm64-ios/**").hasRole("IOS").and().httpBasic();
 					http.authorizeRequests().antMatchers("/build/x86_64-ios/**").hasRole("IOS").and().httpBasic();
 					break;


### PR DESCRIPTION
We can build ios for armv7 without authentication because there is misprint in endpoint name.