### PR TITLE
Upgrade gradle docker plugin

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id 'idea'
     id 'eclipse'
     id 'org.springframework.boot' version '2.6.6'
-    id 'com.bmuschko.docker-remote-api' version '7.2.0'
+    id 'com.bmuschko.docker-remote-api' version '9.4.0'
 }
 
 apply plugin: 'com.bmuschko.docker-remote-api'


### PR DESCRIPTION
I had issues on my mac to connect from Gradle to the Docker daemon. An update of the plugin solved it. I have not noticed any problems and I can now perform a full build with tests.

While testing I also had Gradle logging set to `debug` which will log **A LOT**. This resulted in `OutOfMemoryError` in ProcessExecutor.java while appending to a `StringBuilder`. I added a try-catch and truncate the log if this happens.