### PR TITLE
Remove dependency duplication. Now extender start inside Jetty not inside Tomcat.

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -64,7 +64,6 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-starter-actuator')
     implementation('org.springframework.boot:spring-boot-starter-jetty')
     implementation('org.springframework.boot:spring-boot-starter-security')
-    implementation('org.springframework.boot:spring-boot-starter-web')
     implementation('org.springframework.security:spring-security-test')
     implementation('io.micrometer:micrometer-core:1.8.1')
     runtime('io.micrometer:micrometer-registry-influx:1.8.1')


### PR DESCRIPTION
Because of dependency duplication extender starts inside Apache Tomcat, not inside Eclipse Jetty. These bug was introduced when spring boot were updated (https://github.com/defold/extender/commit/38d045ba2123eae178cc52eb6130cad5198c2637).
These fix remove dependency duplication. Now extender runs inside Jetty.