### PR TITLE
Revert "Add standalone jetifier. Run jetifier when resolve gradle dependencies."

### DIFF
--- a/server/docker/Dockerfile.android-env
+++ b/server/docker/Dockerfile.android-env
@@ -8,7 +8,7 @@ FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extend
 ENV GRADLE_USER_HOME=/tmp/.gradle
 ENV GRADLE_VERSION=8.4
 ENV GRADLE_PLUGIN_VERSION=8.3.2
-ENV PATH=${PATH}:/opt/gradle/gradle-${GRADLE_VERSION}/bin:/opt/jetifier-standalone/bin
+ENV PATH=${PATH}:/opt/gradle/gradle-${GRADLE_VERSION}/bin
 RUN \
   echo "Gradle" && \
   wget -q https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip && \
@@ -17,12 +17,3 @@ RUN \
   rm gradle-${GRADLE_VERSION}-bin.zip && \
   which gradle && \
   chown -R extender: /opt/gradle
-
-# https://developer.android.com/tools/jetifier
-ENV JETIFIER_VERSION=1.0.0-beta10
-
-RUN \
-  wget -q https://dl.google.com/dl/android/studio/jetifier-zips/${JETIFIER_VERSION}/jetifier-standalone.zip && \
-  unzip -q -d /opt/ jetifier-standalone.zip && \
-  rm jetifier-standalone.zip && \
-  chown -R extender: /opt/jetifier-standalone

--- a/server/docker/Dockerfile.android.ndk25-env
+++ b/server/docker/Dockerfile.android.ndk25-env
@@ -1,4 +1,4 @@
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-android-env:1.3.0
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-android-env:1.3.1
 
 #
 # Android SDK/NDK

--- a/server/src/main/java/com/defold/extender/services/RealGradleService.java
+++ b/server/src/main/java/com/defold/extender/services/RealGradleService.java
@@ -103,7 +103,7 @@ public class RealGradleService implements GradleServiceInterface {
         File localPropertiesFile = new File(cwd, "local.properties");
         createLocalPropertiesFile(localPropertiesFile, jobEnvContext);
 
-        return downloadDependencies(cwd, useJetifier);
+        return downloadDependencies(cwd);
     }
 
     @Override
@@ -206,27 +206,20 @@ public class RealGradleService implements GradleServiceInterface {
         return dependencies;
     }
 
-    private File resolveDependencyAAR(File dependency, String name, File jobDir, Boolean useJetifier) throws IOException, ExtenderException {
+    private File resolveDependencyAAR(File dependency, String name, File jobDir) throws IOException {
         File unpackedTarget = new File(baseDirectory, name);
         if (unpackedTarget.exists()) {
             return unpackedTarget;
         }
 
         // use job folder as tmp location
-        File unpackSource = null;
-        if (useJetifier){
-            unpackSource = new File(jobDir, dependency.getName() + ".jetifier.tmp");
-            runJetifier(dependency, unpackSource);
-        } else {
-            unpackSource = dependency;
-        }
         File unpackedTmp = new File(jobDir, dependency.getName() + ".tmp");
-        ZipUtils.unzip(new FileInputStream(unpackSource), unpackedTmp.toPath());
+        ZipUtils.unzip(new FileInputStream(dependency), unpackedTmp.toPath());
         Move(unpackedTmp.toPath(), unpackedTarget.toPath());
         return unpackedTarget;
     }
 
-    private File resolveDependencyJAR(File dependency, String name, File jobDir, Boolean useJetifier) throws IOException, ExtenderException {
+    private File resolveDependencyJAR(File dependency, String name, File jobDir) throws IOException {
         File targetFile = new File(baseDirectory, name);
         if (targetFile.exists()) {
             return targetFile;
@@ -234,16 +227,12 @@ public class RealGradleService implements GradleServiceInterface {
 
         // use job folder as tmp location
         File tmpFile = new File(jobDir, dependency.getName() + ".tmp");
-        if (useJetifier) {
-            runJetifier(dependency, tmpFile);
-        } else {
-            FileUtils.copyFile(dependency, tmpFile);
-        }
+        FileUtils.copyFile(dependency, tmpFile);
         Move(tmpFile.toPath(), targetFile.toPath());
         return targetFile;
     }
 
-    private List<File> unpackDependencies(Map<String, String> dependencies, File jobDir, Boolean useJetifier) throws IOException, ExtenderException {
+    private List<File> unpackDependencies(Map<String, String> dependencies, File jobDir) throws IOException {
         List<File> resolvedDependencies = new ArrayList<>();
         Timer timer = new Timer();
         timer.start();
@@ -255,19 +244,19 @@ public class RealGradleService implements GradleServiceInterface {
                 throw new IOException("File does not exist: %s" + dependency);
             }
             if (dependency.endsWith(".aar")) {
-                resolvedDependencies.add(resolveDependencyAAR(file, newName, jobDir, useJetifier));
+                resolvedDependencies.add(resolveDependencyAAR(file, newName, jobDir));
             } else if (dependency.endsWith(".jar")) {
-                resolvedDependencies.add(resolveDependencyJAR(file, newName, jobDir, useJetifier));
+                resolvedDependencies.add(resolveDependencyJAR(file, newName, jobDir));
             } else {
                 resolvedDependencies.add(file);
             }
         }
         long duration = timer.start();
-        MetricsWriter.metricsTimer(meterRegistry, "extender.service.gradle.unpack", duration, "jetifier", useJetifier.toString());
+        MetricsWriter.metricsTimer(meterRegistry, "extender.service.gradle.unpack", duration, "jetifier");
         return resolvedDependencies;
     }
 
-    private List<File> downloadDependencies(File cwd, Boolean useJetifier) throws IOException, ExtenderException {
+    private List<File> downloadDependencies(File cwd) throws IOException, ExtenderException {
         long methodStart = System.currentTimeMillis();
         LOGGER.info("Resolving dependencies");
 
@@ -278,16 +267,10 @@ public class RealGradleService implements GradleServiceInterface {
 
         Map<String, String> dependencies = parseDependencies(log);
 
-        List<File> unpackedDependencies = unpackDependencies(dependencies, cwd, useJetifier);
+        List<File> unpackedDependencies = unpackDependencies(dependencies, cwd);
 
         MetricsWriter.metricsTimer(meterRegistry, "extender.service.gradle.get", System.currentTimeMillis() - methodStart);
         return unpackedDependencies;
     }
 
-    private void runJetifier(File source, File target) throws ExtenderException {
-        String log = execCommand(String.format("jetifier-standalone -i %s -o %s", source.getAbsolutePath(), target.getAbsolutePath()), null);
-
-        // Put it in the log for the end user to see
-        LOGGER.info("\n" + log);
-    }
 }


### PR DESCRIPTION
This reverts commit f4a4741f02b1b9498a1b4c3563f011361d93eba0.

Revert changes because no need to run jetifier additionally. Gradle plugin make everything in right way.
In case with Helpshift - Gradle doesn't detect helpshift library as artifact that need to be jetifier (`gradle checkJetifier` return no complains about Helpshift). Helpshift already has version (10.3.x) that doesn't have dependencies on `appcompat`
More details https://github.com/defold/extender/issues/301#issuecomment-2284879325