### PR TITLE
Add maxFormPart configuration option for Jetty.

### DIFF
--- a/server/docker/common-services.yml
+++ b/server/docker/common-services.yml
@@ -15,7 +15,7 @@ services:
       - ./../app/:/etc/extender/apps/:ro
       - ./../configs:/etc/defold/extender:ro
       - ${DYNAMO_HOME:-./../app/dummy}:/dynamo_home
-    entrypoint: ["java","-Xmx4g","-XX:MaxDirectMemorySize=2g","-jar","/app/extender.jar"]
+    entrypoint: ["java","-Xmx4g","-XX:MaxDirectMemorySize=2g","-Dorg.eclipse.jetty.server.Request.maxFormKeys=1500","-jar","/app/extender.jar"]
     environment:
       - ${DYNAMO_HOME:+DYNAMO_HOME=/dynamo_home}
       - DM_DEBUG_COMMANDS

--- a/server/scripts/standalone/service-standalone.sh
+++ b/server/scripts/standalone/service-standalone.sh
@@ -43,8 +43,8 @@ start_service() {
         fi
     fi
 
-    echo "Running: java -Xmx4g -XX:MaxDirectMemorySize=2g -jar ${PATH_TO_JAR} --extender.sdk.location=${EXTENDER_SDK_LOCATION} --spring.config.location=classpath:./,file:${SPRING_PROFILES_LOCATION}/ --spring.profiles.active=${PROFILE} >> ${STDOUT_LOG} 2>> ${ERROR_LOG} < /dev/null &"
-    java -Xmx4g -XX:MaxDirectMemorySize=2g -jar ${PATH_TO_JAR} --extender.sdk.location="${EXTENDER_SDK_LOCATION}" --spring.config.location=classpath:./,file:${SPRING_PROFILES_LOCATION}/ --spring.profiles.active=${PROFILE} >> ${STDOUT_LOG} 2>> ${ERROR_LOG} < /dev/null &
+    echo "Running: java -Xmx4g -XX:MaxDirectMemorySize=2g -Dorg.eclipse.jetty.server.Request.maxFormKeys=1500 -jar ${PATH_TO_JAR} --extender.sdk.location=${EXTENDER_SDK_LOCATION} --spring.config.location=classpath:./,file:${SPRING_PROFILES_LOCATION}/ --spring.profiles.active=${PROFILE} >> ${STDOUT_LOG} 2>> ${ERROR_LOG} < /dev/null &"
+    java -Xmx4g -XX:MaxDirectMemorySize=2g -Dorg.eclipse.jetty.server.Request.maxFormKeys=1500 -jar ${PATH_TO_JAR} --extender.sdk.location="${EXTENDER_SDK_LOCATION}" --spring.config.location=classpath:./,file:${SPRING_PROFILES_LOCATION}/ --spring.profiles.active=${PROFILE} >> ${STDOUT_LOG} 2>> ${ERROR_LOG} < /dev/null &
 
     
     echo $! > ${PID_PATH_NAME}


### PR DESCRIPTION
If tried to build project with lots of source file (native part) you can get `400 Bad request` on `/build_async` request. It happened because Jetty has option `maxFormPart` that didn't respect in previous versions. With additional logging on Jetty side (options `-Dlogging.level.org.eclipse.jetty=DEBUG -Dlogging.level.org.eclipse.jetty.websocket=DEBUG`) following error become visible
```
2024-10-03 17:45:34 Caused by: org.eclipse.jetty.http.BadMessageException: 400: bad multipart
2024-10-03 17:45:34     ... 118 common frames omitted
2024-10-03 17:45:34 Caused by: java.lang.IllegalStateException: Form with too many keys [1001 > 1000]
2024-10-03 17:45:34     at org.eclipse.jetty.http.MultiPart$Parser.parse(MultiPart.java:1052)
2024-10-03 17:45:34     at org.eclipse.jetty.http.MultiPartFormData$Parser$1.parse(MultiPartFormData.java:311)
2024-10-03 17:45:34     at org.eclipse.jetty.http.MultiPartFormData$Parser$1.parse(MultiPartFormData.java:301)
2024-10-03 17:45:34     at org.eclipse.jetty.io.content.ContentSourceCompletableFuture.parse(ContentSourceCompletableFuture.java:104)
2024-10-03 17:45:34     at org.eclipse.jetty.http.MultiPartFormData$Parser.parse(MultiPartFormData.java:326)
2024-10-03 17:45:34     at org.eclipse.jetty.http.MultiPartFormData.from(MultiPartFormData.java:109)
2024-10-03 17:45:34     at org.eclipse.jetty.ee10.servlet.ServletMultiPartFormData.from(ServletMultiPartFormData.java:138)
2024-10-03 17:45:34     at org.eclipse.jetty.ee10.servlet.ServletMultiPartFormData.from(ServletMultiPartFormData.java:62)
2024-10-03 17:45:34     at org.eclipse.jetty.ee10.servlet.ServletApiRequest.getParts(ServletApiRequest.java:637)
2024-10-03 17:45:34     ... 117 common frames omitted
```