### PR TITLE
Update gradle/gradle android plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ subprojects {
 }
 
 wrapper {
-    gradleVersion = '6.9'
+    gradleVersion = '8.4'
     distributionType = Wrapper.DistributionType.ALL
 }
 

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 jar {
-    baseName = 'extender-client'
+    archiveBaseName = 'extender-client'
     version = '0.0.5'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -8,9 +8,6 @@ buildscript {
     dependencies {
         classpath 'io.spring.gradle:dependency-management-plugin:1.0.11.RELEASE'
         classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.6.6'
-
-// Updating to gradle 7, means moving from this plugin to something else
-        classpath 'se.transmode.gradle:gradle-docker:1.2'
     }
 }
 
@@ -19,10 +16,13 @@ plugins {
     id 'idea'
     id 'eclipse'
     id 'org.springframework.boot' version '2.6.6'
+    id 'com.bmuschko.docker-remote-api' version '7.2.0'
 }
 
-apply plugin: 'docker'
+apply plugin: 'com.bmuschko.docker-remote-api'
 apply plugin: 'io.spring.dependency-management'
+
+import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 
 configurations {
     // A configuration meant for consumers that need the API of this component
@@ -109,6 +109,7 @@ public class Version {
     def template = engine.createTemplate(text).make(binding)
 
     new File(projectDir.toString() + "/src/main/java/com/defold/extender", "Version.java").text = template.toString()
+    project.ext.set("outSha", sha)
 }
 
 compileJava {
@@ -117,42 +118,53 @@ compileJava {
 
 // Creates the full jar file, with the extender server classes included
 bootJar {
-    baseName = 'extender'
+    archiveBaseName = 'extender'
     version =  '0.1.0'
 }
 
 // Builds the extender server base classes into a .jar file
 jar {
-    baseName = 'extender-base'
+    archiveBaseName = 'extender-base'
     version =  '0.1.0'
     archiveClassifier = '' // use empty string to avoid the 'plain' suffix
 }
 
-task buildDocker(type: Docker) {
-    dependsOn 'build', ':manifestmergetool:mainJar'
-    push = false
-    applicationName = bootJar.baseName
-    dockerfile = file('docker/Dockerfile')
+File dockerBuildDir = new File(project.buildDir, 'docker-stage');
+
+task dockerStageDir {
     doFirst {
+        if (dockerBuildDir.exists()) {
+            dockerBuildDir.delete();
+        }
+        dockerBuildDir.mkdirs();
         copy {
             from(project.projectDir) {
                 include "users/**"
             }
-            into stageDir
+            into dockerBuildDir
         }
         copy {
             from bootJar
-            into stageDir
+            into dockerBuildDir
         }
         copy {
             from project(':manifestmergetool').collect { it.tasks.withType(Jar) }
-            into stageDir
+            into dockerBuildDir
         }
         copy {
             from 'docker'
-            into stageDir
+            into dockerBuildDir
         }
     }
+}
+
+task buildDocker(type: DockerBuildImage) {
+    dependsOn 'build', ':manifestmergetool:mainJar', 'dockerStageDir'
+    inputDir = dockerBuildDir
+    imageId = bootJar.archiveBaseName
+    dockerFile = new File(dockerBuildDir, 'Dockerfile')
+    images.add("extender/extender:latest")
+    images.add("extender/extender:" + project.outSha)
 }
 
 task buildStandalone() {

--- a/server/docker-base/Dockerfile
+++ b/server/docker-base/Dockerfile
@@ -4,7 +4,6 @@ RUN \
   echo "LINUX TOOLS + COMPILER" && \
   apt-get update && \
   apt-get install -y software-properties-common && \
-  add-apt-repository ppa:openjdk-r/ppa && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     wget \
@@ -537,9 +536,8 @@ RUN \
 # Versions: https://developer.android.com/studio/releases/gradle-plugin?buildsystem=ndk-build#updating-gradle
 # Java+Gradle version matrix: https://docs.gradle.org/current/userguide/compatibility.html
 ENV GRADLE_USER_HOME /tmp/.gradle
-ENV GRADLE_VERSION 8.0.2
-#ENV GRADLE_PLUGIN_VERSION 8.0.2 # "Android Gradle plugin requires Java 17 to run. You are currently using Java 11."
-ENV GRADLE_PLUGIN_VERSION 7.4.0
+ENV GRADLE_VERSION 8.4
+ENV GRADLE_PLUGIN_VERSION 8.2.1
 ENV PATH ${PATH}:/opt/gradle/gradle-${GRADLE_VERSION}/bin
 RUN \
   echo "Gradle" && \
@@ -585,36 +583,6 @@ RUN \
 RUN \
   apt-get remove -y apt-transport-https xvfb && \
   apt-get clean autoclean autoremove
-
-
-# To avoid the mysterious error "Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty"
-# # From https://github.com/docker-library/openjdk/blob/master/11/jdk/slim/Dockerfile
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-# utilities for keeping Debian and OpenJDK CA certificates in sync
-    ca-certificates p11-kit \
-  ; \
-# update "cacerts" bundle to use Debian's CA certificates (and make sure it stays up-to-date with changes to Debian's store)
-# see https://github.com/docker-library/openjdk/issues/327
-#     http://rabexc.org/posts/certificates-not-working-java#comment-4099504075
-#     https://salsa.debian.org/java-team/ca-certificates-java/blob/3e51a84e9104823319abeb31f880580e46f45a98/debian/jks-keystore.hook.in
-#     https://git.alpinelinux.org/aports/tree/community/java-cacerts/APKBUILD?id=761af65f38b4570093461e6546dcf6b179d2b624#n29
-  { \
-    echo '#!/usr/bin/env bash'; \
-    echo 'set -Eeuo pipefail'; \
-    echo 'if ! [ -d "$JAVA_HOME" ]; then echo >&2 "error: missing JAVA_HOME environment variable"; exit 1; fi'; \
-# 8-jdk uses "$JAVA_HOME/jre/lib/security/cacerts" and 8-jre and 11+ uses "$JAVA_HOME/lib/security/cacerts" directly (no "jre" directory)
-    echo 'cacertsFile=; for f in "$JAVA_HOME/lib/security/cacerts" "$JAVA_HOME/jre/lib/security/cacerts"; do if [ -e "$f" ]; then cacertsFile="$f"; break; fi; done'; \
-    echo 'if [ -z "$cacertsFile" ] || ! [ -f "$cacertsFile" ]; then echo >&2 "error: failed to find cacerts file in $JAVA_HOME"; exit 1; fi'; \
-    echo 'trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose=server-auth "$cacertsFile"'; \
-  } > /etc/ca-certificates/update.d/docker-openjdk; \
-  chmod +x /etc/ca-certificates/update.d/docker-openjdk; \
-  /etc/ca-certificates/update.d/docker-openjdk; \
-  \
-# https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
-  find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
-  ldconfig;
 
 # Always run last to minimize the size
 RUN apt-get clean autoclean autoremove

--- a/server/docker-base/template.build.gradle
+++ b/server/docker-base/template.build.gradle
@@ -24,6 +24,8 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    namespace = "com.defold.defold"
 }
 
 java {

--- a/server/docker-base/template.gradle.properties
+++ b/server/docker-base/template.gradle.properties
@@ -4,4 +4,4 @@ android.enableJetifier={{android-enable-jetifier}}
 # Gradle will stop resolving dependencies if android.useAndroidX is false and a dependency is using Android X
 android.useAndroidX={{android-enable-jetifier}}
 
-org.gradle.java.home=/usr/lib/jvm/java-11-openjdk-amd64
+org.gradle.java.home=/usr/local/jdk-17.0.7+7

--- a/server/manifestmergetool/build.gradle
+++ b/server/manifestmergetool/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 apply plugin: 'java-library'
 
 jar {
-    baseName = '_manifestmergetool'
+    archiveBaseName = '_manifestmergetool'
     enabled = true
     archiveClassifier = '' // use empty string to avoid the 'plain' suffix
 }
@@ -22,7 +22,7 @@ configurations {
 
 task mainJar(type: Jar) {
     version =  '0.1.0'
-    baseName = 'manifestmergetool'
+    archiveBaseName = 'manifestmergetool'
     manifest {
         attributes 'Main-Class': 'com.defold.manifestmergetool.ManifestMergeTool'
     }
@@ -33,6 +33,7 @@ task mainJar(type: Jar) {
         exclude "META-INF/*.DSA"
         exclude "META-INF/*.RSA"
     }
+    duplicatesStrategy DuplicatesStrategy.WARN
     with jar
 }
 

--- a/server/scripts/standalone/service-standalone.sh
+++ b/server/scripts/standalone/service-standalone.sh
@@ -72,7 +72,7 @@ start_service() {
         java -Xmx2g -XX:MaxDirectMemorySize=1g -jar ${PATH_TO_JAR} --spring.profiles.active=${PROFILE} >> ${STDOUT_LOG} 2>> ${ERROR_LOG} < /dev/null &
     else
         echo "Running: java -Xmx2g -XX:MaxDirectMemorySize=1g -jar ${PATH_TO_JAR} --extender.sdk.location=${EXTENDER_SDK_LOCATION} --spring.profiles.active=${PROFILE} >> ${STDOUT_LOG} 2>> ${ERROR_LOG} < /dev/null &"
-        java -Xmx2g -XX:MaxDirectMemorySize=1g -jar ${PATH_TO_JAR} --extender.sdk.location="${EXTENDER_SDK_LOCATION}" -spring.profiles.active=${PROFILE} >> ${STDOUT_LOG} 2>> ${ERROR_LOG} < /dev/null &
+        java -Xmx2g -XX:MaxDirectMemorySize=1g -jar ${PATH_TO_JAR} --extender.sdk.location="${EXTENDER_SDK_LOCATION}" --spring.profiles.active=${PROFILE} >> ${STDOUT_LOG} 2>> ${ERROR_LOG} < /dev/null &
     fi
 
     


### PR DESCRIPTION
* Update Gradle to 8.4
* Gradle android plugin to 8.2.1
* Update gradle wrapper that used for building to 8.4. 
* Update build scripts according to new version to Gradle.
* Change gradle docker plugin.
* Use jdk 17 to run gradle during Android build.
* Remove various workarounds with jdk certificates from Dokerfile.

Fixes #290.