### PR TITLE
Added merge node markers for Info.plist keys

### DIFF
--- a/server/manifestmergetool/src/test/java/com/defold/manifestmergetool/ManifestMergeToolTest.java
+++ b/server/manifestmergetool/src/test/java/com/defold/manifestmergetool/ManifestMergeToolTest.java
@@ -335,7 +335,7 @@ public class ManifestMergeToolTest {
 
         String builtinsManifest = ""
                 + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-                + "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+                + "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\" [ <!ATTLIST key merge (keep) #IMPLIED> ]>  \n"
                 + "<plist version=\"1.0\">\n"
                 + "<dict>\n"
                 + "    <key merge='keep'>BASE64</key>\n"
@@ -360,16 +360,19 @@ public class ManifestMergeToolTest {
         createFile(contentRoot, "builtins/manifests/ios/InfoLib.plist", libManifest);
 
         String expected = ""
-                + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-                + "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+                + "<?xml version=\"1.0\"?>\n"
+                + "<!DOCTYPE plist SYSTEM \"file://localhost/System/Library/DTDs/PropertyList.dtd\">\n"
                 + "<plist version=\"1.0\">\n"
-                + "<dict>\n"
+                + "    <dict>\n"
                 + "        <key>BASE64</key>\n"
                 + "        <data>SEVMTE8gV09STEQ=</data>\n"
                 + "\n"
                 + "        <key>INT</key>\n"
+                + "        <integer>8</integer>\n"
+                + "\n"
+                + "        <key>INT</key>\n"
                 + "        <integer>42</integer>\n"
-                + "</dict>\n"
+                + "    </dict>\n"
                 + "</plist>\n";
 
         createFile(contentRoot, "builtins/manifests/ios/InfoExpected.plist", expected);

--- a/server/manifestmergetool/src/test/java/com/defold/manifestmergetool/ManifestMergeToolTest.java
+++ b/server/manifestmergetool/src/test/java/com/defold/manifestmergetool/ManifestMergeToolTest.java
@@ -323,6 +323,63 @@ public class ManifestMergeToolTest {
         assertEquals(expected, merged);
     }
 
+
+
+    @Test
+    public void testMergeIOSMergeMarkers() throws IOException {
+        if (platform != Platform.IOS) {
+            return;
+        }
+
+        createDefaultFiles();
+
+        String builtinsManifest = ""
+                + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+                + "<plist version=\"1.0\">\n"
+                + "<dict>\n"
+                + "    <key merge='keep'>BASE64</key>\n"
+                + "    <data>SEVMTE8gV09STEQ=</data>\n"
+                + "    <key>INT</key>\n"
+                + "    <integer>8</integer>\n"
+                + "</dict>\n"
+                + "</plist>\n";
+        createFile(contentRoot, "builtins/manifests/ios/Info.plist", builtinsManifest);
+
+        String libManifest = ""
+                + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+                + "<plist version=\"1.0\">\n"
+                + "<dict>\n"
+                + "    <key>BASE64</key>\n"
+                + "    <data>foobar</data>\n"
+                + "    <key>INT</key>\n"
+                + "    <integer>42</integer>\n"
+                + "</dict>\n"
+                + "</plist>\n";
+        createFile(contentRoot, "builtins/manifests/ios/InfoLib.plist", libManifest);
+
+        String expected = ""
+                + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+                + "<plist version=\"1.0\">\n"
+                + "<dict>\n"
+                + "        <key>BASE64</key>\n"
+                + "        <data>SEVMTE8gV09STEQ=</data>\n"
+                + "\n"
+                + "        <key>INT</key>\n"
+                + "        <integer>42</integer>\n"
+                + "</dict>\n"
+                + "</plist>\n";
+
+        createFile(contentRoot, "builtins/manifests/ios/InfoExpected.plist", expected);
+
+        ManifestMergeTool.merge(ManifestMergeTool.Platform.IOS, this.main, this.target, this.libraries);
+
+        String merged = readFile(this.target);
+        assertEquals(expected, merged);
+    }
+
     @Test
     public void testMergeIOSMixedTypes() throws IOException {
         if (platform != Platform.IOS) {


### PR DESCRIPTION
It is now possible to control if a key in the base Info.plist file should be replaced by a key in a plist file from an extension or not:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd" [ <!ATTLIST key merge (keep) #IMPLIED> ]>

<plist version="1.0">
<dict>
        <key merge="keep">NSPhotoLibraryUsageDescription</key>
        <string>This value will be kept even if an extension also provide a 'NSPhotoLibraryUsageDescription' key</string>
</dict>
</plist>
```

Note the new `[ <!ATTLIST key merge (keep) #IMPLIED> ]` section in the `<!DOCTYPE`!

Fixes #205 