### PR TITLE
Add --platform flag to ensure use right arch for docker container.

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -161,6 +161,7 @@ task dockerStageDir {
 task buildDocker(type: DockerBuildImage) {
     dependsOn 'build', ':manifestmergetool:mainJar', 'dockerStageDir'
     inputDir = dockerBuildDir
+    buildArgs = ['platform': 'linux/amd64']
     imageId = bootJar.archiveBaseName
     dockerFile = new File(dockerBuildDir, 'Dockerfile')
     images.add("extender/extender:latest")

--- a/server/scripts/build.sh
+++ b/server/scripts/build.sh
@@ -27,6 +27,6 @@ if [ "${DM_EXTENDER_PASSWORD}" != "" ]; then
 	unset DM_EXTENDER_PASSWORD
 fi
 
-docker build -t extender-base ${ENV} ${DIR}/../docker-base
+docker build --platform linux/amd64 -t extender-base ${ENV} ${DIR}/../docker-base
 
 ${DIR}/../../gradlew clean buildDocker --info $@


### PR DESCRIPTION
Specify explicitly `--platform` flag helps avoid issue on Apple silicon (and other non-Intel archs) because by default Docker select ubuntu image according to host platform. It leads to error during building because of java and container arch mismatch.