### PR TITLE
Use merge node markers to remove Android manifest tags

### DIFF
--- a/server/manifestmergetool/src/main/java/com/defold/manifestmergetool/ManifestMergeTool.java
+++ b/server/manifestmergetool/src/main/java/com/defold/manifestmergetool/ManifestMergeTool.java
@@ -66,6 +66,7 @@ public class ManifestMergeTool {
 
         ManifestMerger2.Invoker invoker = ManifestMerger2.newMerger(main, ManifestMergeTool.androidLogger, ManifestMerger2.MergeType.APPLICATION);
         invoker.addLibraryManifests(libraries);
+        invoker.withFeatures(ManifestMerger2.Invoker.Feature.REMOVE_TOOLS_DECLARATIONS);
 
         try {
             MergingReport report = invoker.merge();

--- a/server/manifestmergetool/src/test/java/com/defold/manifestmergetool/ManifestMergeToolTest.java
+++ b/server/manifestmergetool/src/test/java/com/defold/manifestmergetool/ManifestMergeToolTest.java
@@ -80,6 +80,7 @@ public class ManifestMergeToolTest {
                 + "    <application android:label=\"Test Project\" android:hasCode=\"true\">"
                 + "    </application>"
                 + "    <uses-permission android:name=\"android.permission.VIBRATE\" />"
+                + "    <uses-permission android:name=\"android.permission.CAMERA\" />"
                 + "</manifest>";
 
         createFile(contentRoot, "builtins/manifests/android/AndroidManifest.xml", androidManifest);
@@ -156,7 +157,7 @@ public class ManifestMergeToolTest {
 
         String manifest = ""
                 + "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
-                + "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" package=\"com.defold.testmerge\">"
+                + "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" xmlns:tools=\"http://schemas.android.com/tools\" package=\"com.defold.testmerge\">"
                 + "    <uses-feature android:required=\"true\" android:glEsVersion=\"0x00030000\" />"
                 + "    <application>"
                 + "        <meta-data android:name=\"com.facebook.sdk.ApplicationName\""
@@ -166,6 +167,7 @@ public class ManifestMergeToolTest {
                 + "          android:configChanges=\"keyboard|keyboardHidden|screenLayout|screenSize|orientation\""
                 + "          android:label=\"Test Project\" />"
                 + "    </application>"
+                + "    <uses-permission android:name=\"android.permission.CAMERA\" tools:node=\"remove\"/>"
                 + "</manifest>";
         createFile(contentRoot, "builtins/manifests/android/AndroidManifestLib.xml", manifest);
 


### PR DESCRIPTION
It is now possible to use a merge node marker in the AndroidManifest.xml to indicate that a tag added from a library dependency should be removed:

```xml
<!-- remove the android.permission.READ_EXTERNAL_STORAGE permission if it exists in a library dependency-->
<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove" />
```

Previous extender versions did not enable this feature of the manifest merge tool and any attempt to use a merge node marker was ignored.