### PR TITLE
Detect if extender run on arm64 mac (m1/m2)

### DIFF
--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -179,10 +179,15 @@ class Extender {
         this.sdk = sdk;
 
         String os = System.getProperty("os.name");
-
+        String arch = System.getProperty("os.arch");
+        
         // These host names are using the Defold SDK names
         if (os.contains("Mac")) {
-            this.hostPlatform = "x86_64-macos";
+            if (arch.contains("aarch64")) {
+                this.hostPlatform = "arm64-macos";
+            } else {
+                this.hostPlatform = "x86_64-macos";
+            }
         } else if (os.contains("Windows")) {
             this.hostPlatform = "x86_64-win32";
         } else {


### PR DESCRIPTION
It's needed in cases the extender runs on M1 machine to be able to use right `protoc` executable, see https://github.com/defold/defold/issues/8566#issuecomment-1985492430