### PR TITLE
Add GCPInstanceService which used to monitor and suspend gcp instances if instance not used for a while.

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     }
 
     implementation('com.google.cloud:spring-cloud-gcp-starter-storage')
+    implementation('com.google.cloud:google-cloud-compute:1.57.0')
     implementation('com.google.guava:guava:33.2.1-jre')
     implementation('com.samskivert:jmustache:1.15')
     implementation('commons-chain:commons-chain:1.2')

--- a/server/configs/application-local-dev-app.yml
+++ b/server/configs/application-local-dev-app.yml
@@ -2,20 +2,36 @@ extender:
     remote-builder:
         enabled: true
         platforms:
-            android-ndk25: http://android-ndk25:9000
-            android-latest: http://android-ndk25:9000
-            emsdk-2011: http://emsdk-2011:9000
-            emsdk-3155: http://emsdk-3155:9000
-            emsdk-latest: http://emsdk-3155:9000
-            linux-latest: http://linux:9000
-            nssdk-1532: http://nssdk-1532:9000
-            nssdk-1753: http://nssdk-1753:9000
-            nssdk-latest: http://nssdk-1753:9000
-            ps4-10500: http://ps4-10500:9000
-            ps4-11000: http://ps4-11000:9000
-            ps4-latest: http://ps4-11000:9000
-            ps5-8000: http://ps5-8000:9000
-            ps5-latest: http://ps5-8000:9000
-            winsdk-2019: http://winsdk-2019:9000
-            winsdk-2022: http://winsdk-2022:9000
-            winsdk-latest: http://winsdk-2022:9000
+            android-ndk25:
+                url: http://android-ndk25:9000
+                instance: android-ndk25
+            emsdk-2011:
+                url: http://emsdk-2011:9000
+                instance: emsdk-2011
+            emsdk-3155:
+                url: http://emsdk-3155:9000
+                instance: emsdk-3155
+            linux-latest:
+                url: http://linux:9000
+                instance: linux
+            nssdk-1532:
+                url: http://10.0.0.3:9000
+                instance: nssdk-1532
+            nssdk-1753:
+                url: http://10.0.0.4:9000
+                instance: nssdk-1753
+            ps4-10500:
+                url: http://ps4-10500:9000
+                instance: ps4-10500
+            ps4-11000:
+                url: http://ps4-11000:9000
+                instance: ps4-11000
+            ps5-8000:
+                url: http://ps5-8000:9000
+                instance: ps5-8000
+            winsdk-2019:
+                url: http://winsdk-2019:9000
+                instance: winsdk-2019
+            winsdk-2022:
+                url: http://winsdk-2022:9000
+                instance: winsdk-2022

--- a/server/configs/application-local-dev-app.yml
+++ b/server/configs/application-local-dev-app.yml
@@ -4,34 +4,35 @@ extender:
         platforms:
             android-ndk25:
                 url: http://android-ndk25:9000
-                instance: android-ndk25
+                instanceId: android-ndk25
+                alwaysOn: true
             emsdk-2011:
                 url: http://emsdk-2011:9000
-                instance: emsdk-2011
+                instanceId: emsdk-2011
             emsdk-3155:
                 url: http://emsdk-3155:9000
-                instance: emsdk-3155
+                instanceId: emsdk-3155
             linux-latest:
                 url: http://linux:9000
-                instance: linux
+                instanceId: linux
             nssdk-1532:
                 url: http://10.0.0.3:9000
-                instance: nssdk-1532
+                instanceId: nssdk-1532
             nssdk-1753:
                 url: http://10.0.0.4:9000
-                instance: nssdk-1753
+                instanceId: nssdk-1753
             ps4-10500:
                 url: http://ps4-10500:9000
-                instance: ps4-10500
+                instanceId: ps4-10500
             ps4-11000:
                 url: http://ps4-11000:9000
-                instance: ps4-11000
+                instanceId: ps4-11000
             ps5-8000:
                 url: http://ps5-8000:9000
-                instance: ps5-8000
+                instanceId: ps5-8000
             winsdk-2019:
                 url: http://winsdk-2019:9000
-                instance: winsdk-2019
+                instanceId: winsdk-2019
             winsdk-2022:
                 url: http://winsdk-2022:9000
-                instance: winsdk-2022
+                instanceId: winsdk-2022

--- a/server/src/main/java/com/defold/extender/remote/RemoteEngineBuilder.java
+++ b/server/src/main/java/com/defold/extender/remote/RemoteEngineBuilder.java
@@ -3,6 +3,7 @@ package com.defold.extender.remote;
 import com.defold.extender.BuilderConstants;
 import com.defold.extender.ExtenderException;
 import com.defold.extender.metrics.MetricsWriter;
+import com.defold.extender.services.GCPInstanceService;
 import com.defold.extender.Timer;
 
 import org.apache.commons.io.FileUtils;
@@ -34,6 +35,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.Optional;
 import java.nio.charset.StandardCharsets;
 
 @Service
@@ -41,14 +43,17 @@ public class RemoteEngineBuilder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RemoteEngineBuilder.class);
 
+    private GCPInstanceService instanceService;
     private File jobResultLocation;
     private long buildSleepTimeout;
     private long buildResultWaitTimeout;
     private boolean keepJobDirectory = false;
 
-    public RemoteEngineBuilder(@Value("${extender.job-result.location}") String jobResultLocation,
+    public RemoteEngineBuilder(Optional<GCPInstanceService> instanceService,
+                            @Value("${extender.job-result.location}") String jobResultLocation,
                             @Value("${extender.remote-builder.build-sleep-timeout:5000}") long buildSleepTimeout,
                             @Value("${extender.remote-builder.build-result-wait-timeout:1200000}") long buildResultWaitTimeout) {
+        instanceService.ifPresent(val -> { LOGGER.info("Instance client is initialized"); this.instanceService = val; });
         this.buildSleepTimeout = buildSleepTimeout;
         this.buildResultWaitTimeout = buildResultWaitTimeout;
         this.jobResultLocation = new File(jobResultLocation);
@@ -56,20 +61,19 @@ public class RemoteEngineBuilder {
     }
 
     private String getErrorString(HttpResponse response) throws IOException {
-
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         response.getEntity().writeTo(bos);
         final byte[] bytes = bos.toByteArray();
         return new String(bytes, StandardCharsets.UTF_8);
     }
 
-    public void build(final String remoteBuilderUrl,
+    public void build(final RemoteInstanceConfig remoteInstanceConfig,
                         final File projectDirectory,
                         final String platform,
                         final String sdkVersion,
                         final OutputStream out) throws ExtenderException {
 
-        LOGGER.info("Building engine remotely at {}", remoteBuilderUrl);
+        LOGGER.info("Building engine remotely at {}", remoteInstanceConfig.getUrl());
 
         final HttpEntity httpEntity;
 
@@ -81,8 +85,10 @@ public class RemoteEngineBuilder {
 
 
         try {
-            final HttpResponse response = sendRequest(remoteBuilderUrl, platform, sdkVersion, httpEntity);
+            touchInstance(remoteInstanceConfig.getInstance());
+            final HttpResponse response = sendRequest(remoteInstanceConfig.getUrl(), platform, sdkVersion, httpEntity);
 
+            touchInstance(remoteInstanceConfig.getInstance());
             LOGGER.info("Remote builder response status: {}", response.getStatusLine());
 
             if (isClientError(response)) {
@@ -102,13 +108,13 @@ public class RemoteEngineBuilder {
     }
 
     @Async
-    public void buildAsync(final String remoteBuilderUrl,
+    public void buildAsync(final RemoteInstanceConfig remoteInstanceConfig,
                         final File projectDirectory,
                         final String platform,
                         final String sdkVersion,
                         File jobDirectory, File buildDirectory, MetricsWriter metricsWriter) throws FileNotFoundException, IOException {
 
-        LOGGER.info("Building engine remotely at {}", remoteBuilderUrl);
+        LOGGER.info("Building engine remotely at {}", remoteInstanceConfig.getUrl());
         String jobName = jobDirectory.getName();
         Thread.currentThread().setName(String.format("async-build-%s", jobName));
         File resultDir = new File(jobResultLocation.getAbsolutePath(), jobName);
@@ -125,12 +131,13 @@ public class RemoteEngineBuilder {
         }
 
         try {
-            final String serverUrl = String.format("%s/build_async/%s/%s", remoteBuilderUrl, platform, sdkVersion);
+            final String serverUrl = String.format("%s/build_async/%s/%s", remoteInstanceConfig.getUrl(), platform, sdkVersion);
             final HttpPost request = new HttpPost(serverUrl);
             request.setEntity(httpEntity);
     
             final HttpClient client  = HttpClientBuilder.create().build();
     
+            touchInstance(remoteInstanceConfig.getInstance());
             HttpResponse response = client.execute(request);
             // copied from ExtenderClient. Think about code deduplication.
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
@@ -140,7 +147,8 @@ public class RemoteEngineBuilder {
                 Integer jobStatus = 0;
                 Thread.sleep(buildSleepTimeout);
                 while (System.currentTimeMillis() - currentTime < buildResultWaitTimeout) {
-                    HttpGet statusRequest = new HttpGet(String.format("%s/job_status?jobId=%s", remoteBuilderUrl, jobId));
+                    touchInstance(remoteInstanceConfig.getInstance());
+                    HttpGet statusRequest = new HttpGet(String.format("%s/job_status?jobId=%s", remoteInstanceConfig.getUrl(), jobId));
                     response = client.execute(statusRequest);
                     jobStatus = Integer.valueOf(EntityUtils.toString(response.getEntity()));
                     if (jobStatus != 0) {
@@ -155,7 +163,8 @@ public class RemoteEngineBuilder {
                     writer.write(String.format("Job %s result cannot be defined during %d", jobId, buildResultWaitTimeout));
                     writer.close();
                 }
-                HttpGet resultRequest = new HttpGet(String.format("%s/job_result?jobId=%s", remoteBuilderUrl, jobId));
+                touchInstance(remoteInstanceConfig.getInstance());
+                HttpGet resultRequest = new HttpGet(String.format("%s/job_result?jobId=%s", remoteInstanceConfig.getUrl(), jobId));
                 response = client.execute(resultRequest);
                 LOGGER.info(String.format("Job %s result got.", jobId));
                 if (jobStatus == BuilderConstants.JobStatus.SUCCESS.ordinal()) {
@@ -240,5 +249,15 @@ public class RemoteEngineBuilder {
 
     private String getStatusReason(final HttpResponse response) {
         return response.getStatusLine().getReasonPhrase();
+    }
+
+    private void touchInstance(String instanceId) {
+        if (instanceService != null) {
+            try {
+                instanceService.touchInstance(instanceId);
+            } catch(Exception exc) {
+
+            }
+        }
     }
 }

--- a/server/src/main/java/com/defold/extender/remote/RemoteEngineBuilder.java
+++ b/server/src/main/java/com/defold/extender/remote/RemoteEngineBuilder.java
@@ -85,10 +85,10 @@ public class RemoteEngineBuilder {
 
 
         try {
-            touchInstance(remoteInstanceConfig.getInstance());
+            touchInstance(remoteInstanceConfig.getInstanceId());
             final HttpResponse response = sendRequest(remoteInstanceConfig.getUrl(), platform, sdkVersion, httpEntity);
 
-            touchInstance(remoteInstanceConfig.getInstance());
+            touchInstance(remoteInstanceConfig.getInstanceId());
             LOGGER.info("Remote builder response status: {}", response.getStatusLine());
 
             if (isClientError(response)) {
@@ -137,7 +137,7 @@ public class RemoteEngineBuilder {
     
             final HttpClient client  = HttpClientBuilder.create().build();
     
-            touchInstance(remoteInstanceConfig.getInstance());
+            touchInstance(remoteInstanceConfig.getInstanceId());
             HttpResponse response = client.execute(request);
             // copied from ExtenderClient. Think about code deduplication.
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
@@ -147,7 +147,7 @@ public class RemoteEngineBuilder {
                 Integer jobStatus = 0;
                 Thread.sleep(buildSleepTimeout);
                 while (System.currentTimeMillis() - currentTime < buildResultWaitTimeout) {
-                    touchInstance(remoteInstanceConfig.getInstance());
+                    touchInstance(remoteInstanceConfig.getInstanceId());
                     HttpGet statusRequest = new HttpGet(String.format("%s/job_status?jobId=%s", remoteInstanceConfig.getUrl(), jobId));
                     response = client.execute(statusRequest);
                     jobStatus = Integer.valueOf(EntityUtils.toString(response.getEntity()));
@@ -163,7 +163,7 @@ public class RemoteEngineBuilder {
                     writer.write(String.format("Job %s result cannot be defined during %d", jobId, buildResultWaitTimeout));
                     writer.close();
                 }
-                touchInstance(remoteInstanceConfig.getInstance());
+                touchInstance(remoteInstanceConfig.getInstanceId());
                 HttpGet resultRequest = new HttpGet(String.format("%s/job_result?jobId=%s", remoteInstanceConfig.getUrl(), jobId));
                 response = client.execute(resultRequest);
                 LOGGER.info(String.format("Job %s result got.", jobId));
@@ -256,7 +256,7 @@ public class RemoteEngineBuilder {
             try {
                 instanceService.touchInstance(instanceId);
             } catch(Exception exc) {
-
+                LOGGER.error(String.format("Exception during touch instance '%s'", instanceId), exc);
             }
         }
     }

--- a/server/src/main/java/com/defold/extender/remote/RemoteHostConfiguration.java
+++ b/server/src/main/java/com/defold/extender/remote/RemoteHostConfiguration.java
@@ -9,9 +9,9 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties(prefix = "extender.remote-builder")
 public class RemoteHostConfiguration {
-    private Map<String, String> platforms = new HashMap<>();
+    private Map<String, RemoteInstanceConfig> platforms = new HashMap<>();
 
-    public Map<String, String> getPlatforms() {
+    public Map<String, RemoteInstanceConfig> getPlatforms() {
         return platforms;
     }
 }

--- a/server/src/main/java/com/defold/extender/remote/RemoteInstanceConfig.java
+++ b/server/src/main/java/com/defold/extender/remote/RemoteInstanceConfig.java
@@ -2,26 +2,24 @@ package com.defold.extender.remote;
 
 public class RemoteInstanceConfig {
     private String url;
-    private String instance;
+    private String instanceId;
+    private boolean alwaysOn;
 
-    public RemoteInstanceConfig(String id, String url) {
-        this.instance = id;
+    public RemoteInstanceConfig(String url, String instanceId, boolean alwaysOn) {
         this.url = url;
+        this.instanceId = instanceId;
+        this.alwaysOn = alwaysOn;
     }
 
     public String getUrl() {
         return url;
     }
 
-    public String getInstance() {
-        return instance;
+    public String getInstanceId() {
+        return instanceId;
     }
 
-    public void setInstance(String instance) {
-        this.instance = instance;
-    }
-
-    public void setUrl(String url) {
-        this.url = url;
+    public boolean getAlwaysOn() {
+        return alwaysOn;
     }
 }

--- a/server/src/main/java/com/defold/extender/remote/RemoteInstanceConfig.java
+++ b/server/src/main/java/com/defold/extender/remote/RemoteInstanceConfig.java
@@ -1,0 +1,27 @@
+package com.defold.extender.remote;
+
+public class RemoteInstanceConfig {
+    private String url;
+    private String instance;
+
+    public RemoteInstanceConfig(String id, String url) {
+        this.instance = id;
+        this.url = url;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getInstance() {
+        return instance;
+    }
+
+    public void setInstance(String instance) {
+        this.instance = instance;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/server/src/main/java/com/defold/extender/services/GCPInstanceService.java
+++ b/server/src/main/java/com/defold/extender/services/GCPInstanceService.java
@@ -141,10 +141,9 @@ public class GCPInstanceService {
 
 
     // inner endpoint used to make necessary changes before starting instance update
-    @ConditionalOnProperty(prefix = "extender", name = "gcp.controller.enabled", havingValue = "true")
-    @PostMapping("/maintance_mode")
-    public void postMethodName() {
-        LOGGER.info("Set maintance mode");
+    @PostMapping("/maintenance_mode")
+    public void maintenanceMode() {
+        LOGGER.info("Set maintenance mode");
         for (Map.Entry<String, GCPInstanceState> entry : instanceState.entrySet()) {
             try {
                 touchInstance(entry.getKey());

--- a/server/src/main/java/com/defold/extender/services/GCPInstanceService.java
+++ b/server/src/main/java/com/defold/extender/services/GCPInstanceService.java
@@ -1,0 +1,116 @@
+package com.defold.extender.services;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.google.cloud.compute.v1.InstancesClient;
+import com.google.cloud.compute.v1.Operation;
+import com.defold.extender.remote.RemoteHostConfiguration;
+import com.defold.extender.services.data.GCPInstanceState;
+import com.google.cloud.compute.v1.Instance.Status;
+
+@Service
+@ConditionalOnProperty(prefix = "extender", name = "gcp.controller.enabled", havingValue = "true")
+public class GCPInstanceService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GCPInstanceService.class);
+
+    private InstancesClient instancesClient = null;
+    @Value("${extender.gcp.controller.project_id}") private String projectId;
+    @Value("${extender.gcp.controller.zone}") private String computeZone;
+    @Value("${extender.gcp.controller.wait-timeout:30000}") private long operationWaitTimeout;
+    @Value("${extender.gcp.controller.retry-attempts:3}") private int retryAttempts;
+    @Value("${extender.gcp.controller.retry-timeout:10000}") private long retryTimeout;
+    @Value("${extender.gcp.controller.time-before-suspend:1800000}") private long timeBeforeSuspend;
+    @Value("${extender.gcp.controller.wait-startup-time:10000}") private long waitStartupTime;
+
+    private Map<String, GCPInstanceState> instanceState = new HashMap<>();
+
+    public GCPInstanceService(RemoteHostConfiguration remoteHostConfiguration) throws IOException{
+        instancesClient = InstancesClient.create();
+    }
+
+    private void suspendInstance(final String instanceId) throws InterruptedException, ExecutionException, TimeoutException {
+        int attemptCount = 0;
+        while (true) {
+            Operation response = instancesClient.suspendAsync(projectId, computeZone, instanceId).get(operationWaitTimeout, TimeUnit.MILLISECONDS);
+            if (response.hasError() || !getInstanceStatus(instanceId).equalsIgnoreCase(Status.SUSPENDED.toString())) {
+                attemptCount++;
+                if (attemptCount >= retryAttempts) {
+                    throw new TimeoutException("Run out of attempt count. VM not suspended.");
+                }
+                LOGGER.warn(String.format("VM '%s' not suspended. Attempt %d from %d", instanceId, attemptCount, retryAttempts));
+                Thread.sleep(retryTimeout);
+            } else {
+                LOGGER.info(String.format("VM '%s' was suspended", instanceId));
+                break;
+            }
+        }
+    }
+
+    public void resumeInstance(String instanceId) throws InterruptedException, ExecutionException, TimeoutException {
+        int attemptCount = 0;
+        while (true) {
+            Operation response = instancesClient.resumeAsync(projectId, computeZone, instanceId).get(operationWaitTimeout, TimeUnit.MILLISECONDS);
+            if (response.hasError() || !getInstanceStatus(instanceId).equalsIgnoreCase(Status.RUNNING.toString())) {
+                attemptCount++;
+                if (attemptCount >= retryAttempts) {
+                    throw new TimeoutException("Run out of attempt count. VM not resumed.");
+                }
+                LOGGER.warn(String.format("VM '%s' not resumed. Attempt %d from %d", instanceId, attemptCount, retryAttempts));
+                Thread.sleep(retryTimeout);
+            } else {
+                LOGGER.info(String.format("VM '%s' was resumed. Wait %ds before return.", instanceId, waitStartupTime / 1000));
+                Thread.sleep(waitStartupTime);
+                instanceState.get(instanceId).lastTimeTouched = System.currentTimeMillis();
+                break;
+            }
+        }
+    }
+
+    public String getInstanceStatus(final String instanceId) {
+        return instancesClient.get(projectId, computeZone, instanceId).getStatus();
+    }
+
+    public void touchInstance(String instanceId) throws InterruptedException, ExecutionException, TimeoutException {
+        // update last touched time to prevent suspending
+        instanceState.get(instanceId).lastTimeTouched = System.currentTimeMillis();
+        String instanceStatus = getInstanceStatus(instanceId);
+        LOGGER.info(String.format("Current instance '%s' status '%s'", instanceId, instanceStatus));
+        //! TODO: think how to handle other instance states. Especially SUSPENDING state (when suspend request send but not handled)
+        if (instanceStatus.equalsIgnoreCase(Status.SUSPENDED.toString())) {
+            resumeInstance(instanceId);
+        }
+        //  Status.SUSPENDING
+    }
+
+    @Scheduled(initialDelayString="${extender.gcp.controller.check-period:60000}", fixedDelayString="${extender.gcp.controller.check-period:60000}")
+    public void checkInstancesState() {
+        for (Map.Entry<String, GCPInstanceState> entry : instanceState.entrySet()) {
+            if (getInstanceStatus(entry.getKey()).equalsIgnoreCase(Status.RUNNING.toString()) 
+                && entry.getValue().lastTimeTouched + timeBeforeSuspend <= System.currentTimeMillis()) {
+                    try {
+                        suspendInstance(entry.getKey());
+                    } catch(TimeoutException exc) {
+                        LOGGER.error(String.format("Suspend '%s' timeouted.", entry.getKey()), exc);
+                    } catch(InterruptedException exc) {
+                        LOGGER.error(String.format("Suspend '%s' interrupted.", entry.getKey()), exc);
+                    } catch(ExecutionException exc) {
+                        LOGGER.error(String.format("Suspend '%s' failed.", entry.getKey()), exc);
+                    }
+
+            }
+        }
+    }
+}

--- a/server/src/main/java/com/defold/extender/services/GCPInstanceService.java
+++ b/server/src/main/java/com/defold/extender/services/GCPInstanceService.java
@@ -48,6 +48,7 @@ public class GCPInstanceService {
     }
 
     private void suspendInstance(final String instanceId) throws InterruptedException, ExecutionException, TimeoutException {
+        LOGGER.info(String.format("Try suspend VM '%s'", instanceId));
         int attemptCount = 0;
         while (true) {
             Operation response = instancesClient.suspendAsync(projectId, computeZone, instanceId).get(operationWaitTimeout, TimeUnit.MILLISECONDS);
@@ -65,7 +66,8 @@ public class GCPInstanceService {
         }
     }
 
-    public void resumeInstance(String instanceId) throws InterruptedException, ExecutionException, TimeoutException {
+    private void resumeInstance(String instanceId) throws InterruptedException, ExecutionException, TimeoutException {
+        LOGGER.info(String.format("Try resume VM '%s'", instanceId));
         int attemptCount = 0;
         while (true) {
             Operation response = instancesClient.resumeAsync(projectId, computeZone, instanceId).get(operationWaitTimeout, TimeUnit.MILLISECONDS);
@@ -119,7 +121,6 @@ public class GCPInstanceService {
                     } catch(ExecutionException exc) {
                         LOGGER.error(String.format("Suspend '%s' failed.", entry.getKey()), exc);
                     }
-
             }
         }
     }

--- a/server/src/main/java/com/defold/extender/services/HealthReporterService.java
+++ b/server/src/main/java/com/defold/extender/services/HealthReporterService.java
@@ -15,6 +15,8 @@ import org.json.simple.parser.JSONParser;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import com.defold.extender.remote.RemoteInstanceConfig;
+
 @Service
 public class HealthReporterService {
 
@@ -29,7 +31,7 @@ public class HealthReporterService {
     }
 
     @SuppressWarnings("unchecked")
-    public String collectHealthReport(boolean isRemoteBuildEnabled, Map<String, String> remoteBuilderPlatformMappings) {
+    public String collectHealthReport(boolean isRemoteBuildEnabled, Map<String, RemoteInstanceConfig> remoteBuilderPlatformMappings) {
         if (isRemoteBuildEnabled) {
             // we collect information by platform. If one of the builder is unreachable - set
             Map<String, OperationalStatus> platformOperationalStatus = new HashMap<>();
@@ -40,8 +42,8 @@ public class HealthReporterService {
                 .setConnectionRequestTimeout(connectionTimeout)
                 .setSocketTimeout(connectionTimeout).build();
             final HttpClient client  = HttpClientBuilder.create().setDefaultRequestConfig(config).build();
-            for (Map.Entry<String, String> entry : remoteBuilderPlatformMappings.entrySet()) {
-                final String healthUrl = String.format("%s/health_report", entry.getValue());
+            for (Map.Entry<String, RemoteInstanceConfig> entry : remoteBuilderPlatformMappings.entrySet()) {
+                final String healthUrl = String.format("%s/health_report", entry.getValue().getUrl());
                 final HttpGet request = new HttpGet(healthUrl);
                 String platform = getPlatform(entry.getKey());
                 try {

--- a/server/src/main/java/com/defold/extender/services/data/GCPInstanceState.java
+++ b/server/src/main/java/com/defold/extender/services/data/GCPInstanceState.java
@@ -1,5 +1,5 @@
 package com.defold.extender.services.data;
 
 public class GCPInstanceState {
-    public volatile long lastTimeTouched = 0;
+    public volatile long lastTimeTouched = System.currentTimeMillis();
 }

--- a/server/src/main/java/com/defold/extender/services/data/GCPInstanceState.java
+++ b/server/src/main/java/com/defold/extender/services/data/GCPInstanceState.java
@@ -1,0 +1,5 @@
+package com.defold.extender.services.data;
+
+public class GCPInstanceState {
+    public volatile long lastTimeTouched = 0;
+}

--- a/server/src/test/java/com/defold/extender/remote/RemoteEngineBuilderTest.java
+++ b/server/src/test/java/com/defold/extender/remote/RemoteEngineBuilderTest.java
@@ -1,6 +1,8 @@
 package com.defold.extender.remote;
 
 import com.defold.extender.ExtenderException;
+import com.defold.extender.services.GCPInstanceService;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.StatusLine;
 import org.apache.http.entity.ByteArrayEntity;
@@ -11,6 +13,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Optional;
 import java.io.ByteArrayOutputStream;
 
 import static org.junit.Assert.*;
@@ -23,13 +26,13 @@ import static org.mockito.Mockito.spy;
 public class RemoteEngineBuilderTest {
 
     private RemoteEngineBuilder remoteEngineBuilder;
-    final String remoteBuilderBaseUrl = "https://test.darwin-build.defold.com";
+    final RemoteInstanceConfig remoteBuilderConfig = new RemoteInstanceConfig("osx-latest", "https://test.darwin-build.defold.com");
 
     @Before
     public void setUp() throws IOException {
         final HttpEntity httpEntity = mock(HttpEntity.class);
 
-        remoteEngineBuilder = spy(new RemoteEngineBuilder("/var/tmp/results", 5000, 240000));
+        remoteEngineBuilder = spy(new RemoteEngineBuilder(Optional.empty(), "/var/tmp/results", 5000, 240000));
         doReturn(httpEntity).when(remoteEngineBuilder).buildHttpEntity(any(File.class));
     }
 
@@ -52,7 +55,7 @@ public class RemoteEngineBuilderTest {
                 .sendRequest(anyString(), anyString(), anyString(), any(HttpEntity.class));
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        remoteEngineBuilder.build(remoteBuilderBaseUrl, directory, "armv7-ios", "a6876bc5s", baos);
+        remoteEngineBuilder.build(remoteBuilderConfig, directory, "armv7-ios", "a6876bc5s", baos);
 
         byte[] bytes = baos.toByteArray();
         assertEquals(content, new String(bytes));
@@ -77,6 +80,6 @@ public class RemoteEngineBuilderTest {
                 .sendRequest(anyString(), anyString(), anyString(), any(HttpEntity.class));
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        remoteEngineBuilder.build(remoteBuilderBaseUrl, directory, "armv7-ios", "a6876bc5s", baos);
+        remoteEngineBuilder.build(remoteBuilderConfig, directory, "armv7-ios", "a6876bc5s", baos);
     }
 }

--- a/server/src/test/java/com/defold/extender/remote/RemoteEngineBuilderTest.java
+++ b/server/src/test/java/com/defold/extender/remote/RemoteEngineBuilderTest.java
@@ -1,7 +1,6 @@
 package com.defold.extender.remote;
 
 import com.defold.extender.ExtenderException;
-import com.defold.extender.services.GCPInstanceService;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.StatusLine;
@@ -26,7 +25,7 @@ import static org.mockito.Mockito.spy;
 public class RemoteEngineBuilderTest {
 
     private RemoteEngineBuilder remoteEngineBuilder;
-    final RemoteInstanceConfig remoteBuilderConfig = new RemoteInstanceConfig("osx-latest", "https://test.darwin-build.defold.com");
+    final RemoteInstanceConfig remoteBuilderConfig = new RemoteInstanceConfig("https://test.darwin-build.defold.com", "osx-latest", true);
 
     @Before
     public void setUp() throws IOException {


### PR DESCRIPTION
* Added new service that implements VM state management.
* Add new endpoint to set maintenance mode (update last used timestamp to prevent VMs from suspending/resuming VMs if it was suspended)

General implementation:
* At startup service look over extender.service.remote-builder.platforms and form maps with instance name and update last "touched" timestamp
* According to last "touched" timestamp and configured `extender.gcp.controller.time-before-suspend` service checks every `extender.gcp.controller.check-period` do VM need to be suspended.
* Before every request to remote builder we invoke `GCPInstanceService.touchInstance` to update last "touched" timestamp

Example of configuration:
```yml
extender:
    gcp:
        controller:
            enabled: true
            project_id: ${project_id}
            zone: ${vm_zone}
            wait-timeout: 60000
            retry-attempts: 3
            retry-timeout: 10000
            time-before-suspend: 1800000
            wait-startup-time: 10000
            check-period: 60000
            gax-max-thread-count: 10
```