### PR TITLE
Exclude dependencies that not necessary for manifestmergetool.

### DIFF
--- a/server/manifestmergetool/build.gradle
+++ b/server/manifestmergetool/build.gradle
@@ -22,6 +22,8 @@ configurations {
     implementation {
         canBeResolved = true
     }
+    all*.exclude group: 'com.android.tools', module: 'repository'
+    all*.exclude group: 'com.android.tools', module: 'sdklib'
 }
 
 task mainJar(type: Jar) {


### PR DESCRIPTION
Exclude dependencies that used by Google team to work with repo/tools. It's not necessary for Manifest merge implementation. As bonus - remove packages with security issues.