### PR TITLE
Merge privacy manifests and copy to build output

### DIFF
--- a/server/manifestmergetool/src/main/java/com/defold/manifestmergetool/AndroidManifestMerger.java
+++ b/server/manifestmergetool/src/main/java/com/defold/manifestmergetool/AndroidManifestMerger.java
@@ -1,0 +1,80 @@
+package com.defold.manifestmergetool;
+
+import java.io.File;
+import java.io.OutputStreamWriter;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import java.nio.charset.StandardCharsets;
+
+import com.android.manifmerger.ManifestMerger2;
+import com.android.manifmerger.MergingReport;
+import com.android.manifmerger.XmlDocument;
+import com.android.utils.ILogger;
+
+public class AndroidManifestMerger {
+
+    private static Logger logger;
+    private static ILoggerWrapper androidLogger;
+
+    private static class ILoggerWrapper implements ILogger {
+        private Logger logger;
+        public ILoggerWrapper(Logger logger) {
+            this.logger = logger;
+        }
+        public void error(Throwable t, String msgFormat, Object... args) {
+            AndroidManifestMerger.logger.log(Level.SEVERE, msgFormat, args);
+        }
+        public void warning(String msgFormat, Object... args) {
+            AndroidManifestMerger.logger.log(Level.WARNING, msgFormat, args);
+        }
+        public void info(String msgFormat, Object... args) {
+            AndroidManifestMerger.logger.log(Level.INFO, msgFormat, args);
+        }
+        public void verbose(String msgFormat, Object... args) {
+            AndroidManifestMerger.logger.log(Level.FINE, msgFormat, args);
+        }
+    }
+
+    public AndroidManifestMerger(Logger logger) {
+        this.logger = logger;
+        this.androidLogger = new ILoggerWrapper(logger);
+
+    }
+
+    public void merge(File main, File[] libraries, File out) throws RuntimeException {
+        // Good explanation of merge rules: https://android.googlesource.com/platform/tools/base/+/jb-mr2-dev/manifest-merger/src/main/java/com/android/manifmerger/ManifestMerger.java
+        // https://github.com/pixnet/android-platform-tools-base/blob/master/build-system/manifest-merger/src/main/java/com/android/manifmerger/ManifestMerger2.java
+        // https://android.googlesource.com/platform/tools/base/+/master/build-system/manifest-merger/src/main/java/com/android/manifmerger/Merger.java
+        logger.log(Level.FINE, "Merging manifests for Android");
+
+        ManifestMerger2.Invoker invoker = ManifestMerger2.newMerger(main, AndroidManifestMerger.androidLogger, ManifestMerger2.MergeType.APPLICATION);
+        invoker.addLibraryManifests(libraries);
+        invoker.withFeatures(ManifestMerger2.Invoker.Feature.REMOVE_TOOLS_DECLARATIONS);
+
+        try {
+            MergingReport report = invoker.merge();
+            if (report.getResult().isSuccess()) {
+                String xml = report.getMergedDocument(MergingReport.MergedManifestKind.MERGED);
+                if (out != null) {
+                    try {
+                        try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(out), StandardCharsets.UTF_8)) {
+                            writer.write(xml);
+                        }
+                    } catch (IOException e) {
+                        throw new RuntimeException("Failed to write xml to " + out.getAbsolutePath(), e);
+                    }
+                } else {
+                    System.out.println(xml);
+                }
+            } else {
+                report.log(AndroidManifestMerger.androidLogger);
+                throw new RuntimeException("Failed to merge manifests: " + report.toString());
+            }
+        } catch (ManifestMerger2.MergeFailureException e) {
+            throw new RuntimeException("Exception while merging manifests: " + e.toString());
+        }
+    }
+}

--- a/server/manifestmergetool/src/main/java/com/defold/manifestmergetool/HtmlMerger.java
+++ b/server/manifestmergetool/src/main/java/com/defold/manifestmergetool/HtmlMerger.java
@@ -24,20 +24,20 @@ public class HtmlMerger {
         KEEP, MERGE
     }
 
-    HtmlMerger(Logger logger) {
+    public HtmlMerger(Logger logger) {
         HtmlMerger.logger = logger;
     }
 
     class HtmlMergeException extends RuntimeException {
     };
 
-    private static MergePolicy getMergePolicy(Element e) {
+    private MergePolicy getMergePolicy(Element e) {
         String attr = e.attr("merge");
         if (attr.equals("keep")) return MergePolicy.KEEP;
         return MergePolicy.MERGE;
     }
 
-    public static Element findElement(Element e, String tag, String id) {
+    public Element findElement(Element e, String tag, String id) {
         for(Element child : e.children()) {
             if (child.tagName().equals(tag) && child.id().equals(id))
                 return child;
@@ -45,7 +45,7 @@ public class HtmlMerger {
         return null;
     }
 
-    public static void mergeNode(Element elementa, Element elementb) {
+    public void mergeNode(Element elementa, Element elementb) {
         for (Attribute attr : elementb.attributes()) {
             elementa.attr(attr.getKey(), attr.getValue());
         }
@@ -55,7 +55,7 @@ public class HtmlMerger {
         }
     }
 
-    public static void mergeElement(Element elementa, Element elementb) {
+    public void mergeElement(Element elementa, Element elementb) {
         MergePolicy mergePolicyA = getMergePolicy(elementa);
         MergePolicy mergePolicyB = getMergePolicy(elementb);
 
@@ -92,12 +92,12 @@ public class HtmlMerger {
         }
     }
 
-    public static void mergeDocuments(Document a, Document b) {
+    public void mergeDocuments(Document a, Document b) {
         mergeElement(a.head(), b.head());
         mergeElement(a.body(), b.body());
     }
 
-    public static void writeDocument(Document doc, File out) {
+    public void writeDocument(Document doc, File out) {
         if (out != null) {
             try {
                 try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(out), StandardCharsets.UTF_8)) {
@@ -110,11 +110,11 @@ public class HtmlMerger {
         }
     }
 
-    private static Document loadDocument(File file) throws IOException {
+    private Document loadDocument(File file) throws IOException {
         return Jsoup.parse(file, "UTF-8");
     }
 
-    public static void merge(File main, File[] libraries, File out) throws RuntimeException, IOException {
+    public void merge(File main, File[] libraries, File out) throws RuntimeException, IOException {
         Document baseDocument = loadDocument(main);
 
         // For error reporting/troubleshooting
@@ -130,6 +130,6 @@ public class HtmlMerger {
             }
         }
 
-        HtmlMerger.writeDocument(baseDocument, out);
+        writeDocument(baseDocument, out);
     }
 }

--- a/server/manifestmergetool/src/main/java/com/defold/manifestmergetool/InfoPlistMerger.java
+++ b/server/manifestmergetool/src/main/java/com/defold/manifestmergetool/InfoPlistMerger.java
@@ -36,12 +36,12 @@ class PlistMergeException extends Exception {
 public class InfoPlistMerger {
     private static Logger logger;
 
-    InfoPlistMerger(Logger logger) {
+    public InfoPlistMerger(Logger logger) {
         InfoPlistMerger.logger = logger;
     }
 
     // Merges the lib onto base, using the merging rules from https://developer.android.com/studio/build/manifest-merge.html
-    private static void mergePlists(XMLPropertyListConfiguration base, XMLPropertyListConfiguration lib, Map<String, String> mergeMarkers) throws PlistMergeException {
+    private void mergePlists(XMLPropertyListConfiguration base, XMLPropertyListConfiguration lib, Map<String, String> mergeMarkers) throws PlistMergeException {
 
 
         @SuppressWarnings("unchecked")
@@ -129,7 +129,7 @@ public class InfoPlistMerger {
         }
     }
 
-    private static XMLPropertyListConfiguration loadPlist(File file) {
+    private XMLPropertyListConfiguration loadPlist(File file) {
         try {
             XMLPropertyListConfiguration plist = new XMLPropertyListConfiguration();
             plist.read(new FileReader(file));
@@ -170,7 +170,7 @@ public class InfoPlistMerger {
     }
 
 
-    private static Map<String, String> parseMergeNodeMarkers(File file) {
+    private Map<String, String> parseMergeNodeMarkers(File file) {
         Map<String, String> markers = new HashMap<>();
         try {
             // parse the file and get the first <dict> tag
@@ -197,7 +197,7 @@ public class InfoPlistMerger {
         return markers;
     }
 
-    public static void merge(File main, File[] libraries, File out) throws RuntimeException {
+    public void merge(File main, File[] libraries, File out) throws RuntimeException {
 
         Map<String, String> markers = parseMergeNodeMarkers(main);
 

--- a/server/manifestmergetool/src/main/java/com/defold/manifestmergetool/PrivacyManifestMerger.java
+++ b/server/manifestmergetool/src/main/java/com/defold/manifestmergetool/PrivacyManifestMerger.java
@@ -1,0 +1,147 @@
+package com.defold.manifestmergetool;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+// https://cayenne.apache.org/docs/2.0/api/org/apache/cayenne/conf/FileConfiguration.html
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.io.FileLocator.FileLocatorBuilder;
+import org.apache.commons.configuration2.io.FileLocatorUtils;
+import org.apache.commons.configuration2.io.FileLocator;
+import org.apache.commons.configuration2.plist.XMLPropertyListConfiguration;
+
+public class PrivacyManifestMerger {
+    private static Logger logger;
+
+    PrivacyManifestMerger(Logger logger) {
+        PrivacyManifestMerger.logger = logger;
+    }
+
+    private ArrayList<XMLPropertyListConfiguration> getArrayList(XMLPropertyListConfiguration config, String key) {
+        @SuppressWarnings("unchecked")
+        ArrayList<XMLPropertyListConfiguration> a = (ArrayList<XMLPropertyListConfiguration>)config.getProperty(key);
+        return a;
+    }
+
+    private ArrayList<String> getStringArrayList(XMLPropertyListConfiguration config, String key) {
+        @SuppressWarnings("unchecked")
+        ArrayList<String> a = (ArrayList<String>)config.getProperty(key);
+        return a;
+    }
+
+    /**
+     * Search a list of 'dict' objects (XMLPropertyListConfiguration) for a dict
+     * with a specific NSPrivacyAccessedAPIType.
+     * @param list List of dicts
+     * @param apiTypeToFind The api type to find
+     * @return The dict or null
+     */
+    private XMLPropertyListConfiguration findAccessedAPI(ArrayList<XMLPropertyListConfiguration> list, String apiTypeToFind) {
+        for (XMLPropertyListConfiguration api : list) {
+            String apiType = api.getString("NSPrivacyAccessedAPIType");
+            if (apiTypeToFind.equals(apiType)) {
+                return api;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Merge NSPrivacyAccessedAPITypes. This function will do a deep merge
+     * and ignore duplicates of the same access reason per api.
+     * @param target Config to merge to
+     * @param source Config to merge from
+     */
+    private void mergeAccessedAPITypes(XMLPropertyListConfiguration target, XMLPropertyListConfiguration source) {
+        ArrayList<XMLPropertyListConfiguration> targetAccessedAPITypes = getArrayList(target, "NSPrivacyAccessedAPITypes");
+        ArrayList<XMLPropertyListConfiguration> sourceAccessedAPITypes = getArrayList(source, "NSPrivacyAccessedAPITypes");
+
+        for (XMLPropertyListConfiguration sourceApi : sourceAccessedAPITypes) {
+            String sourceType = sourceApi.getString("NSPrivacyAccessedAPIType");
+
+            // find if this api is already declared as accessed
+            XMLPropertyListConfiguration targetApi = findAccessedAPI(targetAccessedAPITypes, sourceType);
+            // if the api is not declared as accessed then add the api as-is
+            if (targetApi == null) {
+                targetAccessedAPITypes.add(sourceApi);
+                continue;
+            }
+
+            // the api is declared as accessed already
+            // only add reasons not already declared
+            ArrayList<String> targetReasons = getStringArrayList(targetApi, "NSPrivacyAccessedAPITypeReasons");
+            ArrayList<String> sourceReasons = getStringArrayList(sourceApi, "NSPrivacyAccessedAPITypeReasons");
+            for (String reason : sourceReasons) {
+                if (!targetReasons.contains(reason)) {
+                    targetReasons.add(reason);
+                }
+            }
+        }
+    }
+
+    private void mergeConfigs(XMLPropertyListConfiguration base, XMLPropertyListConfiguration lib) throws PlistMergeException {
+        Object baseTracking = base.getProperty("NSPrivacyTracking");
+        Object libTracking = lib.getProperty("NSPrivacyTracking");
+
+        // merge privacy tracking domains
+        ArrayList<String> baseTrackingDomains = getStringArrayList(base, "NSPrivacyTrackingDomains");
+        ArrayList<String> libTrackingDomains = getStringArrayList(lib, "NSPrivacyTrackingDomains");
+        baseTrackingDomains.addAll(libTrackingDomains);
+
+        // merge collected data types
+        ArrayList<XMLPropertyListConfiguration> baseCollectedDataTypes = getArrayList(base, "NSPrivacyCollectedDataTypes");
+        ArrayList<XMLPropertyListConfiguration> libCollectedDataTypes = getArrayList(lib, "NSPrivacyCollectedDataTypes");
+        baseCollectedDataTypes.addAll(libCollectedDataTypes);
+
+        // merge accessed apis
+        mergeAccessedAPITypes(base, lib);
+    }
+
+    private XMLPropertyListConfiguration loadConfig(File file) {
+        try {
+            XMLPropertyListConfiguration plist = new XMLPropertyListConfiguration();
+            plist.read(new FileReader(file));
+            return plist;
+        } catch (ConfigurationException e) {
+            throw new RuntimeException(String.format("Failed to parse plist '%s': %s", file.getAbsolutePath(), e.toString()));
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(String.format("File not found: %s", file.getAbsolutePath()));
+        }
+    }
+
+    public void merge(File main, File[] libraries, File out) throws RuntimeException {
+
+        XMLPropertyListConfiguration basePlist = loadConfig(main);
+        // For error reporting/troubleshooting
+        String paths = "\n" + main.getAbsolutePath();
+
+        for (File library : libraries) {
+            paths += "\n" + library.getAbsolutePath();
+            XMLPropertyListConfiguration libraryPlist = loadConfig(library);
+            try {
+                mergeConfigs(basePlist, libraryPlist);
+            } catch (PlistMergeException e) {
+                throw new RuntimeException(String.format("Errors merging plists: %s:\n%s", paths, e.toString()));
+            }
+        }
+
+        try {
+            FileWriter writer = new FileWriter(out);
+            FileLocatorBuilder builder = FileLocatorUtils.fileLocator();
+            FileLocator locator = new FileLocator(builder);
+            basePlist.initFileLocator(locator);
+            basePlist.write(writer);
+            writer.close();
+        } catch (ConfigurationException e) {
+            throw new RuntimeException("Failed to parse plist: " + e.toString());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to parse plist: " + e.toString());
+        }
+    }
+}

--- a/server/manifestmergetool/src/test/java/com/defold/manifestmergetool/ManifestMergeToolTest.java
+++ b/server/manifestmergetool/src/test/java/com/defold/manifestmergetool/ManifestMergeToolTest.java
@@ -29,11 +29,11 @@ public class ManifestMergeToolTest {
     private File target;
     List<File> libraries;
 
-    private String createFile(String root, String name, String content) throws IOException {
+    private File createFile(String root, String name, String content) throws IOException {
         File file = new File(root, name);
         file.deleteOnExit();
         FileUtils.copyInputStreamToFile(new ByteArrayInputStream(content.getBytes()), file);
-        return file.getAbsolutePath();
+        return file;
     }
 
     protected void createDefaultFiles() throws IOException {
@@ -483,7 +483,7 @@ public class ManifestMergeToolTest {
 
     @Test
     public void testMergeNestedDictionaries() throws IOException {
-                if (platform != Platform.IOS) {
+        if (platform != Platform.IOS) {
             return;
         }
         createDefaultFiles();
@@ -620,6 +620,156 @@ public class ManifestMergeToolTest {
         ManifestMergeTool.merge(ManifestMergeTool.Platform.IOS, this.main, this.target, this.libraries);
 
         String merged = readFile(this.target);
+        assertEquals(expected, merged);
+    }
+
+
+    @Test
+    public void testMergePrivacyManifest() throws IOException {
+        if (platform != Platform.IOS && platform != Platform.OSX) {
+            return;
+        }
+        createDefaultFiles();
+
+        String main = ""
+            + "<?xml version=\"1.0\"?>\n"
+            + "<!DOCTYPE plist SYSTEM \"file://localhost/System/Library/DTDs/PropertyList.dtd\">\n"
+            + "<plist version=\"1.0\">\n"
+            + "    <dict>\n"
+            + "        <key>NSPrivacyTracking</key>\n"
+            + "        <false/>\n"
+            + "\n"
+            + "        <key>NSPrivacyTrackingDomains</key>\n"
+            + "        <array>\n"
+            + "        </array>\n"
+            + "\n"
+            + "        <key>NSPrivacyCollectedDataTypes</key>\n"
+            + "        <array>\n"
+            + "          <dict>\n"
+            + "              <key>FooKey</key>\n"
+            + "              <string>FooString</string>\n"
+            + "          </dict>\n"
+            + "        </array>\n"
+            + "\n"
+            + "        <key>NSPrivacyAccessedAPITypes</key>\n"
+            + "        <array>\n"
+            + "          <dict>\n"
+            + "              <key>NSPrivacyAccessedAPIType</key>\n"
+            + "              <string>Foo</string>\n"
+            + "\n"
+            + "              <key>NSPrivacyAccessedAPITypeReasons</key>\n"
+            + "              <array>\n"
+            + "                  <string>A</string>\n"
+            + "              </array>\n"
+            + "          </dict>\n"
+            + "        </array>\n"
+            + "    </dict>\n"
+            + "</plist>\n";
+
+        String lib = ""
+            + "<?xml version=\"1.0\"?>\n"
+            + "<!DOCTYPE plist SYSTEM \"file://localhost/System/Library/DTDs/PropertyList.dtd\">\n"
+            + "<plist version=\"1.0\">\n"
+            + "    <dict>\n"
+            + "        <key>NSPrivacyTracking</key>\n"
+            + "        <false/>\n"
+            + "\n"
+            + "        <key>NSPrivacyTrackingDomains</key>\n"
+            + "        <array>\n"
+            + "        </array>\n"
+            + "\n"
+            + "        <key>NSPrivacyCollectedDataTypes</key>\n"
+            + "        <array>\n"
+            + "            <dict>\n"
+            + "                <key>BarKey</key>\n"
+            + "                <string>BarString</string>\n"
+            + "            </dict>\n"
+            + "        </array>\n"
+            + "\n"
+            + "        <key>NSPrivacyAccessedAPITypes</key>\n"
+            + "        <array>\n"
+            + "            <dict>\n"
+            + "                <key>NSPrivacyAccessedAPIType</key>\n"
+            + "                <string>Foo</string>\n"
+            + "\n"
+            + "                <key>NSPrivacyAccessedAPITypeReasons</key>\n"
+            + "                <array>\n"
+            + "                    <string>B</string>\n"
+            + "                </array>\n"
+            + "            </dict>\n"
+            + "            <dict>\n"
+            + "                <key>NSPrivacyAccessedAPIType</key>\n"
+            + "                <string>Bar</string>\n"
+            + "\n"
+            + "                <key>NSPrivacyAccessedAPITypeReasons</key>\n"
+            + "                <array>\n"
+            + "                    <string>A</string>\n"
+            + "                </array>\n"
+            + "            </dict>\n"
+            + "        </array>\n"
+            + "    </dict>\n"
+            + "</plist>\n";
+
+        String expected = ""
+            + "<?xml version=\"1.0\"?>\n"
+            + "<!DOCTYPE plist SYSTEM \"file://localhost/System/Library/DTDs/PropertyList.dtd\">\n"
+            + "<plist version=\"1.0\">\n"
+            + "    <dict>\n"
+            + "        <key>NSPrivacyTracking</key>\n"
+            + "        <false/>\n"
+            + "\n"
+            + "        <key>NSPrivacyTrackingDomains</key>\n"
+            + "        <array>\n"
+            + "        </array>\n"
+            + "\n"
+            + "        <key>NSPrivacyCollectedDataTypes</key>\n"
+            + "        <array>\n"
+            + "            <dict>\n"
+            + "                <key>FooKey</key>\n"
+            + "                <string>FooString</string>\n"
+            + "            </dict>\n"
+            + "            <dict>\n"
+            + "                <key>BarKey</key>\n"
+            + "                <string>BarString</string>\n"
+            + "            </dict>\n"
+            + "        </array>\n"
+            + "\n"
+            + "        <key>NSPrivacyAccessedAPITypes</key>\n"
+            + "        <array>\n"
+            + "            <dict>\n"
+            + "                <key>NSPrivacyAccessedAPIType</key>\n"
+            + "                <string>Foo</string>\n"
+            + "\n"
+            + "                <key>NSPrivacyAccessedAPITypeReasons</key>\n"
+            + "                <array>\n"
+            + "                    <string>A</string>\n"
+            + "                    <string>B</string>\n"
+            + "                </array>\n"
+            + "            </dict>\n"
+            + "            <dict>\n"
+            + "                <key>NSPrivacyAccessedAPIType</key>\n"
+            + "                <string>Bar</string>\n"
+            + "\n"
+            + "                <key>NSPrivacyAccessedAPITypeReasons</key>\n"
+            + "                <array>\n"
+            + "                    <string>A</string>\n"
+            + "                </array>\n"
+            + "            </dict>\n"
+            + "        </array>\n"
+            + "    </dict>\n"
+            + "</plist>\n";
+
+        File mainFile = createFile(contentRoot, "builtins/manifests/ios/PrivacyInfo.xcprivacy", main);
+        File libFile = createFile(contentRoot, "builtins/manifests/ios/PrivacyInfoLib.xcprivacy", lib);
+        File targetFile = new File(contentRoot, "builtins/manifests/ios/PrivacyInfoMerged.plist");
+
+        List<File> libraries = new ArrayList<>();
+        libraries.add(libFile);
+        ManifestMergeTool.merge(ManifestMergeTool.Platform.IOS, mainFile, targetFile, libraries);
+
+        String merged = readFile(targetFile);
+        System.out.println("expected: " + expected);
+        System.out.println("merged: " + merged);
         assertEquals(expected, merged);
     }
 

--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -2370,24 +2370,6 @@ class Extender {
         return outputFiles;
     }
 
-    private List<File> copyApplePrivacyManifests(String platform) throws ExtenderException {
-        List<File> manifests = new ArrayList<>();
-        if (resolvedPods != null) {
-            for (File sourcePrivacyManifest : resolvedPods.getAllPrivacyManifests(platform)) {
-                String relativePath = ExtenderUtil.getRelativePath(resolvedPods.podsDir, sourcePrivacyManifest);
-                File targetPrivacyManifest = new File(buildDirectory, relativePath);
-                try {
-                    FileUtils.copyFile(sourcePrivacyManifest, targetPrivacyManifest);
-                }
-                catch (IOException e) {
-                    throw new ExtenderException(e, "Failed to copy privacy manifest");
-                }
-                manifests.add(targetPrivacyManifest);
-            }
-        }
-        return manifests;
-    }
-
     private List<File> buildApple(String platform) throws ExtenderException {
         LOGGER.info("Building Apple specific code");
         List<File> outputFiles = new ArrayList<>();

--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -2374,7 +2374,7 @@ class Extender {
         List<File> manifests = new ArrayList<>();
         if (resolvedPods != null) {
             for (File sourcePrivacyManifest : resolvedPods.getAllPrivacyManifests(platform)) {
-                String relativePath = ExtenderUtil.getRelativePath(resolvedPods.podsDir, privacyManifest);
+                String relativePath = ExtenderUtil.getRelativePath(resolvedPods.podsDir, sourcePrivacyManifest);
                 File targetPrivacyManifest = new File(buildDirectory, relativePath);
                 try {
                     FileUtils.copyFile(sourcePrivacyManifest, targetPrivacyManifest);

--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -2370,6 +2370,31 @@ class Extender {
         return outputFiles;
     }
 
+    private List<File> copyApplePrivacyManifests(String platform) throws ExtenderException {
+        List<File> manifests = new ArrayList<>();
+        if (resolvedPods != null) {
+            for (File sourcePrivacyManifest : resolvedPods.getAllPrivacyManifests(platform)) {
+                String relativePath = ExtenderUtil.getRelativePath(resolvedPods.podsDir, privacyManifest);
+                File targetPrivacyManifest = new File(buildDirectory, relativePath);
+                try {
+                    FileUtils.copyFile(sourcePrivacyManifest, targetPrivacyManifest);
+                }
+                catch (IOException e) {
+                    throw new ExtenderException(e, "Failed to copy privacy manifest");
+                }
+                manifests.add(targetPrivacyManifest);
+            }
+        }
+        return manifests;
+    }
+
+    private List<File> buildApple(String platform) throws ExtenderException {
+        LOGGER.info("Building Apple specific code");
+        List<File> outputFiles = new ArrayList<>();
+        outputFiles.addAll(copyApplePrivacyManifests(platform));
+        return outputFiles;
+    }
+
     private String getBasePlatform(String platform) {
         String[] platformParts = this.platform.split("-");
         return platformParts[1];
@@ -2498,6 +2523,9 @@ class Extender {
             // TODO: Thread this step
             if (platform.endsWith("android")) {
                 outputFiles.addAll(buildAndroid(platform));
+            }
+            else if (platform.endsWith("ios") || platform.endsWith("macos")) {
+                outputFiles.addAll(buildApple(platform));
             }
 
             outputFiles.addAll(buildEngine());

--- a/server/src/main/java/com/defold/extender/services/CocoaPodsService.java
+++ b/server/src/main/java/com/defold/extender/services/CocoaPodsService.java
@@ -119,6 +119,11 @@ public class CocoaPodsService {
             }
             return new ArrayList<String>(weakFrameworks);
         }
+
+        public List<File> getAllPrivacyManifests(String platform) {
+            List<File> manifests = ExtenderUtil.listFilesMatchingRecursive(podsDir, "PrivacyInfo.xcprivacy");
+            return manifests;
+        }
     }
 
     public class LanguageSet {

--- a/server/src/main/java/com/defold/extender/services/CocoaPodsService.java
+++ b/server/src/main/java/com/defold/extender/services/CocoaPodsService.java
@@ -119,11 +119,6 @@ public class CocoaPodsService {
             }
             return new ArrayList<String>(weakFrameworks);
         }
-
-        public List<File> getAllPrivacyManifests(String platform) {
-            List<File> manifests = ExtenderUtil.listFilesMatchingRecursive(podsDir, "PrivacyInfo.xcprivacy");
-            return manifests;
-        }
     }
 
     public class LanguageSet {


### PR DESCRIPTION
This change will gather all `*.xcprivacy` files from upload directory and from resolved pods and merge them into a single `PrivacyInfo.xcprivacy` and send the merged file together with other output files to the client.

Fixes #354 