### PR TITLE
Run standalone jetifier if needed

### DIFF
--- a/server/docker/Dockerfile.android-env
+++ b/server/docker/Dockerfile.android-env
@@ -8,7 +8,7 @@ FROM europe-north1-docker.pkg.dev/extender-426409/extender-public-registry/exten
 ENV GRADLE_USER_HOME=/tmp/.gradle
 ENV GRADLE_VERSION=8.4
 ENV GRADLE_PLUGIN_VERSION=8.3.2
-ENV PATH=${PATH}:/opt/gradle/gradle-${GRADLE_VERSION}/bin
+ENV PATH=${PATH}:/opt/gradle/gradle-${GRADLE_VERSION}/bin:/opt/jetifier-standalone/bin
 RUN \
   echo "Gradle" && \
   wget -q https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip && \
@@ -17,3 +17,12 @@ RUN \
   rm gradle-${GRADLE_VERSION}-bin.zip && \
   which gradle && \
   chown -R extender: /opt/gradle
+
+# https://developer.android.com/tools/jetifier
+ENV JETIFIER_VERSION=1.0.0-beta10
+
+RUN \
+  wget -q https://dl.google.com/dl/android/studio/jetifier-zips/${JETIFIER_VERSION}/jetifier-standalone.zip && \
+  unzip -q -d /opt/ jetifier-standalone.zip && \
+  rm jetifier-standalone.zip && \
+  chown -R extender: /opt/jetifier-standalone

--- a/server/docker/Dockerfile.android.ndk25-env
+++ b/server/docker/Dockerfile.android.ndk25-env
@@ -1,4 +1,4 @@
-FROM europe-north1-docker.pkg.dev/extender-426409/extender-public-registry/extender-android-env:1.2.0
+FROM europe-north1-docker.pkg.dev/extender-426409/extender-public-registry/extender-android-env:1.3.0
 
 #
 # Android SDK/NDK

--- a/server/src/main/resources/template.build.gradle
+++ b/server/src/main/resources/template.build.gradle
@@ -11,7 +11,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        mavenLocal()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
* Add standalone jetifier to Android docker image
* When resolve Gradle dependencies run standalone jetifier according to flag `useJetifier`.

P.S. Based on `split-docker` branch.

Fixes #301 