### PR TITLE
Remove file-to-file bind

### DIFF
--- a/server/docker/common-services.yml
+++ b/server/docker/common-services.yml
@@ -12,6 +12,7 @@ services:
     platform: linux/amd64
     volumes:
       - ./../app/:/app/:ro
+      - ./../app/:/etc/extender/apps/:ro
       - ./../configs:/etc/defold/extender:ro
       - ./../../dynamo_home:/dynamo_home:ro
     entrypoint: ["java","-Xmx4g","-XX:MaxDirectMemorySize=2g","-jar","/app/extender.jar"]

--- a/server/docker/common-services.yml
+++ b/server/docker/common-services.yml
@@ -12,7 +12,6 @@ services:
     platform: linux/amd64
     volumes:
       - ./../app/:/app/:ro
-      - ./../manifestmergetool/app/manifestmergetool.jar:/etc/extender/apps/manifestmergetool.jar:ro
       - ./../configs:/etc/defold/extender:ro
       - ./../../dynamo_home:/dynamo_home:ro
     entrypoint: ["java","-Xmx4g","-XX:MaxDirectMemorySize=2g","-jar","/app/extender.jar"]

--- a/server/manifestmergetool/build.gradle
+++ b/server/manifestmergetool/build.gradle
@@ -44,7 +44,7 @@ task mainJar(type: Jar) {
         doLast {
         copy {
             from "${project.projectDir}/build/libs/manifestmergetool-${project.ext.manifestMergetoolVersion}.jar"
-            into "app"
+            into "${project.projectDir}/../app"
             rename { String fileName ->
                 fileName.replace("-$project.ext.manifestMergetoolVersion", "")
             }


### PR DESCRIPTION
Remove file-to-file bind.
Copy manifestmergetool directrly to ./server/app.

Seems on Windows something works in different way when use file bind.

Fixes #473 