### PR TITLE
Fix key for dynamicLibs when merge contexts.

### DIFF
--- a/server/src/main/java/com/defold/extender/ExtenderUtil.java
+++ b/server/src/main/java/com/defold/extender/ExtenderUtil.java
@@ -513,7 +513,7 @@ public class ExtenderUtil
         mappings.add(new PruneMapping("engineLibs", "includeLibs", "excludeLibs"));
         mappings.add(new PruneMapping("engineJsLibs", "includeJsLibs", "excludeJsLibs"));
         mappings.add(new PruneMapping("objectFiles", "includeObjectFiles", "excludeObjectFiles"));
-        mappings.add(new PruneMapping("objectFiles", "includeDynamicLibs", "excludeDynamicLibs"));
+        mappings.add(new PruneMapping("dynamicLibs", "includeDynamicLibs", "excludeDynamicLibs"));
         mappings.add(new PruneMapping("symbols", "includeSymbols", "excludeSymbols"));
 
         for (PruneMapping mapping : mappings) {


### PR DESCRIPTION
Fix key for dynamicLibs during context merging process. It fixes unnecessary dependecies for linux headless build (like openal.so.). 