### PR TITLE
Explicitly set parameter name.

### DIFF
--- a/server/src/main/java/com/defold/extender/ExtenderController.java
+++ b/server/src/main/java/com/defold/extender/ExtenderController.java
@@ -415,7 +415,7 @@ public class ExtenderController {
 
     @GetMapping("/job_status")
     @ResponseBody
-    public Integer getBuildStatus(@RequestParam String jobId) throws IOException {
+    public Integer getBuildStatus(@RequestParam(name = "jobId") String jobId) throws IOException {
         File jobResultDir = new File(jobResultLocation.getAbsolutePath() + "/" + jobId);
         if (jobResultDir.exists()) {
             File jobResult = new File(jobResultDir, BuilderConstants.BUILD_RESULT_FILENAME);
@@ -430,7 +430,7 @@ public class ExtenderController {
     }
 
     @GetMapping("/job_result")
-    public @ResponseBody byte[] getBuildResult(@RequestParam String jobId) throws IOException {
+    public @ResponseBody byte[] getBuildResult(@RequestParam(name = "jobId") String jobId) throws IOException {
         File jobResultDir = new File(jobResultLocation.getAbsolutePath() + "/" + jobId);
         if (jobResultDir.exists()) {
             File jobResult = new File(jobResultDir, BuilderConstants.BUILD_RESULT_FILENAME);


### PR DESCRIPTION
During debugging from VSCode I caught exception when request to `/job_status` and `/job_result` leads to Internal server error. It happened because Spring boot changed logic now doesn't parse argument name from bytecode. 
I don't know exactly why t works when Extender runs from command-line...