### PR TITLE
Fix cocoapods issues

### DIFF
--- a/server/src/main/java/com/defold/extender/ExtenderUtil.java
+++ b/server/src/main/java/com/defold/extender/ExtenderUtil.java
@@ -513,7 +513,7 @@ public class ExtenderUtil
         mappings.add(new PruneMapping("engineLibs", "includeLibs", "excludeLibs"));
         mappings.add(new PruneMapping("engineJsLibs", "includeJsLibs", "excludeJsLibs"));
         mappings.add(new PruneMapping("objectFiles", "includeObjectFiles", "excludeObjectFiles"));
-        mappings.add(new PruneMapping("objectFiles", "includeDynamicLibs", "excludeDynamicLibs"));
+        mappings.add(new PruneMapping("dynamicLibs", "includeDynamicLibs", "excludeDynamicLibs"));
         mappings.add(new PruneMapping("symbols", "includeSymbols", "excludeSymbols"));
 
         for (PruneMapping mapping : mappings) {

--- a/server/src/main/java/com/defold/extender/services/CocoaPodsService.java
+++ b/server/src/main/java/com/defold/extender/services/CocoaPodsService.java
@@ -578,6 +578,16 @@ public class CocoaPodsService {
             if (!specsMap.containsKey(mainpodname)) {
                 String cmd = "pod spec cat --regex ^" + mainpodname + "$ --version=" + podversion;
                 String specJson = execCommand(cmd).replace(cmd, "");
+                // find first occurence of { because in some cases pod command
+                // can produce additional output before json spec
+                // For example:
+                // Ignoring ffi-1.15.4 because its extensions are not built. Try: gem pristine ffi --version 1.15.4
+                // {
+                //     "authors": "Google, Inc.",
+                //     "cocoapods_version": ">= 1.9.0",
+                //     "dependencies": {
+                //     "GoogleAppMeasurement": [
+                specJson = specJson.substring(specJson.indexOf("{", 0), specJson.length());
 
                 specsMap.put(mainpodname, createPodSpec(specJson, podsDir));
             }

--- a/server/src/main/java/com/defold/extender/services/CocoaPodsService.java
+++ b/server/src/main/java/com/defold/extender/services/CocoaPodsService.java
@@ -460,6 +460,18 @@ public class CocoaPodsService {
         if (vendored != null) {
             spec.vendoredframeworks.addAll(vendored);
         }
+        if (ios != null) {
+            JSONArray ios_vendored = getAsJSONArray(ios, "vendored_frameworks");
+            if (ios_vendored != null) {
+                spec.vendoredframeworks.addAll(ios_vendored);
+            }
+        }
+        if (osx != null) {
+            JSONArray osx_vendored = getAsJSONArray(osx, "vendored_frameworks");
+            if (osx_vendored != null) {
+                spec.vendoredframeworks.addAll(osx_vendored);
+            }
+        }
 
         // libraries
         spec.libraries.addAll(getAsJSONArray(specJson, "libraries"));


### PR DESCRIPTION
There were two issues that I found during cocoapods integration testing:
1. When command `pod spec cat --regex ...` produce some additional output like 
```
Ignoring ffi-1.15.4 because its extensions are not built. Try: gem pristine ffi --version 1.15.4
```
build failed with exception.
2. If pod spec has vendored_frameworks section under platform section - it ignores and produces linker error later. For example, UnityAds pod has following spec
```
{
  "name": "UnityAds",
  "version": "4.2.1",
  "license": {
    "type": "Unity License",
    "file": "LICENSE"
  },
  "authors": {
    "UnityAds": "itunes@unity3d.com"
  },
  "homepage": "https://unity3d.com/services/ads",
  "summary": "Monetize your entire player base and reach new audiences with video ads.",
  "platforms": {
    "ios": "9.0"
  },
  "source": {
    "http": "https://github.com/Unity-Technologies/unity-ads-ios/releases/download/4.2.1/UnityAds.zip"
  },
  "ios": {
    "vendored_frameworks": "UnityAds.xcframework"
  }
}
```