### PR TITLE
Remove usage of android.jar from `share` folder

### DIFF
--- a/server/test-data/jars/build.sh
+++ b/server/test-data/jars/build.sh
@@ -12,7 +12,8 @@ BUILD=./build
 
 PACKAGE_NAME=com/defold/dummy
 
-ANDROID_JAR=$DYNAMO_HOME/ext/share/java/android.jar
+ANDROID_SDK_VERSION=33
+ANDROID_JAR=${ANDROID_HOME}/platforms/android-${ANDROID_SDK_VERSION}/android.jar
 
 mkdir -p $BUILD
 


### PR DESCRIPTION
This script for creation test data is the only place where we use `android.jar` from `defoldsdk`. In all other places on extender we use one from SDK 


This is the first step for removing `android.jar` from `defoldsdk.zip`