### PR TITLE
Automatically create Android R.java files for all Gradle dependencies

### DIFF
--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -1015,7 +1015,7 @@ class Extender {
                             .collect(Collectors.toList());
     }
 
-    private List<File> getAndroidResourceFolders(String platform) {
+    private List<String> getAndroidResourceFolders(String platform) {
         // New feature from 1.2.165
         File packageDir = new File(uploadDirectory, "packages");
         if (!packageDir.exists()) {
@@ -1051,14 +1051,8 @@ class Extender {
 
         return packageDirs.stream()
                         .filter(f -> f.isDirectory())
+                        .map(File::getAbsolutePath)
                         .collect(Collectors.toList());
-    }
-
-    private List<String> getAndroidResourceFoldersAsStrings(String platform) {
-        return getAndroidResourceFolders(platform)
-                                        .stream()
-                                        .map(File::getAbsolutePath)
-                                        .collect(Collectors.toList());
     }
 
 
@@ -1147,7 +1141,9 @@ class Extender {
                 extraPackages.addAll((List<String>)mergedAppContext.get("aaptExtraPackages"));
             }
             if (!extraPackages.isEmpty()) {
-                context.put("extraPackages", String.join(":", extraPackages));
+                String extraPackagesString = String.join(":", extraPackages);
+                context.put("extraPackages", extraPackagesString);
+                LOGGER.info("Extra packages {}", extraPackagesString);
             }
 
             File manifestFile = new File(buildDirectory, MANIFEST_ANDROID);
@@ -1909,7 +1905,7 @@ class Extender {
 
         List<File> outputFiles = new ArrayList<>();
 
-        final List<String> androidResourceFolders = getAndroidResourceFoldersAsStrings(platform);
+        final List<String> androidResourceFolders = getAndroidResourceFolders(platform);
 
         File rJavaDir = null;
         // 1.2.174

--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -1873,6 +1873,9 @@ class Extender {
     }
 
 
+    // get extra packages (for aapt2) from the 'package' attribute in the AndroidManifest
+    // of the gradle dependencies. only get extra packages from aar dependencies which
+    // have a res folder
     private List<String> getExtraPackagesFromGradlePackages() throws ExtenderException {
         Set<String> extraPackages = new HashSet<String>();
         try {

--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -1105,6 +1105,7 @@ class Extender {
                     for (File resourceFile : resourceTypeDir.listFiles()) {
                         context.put("resourceFile", resourceFile.getAbsolutePath());
 
+                        // aapt2compileCmd: 'aapt2 compile {{resourceFile}} -o {{outputDirectory}}'
                         String command = templateExecutor.execute(platformConfig.aapt2compileCmd, context);
                         processExecutor.execute(command);
                     }
@@ -1130,6 +1131,7 @@ class Extender {
             for (File packageDir : compiledResourcesDir.listFiles(File::isDirectory)) {
                 for (File file : packageDir.listFiles()) {
                     if (file.getAbsolutePath().endsWith(".flat")) {
+                        LOGGER.info("flat file " + file.getAbsolutePath());
                         sb.append(file.getAbsolutePath() + " ");
                     }
                 }
@@ -1161,6 +1163,7 @@ class Extender {
             files.put("outApkFile", outApkFile);
             files.put("outJavaDirectory", outputJavaDirectory);
 
+            // aapt2linkCmd: 'aapt2 link {{#extraPackages.length}}--extra-packages {{#extraPackages}}{{.}}{{/extraPackages}}{{/extraPackages.length}} --proto-format --non-final-ids --auto-add-overlay --manifest {{manifestFile}} -I {{dynamo_home}}/ext/share/java/android.jar --java {{outJavaDirectory}} -o {{outApkFile}} --emit-ids {{resourceIdsFile}} -R @{{resourceListFile}}'
             String command = templateExecutor.execute(platformConfig.aapt2linkCmd, context);
             processExecutor.execute(command);
         }


### PR DESCRIPTION
This change automatically adds each resolved Android Gradle dependency containing resources as an extra package when linking resources using `aapt2`. This reduces or completely removes the need to specify `aaptExtraPackages` in `ext.manifest`.

Fixes defold/defold#6047