### PR TITLE
Send build server logs on error

### DIFF
--- a/server/src/main/java/com/defold/extender/AsyncBuilder.java
+++ b/server/src/main/java/com/defold/extender/AsyncBuilder.java
@@ -50,8 +50,8 @@ public class AsyncBuilder {
         if (extender == null) return;
         try {
             FileOutputStream fos = new FileOutputStream(file, true);
-            List<File> logs = extender.writeLogs();
-            for (File log : logs) {
+            File log = extender.writeLog();
+            if (log.exists()) {
                 FileInputStream fis = new FileInputStream(log);
                 fis.transferTo(fos);
                 fis.close();

--- a/server/src/main/java/com/defold/extender/AsyncBuilder.java
+++ b/server/src/main/java/com/defold/extender/AsyncBuilder.java
@@ -50,7 +50,7 @@ public class AsyncBuilder {
         if (extender == null) return;
         try {
             FileOutputStream fos = new FileOutputStream(file, true);
-            List<File> logs = extender.writeLogs()
+            List<File> logs = extender.writeLogs();
             for (File log : logs) {
                 FileInputStream fis = new FileInputStream(log);
                 fis.transferTo(fos);

--- a/server/src/main/java/com/defold/extender/AsyncBuilder.java
+++ b/server/src/main/java/com/defold/extender/AsyncBuilder.java
@@ -113,13 +113,13 @@ public class AsyncBuilder {
             Files.move(tmpResult.toPath(), targetResult.toPath(), StandardCopyOption.ATOMIC_MOVE);
         } catch(EofException e) {
             File errorFile = new File(resultDir, BuilderConstants.BUILD_ERROR_FILENAME);
-            writeExceptionToFile(e, errorFile);
             writeExtenderLogsToFile(extender, errorFile);
+            writeExceptionToFile(e, errorFile);
             LOGGER.error("Client closed connection prematurely, build aborted", e);
         } catch(Exception e) {
             File errorFile = new File(resultDir, BuilderConstants.BUILD_ERROR_FILENAME);
-            writeExceptionToFile(e, errorFile);
             writeExtenderLogsToFile(extender, errorFile);
+            writeExceptionToFile(e, errorFile);
             LOGGER.error(String.format("Exception while building or sending response - SDK: %s , metrics: %s", sdkVersion, metricsWriter), e);
         } finally {
             // Regardless of success/fail status, we want to cache the uploaded files

--- a/server/src/main/java/com/defold/extender/AsyncBuilder.java
+++ b/server/src/main/java/com/defold/extender/AsyncBuilder.java
@@ -2,6 +2,8 @@ package com.defold.extender;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.FileOutputStream;
+import java.io.FileInputStream;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
@@ -32,10 +34,10 @@ public class AsyncBuilder {
     private File jobResultLocation;
     private long resultLifetime;
     private boolean keepJobDirectory = false;
-    
-    public AsyncBuilder(DefoldSdkService defoldSdkService, 
-                        DataCacheService dataCacheService, 
-                        GradleService gradleService, 
+
+    public AsyncBuilder(DefoldSdkService defoldSdkService,
+                        DataCacheService dataCacheService,
+                        GradleService gradleService,
                         @Value("${extender.job-result.location}") String jobResultLocation,
                         @Value("${extender.job-result.lifetime:1200000}") long jobResultLifetime) {
         this.defoldSdkService = defoldSdkService;
@@ -63,25 +65,25 @@ public class AsyncBuilder {
         }
     }
 
-    private void writeExceptionToFile(Exception e, File file) {
+    private void writeExceptionToFile(Exception exception, File file) {
         try {
             PrintWriter writer = new PrintWriter(file);
-            e.printStackTrace(writer);
+            exception.printStackTrace(writer);
             writer.close();
         }
         catch(Exception e) {
             LOGGER.error("Could not write exception to error file", e);
         }
     }
-    
+
     @Async
-    public void asyncBuildEngine(MetricsWriter metricsWriter, String platform, String sdkVersion, 
+    public void asyncBuildEngine(MetricsWriter metricsWriter, String platform, String sdkVersion,
             File jobDirectory, File uploadDirectory, File buildDirectory) throws IOException {
         String jobName = jobDirectory.getName();
         Thread.currentThread().setName(String.format("async-build-%s", jobName));
         File resultDir = new File(jobResultLocation.getAbsolutePath(), jobName);
         resultDir.mkdir();
-        Extender extender;
+        Extender extender = null;
         try {
             LOGGER.info("Building engine locally");
 

--- a/server/src/main/java/com/defold/extender/AsyncBuilder.java
+++ b/server/src/main/java/com/defold/extender/AsyncBuilder.java
@@ -67,9 +67,11 @@ public class AsyncBuilder {
 
     private void writeExceptionToFile(Exception exception, File file) {
         try {
-            PrintWriter writer = new PrintWriter(file);
+            FileOutputStream fos = new FileOutputStream(file, true);
+            PrintWriter writer = new PrintWriter(fos);
             exception.printStackTrace(writer);
             writer.close();
+            fos.close();
         }
         catch(Exception e) {
             LOGGER.error("Could not write exception to error file", e);

--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -2048,17 +2048,15 @@ class Extender {
         return out;
     }
 
-    List<File> writeLogs() {
-        List<File> outputFiles = new ArrayList<>();
+    File writeLog() {
         File logFile = new File(buildDirectory, "log.txt");
         try {
             LOGGER.info("Writing log file");
             processExecutor.writeLog(logFile);
-            outputFiles.add(logFile);
         } catch (IOException e) {
             LOGGER.error("Failed to write log file to {}", logFile.getAbsolutePath());
         }
-        return outputFiles;
+        return logFile;
     }
 
     List<File> resolve(GradleService gradleService) throws ExtenderException {
@@ -2083,7 +2081,10 @@ class Extender {
         }
         outputFiles.addAll(buildEngine());
         outputFiles.addAll(buildPipelinePlugin());
-        outputFiles.addAll(writeLogs());
+        File log = writeLog();
+        if (log.exists()) {
+            outputFiles.add(log);
+        }
         return outputFiles;
     }
 }

--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -2048,7 +2048,7 @@ class Extender {
         return out;
     }
 
-    private List<File> writeLog() {
+    List<File> writeLogs() {
         List<File> outputFiles = new ArrayList<>();
         File logFile = new File(buildDirectory, "log.txt");
         try {
@@ -2083,7 +2083,7 @@ class Extender {
         }
         outputFiles.addAll(buildEngine());
         outputFiles.addAll(buildPipelinePlugin());
-        outputFiles.addAll(writeLog());
+        outputFiles.addAll(writeLogs());
         return outputFiles;
     }
 }

--- a/server/src/main/java/com/defold/extender/ExtenderController.java
+++ b/server/src/main/java/com/defold/extender/ExtenderController.java
@@ -395,13 +395,13 @@ public class ExtenderController {
     @GetMapping("/job_result")
     public @ResponseBody byte[] getBuildResult(@RequestParam String jobId) throws IOException {
         File jobResultDir = new File(jobResultLocation.getAbsolutePath() + "/" + jobId);
-        File jobResult = new File(jobResultDir, BuilderConstants.BUILD_RESULT_FILENAME);
-        if (jobResult.exists()) {
-            InputStream in = new FileInputStream(jobResult);
-            return IOUtils.toByteArray(in);
-        } else {
+        if (jobResultDir.exists()) {
+            File jobResult = new File(jobResultDir, BuilderConstants.BUILD_RESULT_FILENAME);
             File errorResult = new File(jobResultDir, BuilderConstants.BUILD_ERROR_FILENAME);
-            if (errorResult.exists()) {
+            if (jobResult.exists()) {
+                InputStream in = new FileInputStream(jobResult);
+                return IOUtils.toByteArray(in);
+            } else if (errorResult.exists()) {
                 InputStream in = new FileInputStream(errorResult);
                 return IOUtils.toByteArray(in);
             }


### PR DESCRIPTION
Async builds will now return the full build log when requesting the `/job_result`. The request previously only returned the stack trace of the error. The result (stack trace and log) will be written to the log file on the client.

Fixes #221 