### PR TITLE
Improve logging

### DIFF
--- a/client/src/main/java/com/defold/extender/client/ExtenderClient.java
+++ b/client/src/main/java/com/defold/extender/client/ExtenderClient.java
@@ -42,6 +42,8 @@ import java.util.logging.Logger;
 public class ExtenderClient {
     private static Logger logger = Logger.getLogger(ExtenderClient.class.getName());
 
+    private static final String TRACE_ID_HEADER_NAME = "X-TraceId";
+
     private final String extenderBaseUrl;
     private ExtenderClientCache cache;
     private CookieStore httpCookies;
@@ -237,7 +239,8 @@ public class ExtenderClient {
             final int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode == HttpStatus.SC_OK) {
                 String jobId = EntityUtils.toString(response.getEntity());
-                log("Async build request was accepted as job %s", jobId);
+                String traceId = response.getFirstHeader(TRACE_ID_HEADER_NAME).getValue();
+                log("Async build request was accepted as job %s (traceId: %s)", jobId, traceId == null ? "null" : traceId);
                 long currentTime = System.currentTimeMillis();
                 Integer jobStatus = 0;
                 Thread.sleep(buildSleepTimeout);

--- a/server/README.md
+++ b/server/README.md
@@ -89,6 +89,21 @@ docker compose -p extender down
 ```
 if docker compose was run in detached mode (e.g. '-d' flag was passed to `docker compose up` command).
 
+In case of usage `metrics` profile you also need to add `influx` profile to service command (see `./server/docker/common-service.yml` and `./server/docker/docker-compose.yml`). For example, for common remote builder definition should looks like (`./server/docker/common-service.yml`):
+```yml
+  remote_builder:
+    extends: common_builder
+    command: ["--spring.config.location=classpath:./,file:/etc/defold/extender/", "--spring.profiles.active=local-dev,metrics,influx${STRUCTURED_LOGGING+,logging}"]
+
+```
+
+## Structured logging
+If you want to see logs in structured form you need to execute docker compose with `STRUCTURED_LOGGING=1` environment variable. For example
+```sh
+STRUCTURED_LOGGING=1 docker compose -f ./server/docker/docker-compose.yml --profile web up
+```
+For more information about structured logs: [link](https://newrelic.com/blog/how-to-relic/structured-logging)
+
 ## How to run tests
 Test can be run from the root directory with
 ```sh

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-starter-security')
     implementation('org.springframework.security:spring-security-test')
     implementation('io.micrometer:micrometer-core:1.13.1')
-    runtimeOnly('net.logstash.logback:logstash-logback-encoder:7.0.1')
+    runtimeOnly('net.logstash.logback:logstash-logback-encoder:8.0')
     runtimeOnly('io.micrometer:micrometer-registry-influx:1.13.2')
 
     testImplementation('junit:junit:4.13.2')

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -70,6 +70,8 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-starter-security')
     implementation('org.springframework.security:spring-security-test')
     implementation('io.micrometer:micrometer-core:1.13.1')
+    implementation('io.micrometer:micrometer-tracing:1.3.4')
+    implementation('io.micrometer:micrometer-tracing-bridge-otel:1.3.4')
     runtimeOnly('net.logstash.logback:logstash-logback-encoder:8.0')
     runtimeOnly('io.micrometer:micrometer-registry-influx:1.13.2')
 

--- a/server/configs/application-local-dev-app.yml
+++ b/server/configs/application-local-dev-app.yml
@@ -39,3 +39,5 @@ extender:
             winsdk-2022:
                 url: http://winsdk-2022:9000
                 instanceId: winsdk-2022
+
+logging.pattern.level: "%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]"

--- a/server/configs/application-local-dev.yml
+++ b/server/configs/application-local-dev.yml
@@ -8,3 +8,5 @@ extender:
     job-result:
         location: /var/extender/results
         cleanup-period: 20000
+
+logging.pattern.level: "%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]"

--- a/server/configs/application-logging.yml
+++ b/server/configs/application-logging.yml
@@ -1,0 +1,2 @@
+spring.main.banner-mode: "off"
+logging.config: etc/defold/extender/extender-logging.xml

--- a/server/configs/application-logging.yml
+++ b/server/configs/application-logging.yml
@@ -1,2 +1,4 @@
 spring.main.banner-mode: "off"
-logging.config: etc/defold/extender/extender-logging.xml
+logging.config: /etc/defold/extender/extender-logging.xml
+logging.pattern.level: "%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]"
+management.tracing.sampling.probability: 1.0

--- a/server/configs/application-metrics.yml
+++ b/server/configs/application-metrics.yml
@@ -1,0 +1,1 @@
+management.metrics.tags.instance: ${INSTANCE_ID}

--- a/server/configs/extender-logging.xml
+++ b/server/configs/extender-logging.xml
@@ -1,0 +1,8 @@
+<configuration>
+<appender name="structuredAppender" class="ch.qos.logback.core.ConsoleAppender">
+  <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+</appender>
+<root level="INFO">
+  <appender-ref ref="structuredAppender"/>
+</root>
+</configuration>

--- a/server/docker/common-services.yml
+++ b/server/docker/common-services.yml
@@ -25,7 +25,7 @@ services:
       - DM_DEBUG_JOB_UPLOAD
   remote_builder:
     extends: common_builder
-    command: ["--spring.config.location=classpath:./,file:/etc/defold/extender/", "--spring.profiles.active=local-dev"]
+    command: ["--spring.config.location=classpath:./,file:/etc/defold/extender/", "--spring.profiles.active=local-dev,metrics${STRUCTURED_LOGGING+,logging}"]
   test_remote_builder:
     extends: test_builder
     command: ["--spring.config.location=classpath:./,file:/etc/defold/extender/", "--spring.profiles.active=local-dev"]

--- a/server/docker/common-services.yml
+++ b/server/docker/common-services.yml
@@ -25,7 +25,7 @@ services:
       - DM_DEBUG_JOB_UPLOAD
   remote_builder:
     extends: common_builder
-    command: ["--spring.config.location=classpath:./,file:/etc/defold/extender/", "--spring.profiles.active=local-dev,metrics${STRUCTURED_LOGGING+,logging}"]
+    command: ["--spring.config.location=classpath:./,file:/etc/defold/extender/", "--spring.profiles.active=local-dev${STRUCTURED_LOGGING+,logging}"]
   test_remote_builder:
     extends: test_builder
     command: ["--spring.config.location=classpath:./,file:/etc/defold/extender/", "--spring.profiles.active=local-dev"]

--- a/server/docker/docker-compose.yml
+++ b/server/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     extends:
       file: common-services.yml
       service: common_builder
-    command: ["--spring.config.location=classpath:./,file:/etc/defold/extender/", "--spring.profiles.active=local-dev-app,metrics${STRUCTURED_LOGGING+,logging}"]
+    command: ["--spring.config.location=classpath:./,file:/etc/defold/extender/", "--spring.profiles.active=local-dev-app${STRUCTURED_LOGGING+,logging}"]
     environment:
       - INSTANCE_ID=frontend-local
     expose:
@@ -45,7 +45,7 @@ services:
     extends:
       file: common-services.yml
       service: common_builder
-    command: ["--spring.config.location=classpath:./,file:/etc/defold/extender/", "--spring.profiles.active=local-dev-android,metrics${STRUCTURED_LOGGING+,logging}"]
+    command: ["--spring.config.location=classpath:./,file:/etc/defold/extender/", "--spring.profiles.active=local-dev-android${STRUCTURED_LOGGING+,logging}"]
     environment:
       - INSTANCE_ID=emsdk-2011-local
     profiles:

--- a/server/docker/docker-compose.yml
+++ b/server/docker/docker-compose.yml
@@ -6,7 +6,9 @@ services:
     extends:
       file: common-services.yml
       service: common_builder
-    command: ["--spring.config.location=classpath:./,file:/etc/defold/extender/", "--spring.profiles.active=local-dev-app", "--management.metrics.tags.instance=frontend-local"]
+    command: ["--spring.config.location=classpath:./,file:/etc/defold/extender/", "--spring.profiles.active=local-dev-app,metrics${STRUCTURED_LOGGING+,logging}"]
+    environment:
+      - INSTANCE_ID=frontend-local
     expose:
       - "9000"
     ports:
@@ -29,7 +31,8 @@ services:
     extends:
       file: common-services.yml
       service: remote_builder
-    command: ["--management.metrics.tags.instance=linux-local"]
+    environment:
+      - INSTANCE_ID=linux-local
     profiles:
       - all
       - linux
@@ -42,7 +45,9 @@ services:
     extends:
       file: common-services.yml
       service: common_builder
-    command: ["--spring.config.location=classpath:./,file:/etc/defold/extender/", "--spring.profiles.active=local-dev-android", "--management.metrics.tags.instance=android_ndk25-local"]
+    command: ["--spring.config.location=classpath:./,file:/etc/defold/extender/", "--spring.profiles.active=local-dev-android,metrics${STRUCTURED_LOGGING+,logging}"]
+    environment:
+      - INSTANCE_ID=emsdk-2011-local
     profiles:
       - all
       - android
@@ -52,10 +57,11 @@ services:
           - android-ndk25
   emscripten_2011-dev:
     image: europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-emsdk-2011-env:latest
+    environment:
+      - INSTANCE_ID=emsdk-2011-local
     extends:
       file: common-services.yml
       service: remote_builder
-    command: ["--management.metrics.tags.instance=emsdk-2011-local"]
     profiles:
       - all
       - web
@@ -68,7 +74,8 @@ services:
     extends:
       file: common-services.yml
       service: remote_builder
-    command: ["--management.metrics.tags.instance=emsdk-3155-local"]
+    environment:
+      - INSTANCE_ID=emsdk-3155-local
     profiles:
       - all
       - web
@@ -81,7 +88,8 @@ services:
     extends:
       file: common-services.yml
       service: remote_builder
-    command: ["--management.metrics.tags.instance=emsdk-3165-local"]
+    environment:
+      - INSTANCE_ID=emsdk-3165-local
     profiles:
       - all
       - web
@@ -94,7 +102,8 @@ services:
     extends:
       file: common-services.yml
       service: remote_builder
-    command: ["--management.metrics.tags.instance=nssdk-1532-local"]
+    environment:
+      - INSTANCE_ID=nssdk-1532-local
     profiles:
       - all
       - consoles
@@ -108,7 +117,8 @@ services:
     extends:
       file: common-services.yml
       service: remote_builder
-    command: ["--management.metrics.tags.instance=nssdk-1753-local"]
+    environment:
+      - INSTANCE_ID=nssdk-1753-local
     profiles:
       - all
       - consoles
@@ -122,7 +132,8 @@ services:
     extends:
       file: common-services.yml
       service: remote_builder
-    command: ["--management.metrics.tags.instance=nssdk-1832-local"]
+    environment:
+      - INSTANCE_ID=nssdk-1832-local
     profiles:
       - all
       - consoles
@@ -136,7 +147,8 @@ services:
     extends:
       file: common-services.yml
       service: remote_builder
-    command: ["--management.metrics.tags.instance=ps4-11000-local"]
+    environment:
+      - INSTANCE_ID=ps4-11000-local
     profiles:
       - all
       - consoles
@@ -150,7 +162,8 @@ services:
     extends:
       file: common-services.yml
       service: remote_builder
-    command: ["--management.metrics.tags.instance=ps4-10500-local"]
+    environment:
+      - INSTANCE_ID=ps4-10500-local
     profiles:
       - all
       - consoles
@@ -164,7 +177,8 @@ services:
     extends:
       file: common-services.yml
       service: remote_builder
-    command: ["--management.metrics.tags.instance=ps5-8000-local"]
+    environment:
+      - INSTANCE_ID=ps5-8000-local
     profiles:
       - all
       - consoles
@@ -178,7 +192,8 @@ services:
     extends:
       file: common-services.yml
       service: remote_builder
-    command: ["--management.metrics.tags.instance=ps5-9000-local"]
+    environment:
+      - INSTANCE_ID=ps5-9000-local
     profiles:
       - all
       - consoles
@@ -192,7 +207,8 @@ services:
     extends:
       file: common-services.yml
       service: remote_builder
-    command: ["--management.metrics.tags.instance=winsdk-2019-local"]
+    environment:
+      - INSTANCE_ID=winsdk-2019-local
     profiles:
       - all
       - windows
@@ -205,7 +221,8 @@ services:
     extends:
       file: common-services.yml
       service: remote_builder
-    command: ["--management.metrics.tags.instance=winsdk-2022-local"]
+    environment:
+      - INSTANCE_ID=winsdk-2022-local
     profiles:
       - all
       - windows

--- a/server/scripts/standalone/service-standalone.sh
+++ b/server/scripts/standalone/service-standalone.sh
@@ -43,8 +43,8 @@ start_service() {
         fi
     fi
 
-    echo "Running: java -Xmx4g -XX:MaxDirectMemorySize=2g -Dorg.eclipse.jetty.server.Request.maxFormKeys=1500 -jar ${PATH_TO_JAR} --extender.sdk.location=${EXTENDER_SDK_LOCATION} --spring.config.location=classpath:./,file:${SPRING_PROFILES_LOCATION}/ --spring.profiles.active=${PROFILE} >> ${STDOUT_LOG} 2>> ${ERROR_LOG} < /dev/null &"
-    java -Xmx4g -XX:MaxDirectMemorySize=2g -Dorg.eclipse.jetty.server.Request.maxFormKeys=1500 -jar ${PATH_TO_JAR} --extender.sdk.location="${EXTENDER_SDK_LOCATION}" --spring.config.location=classpath:./,file:${SPRING_PROFILES_LOCATION}/ --spring.profiles.active=${PROFILE} >> ${STDOUT_LOG} 2>> ${ERROR_LOG} < /dev/null &
+    echo "Running: java -Xmx4g -XX:MaxDirectMemorySize=2g -Dorg.eclipse.jetty.server.Request.maxFormKeys=1500 -jar ${PATH_TO_JAR} --extender.sdk.location=${EXTENDER_SDK_LOCATION} --spring.config.location=classpath:./,file:${SPRING_PROFILES_LOCATION}/ --spring.profiles.active=${PROFILE}${STRUCTURED_LOGGING+,logging} ${STRUCTURED_LOGGING+--logging.config=${SPRING_PROFILES_LOCATION}/extender-logging.xml} >> ${STDOUT_LOG} 2>> ${ERROR_LOG} < /dev/null &"
+    java -Xmx4g -XX:MaxDirectMemorySize=2g -Dorg.eclipse.jetty.server.Request.maxFormKeys=1500 -jar ${PATH_TO_JAR} --extender.sdk.location="${EXTENDER_SDK_LOCATION}" --spring.config.location=classpath:./,file:${SPRING_PROFILES_LOCATION}/ --spring.profiles.active=${PROFILE}${STRUCTURED_LOGGING+,logging} ${STRUCTURED_LOGGING+--logging.config=${SPRING_PROFILES_LOCATION}/extender-logging.xml} >> ${STDOUT_LOG} 2>> ${ERROR_LOG} < /dev/null &
 
     
     echo $! > ${PID_PATH_NAME}

--- a/server/src/main/java/com/defold/extender/AsyncBuilder.java
+++ b/server/src/main/java/com/defold/extender/AsyncBuilder.java
@@ -9,6 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
 
+import com.defold.extender.log.Markers;
 import com.defold.extender.metrics.MetricsWriter;
 import com.defold.extender.services.DataCacheService;
 import com.defold.extender.services.DefoldSdkService;
@@ -65,7 +66,7 @@ public class AsyncBuilder {
             fos.close();
         }
         catch(Exception e) {
-            LOGGER.error("Could not write extender logs to error file", e);
+            LOGGER.error(Markers.SERVER_ERROR, "Could not write extender logs to error file", e);
         }
     }
 
@@ -78,7 +79,7 @@ public class AsyncBuilder {
             fos.close();
         }
         catch(Exception e) {
-            LOGGER.error("Could not write exception to error file", e);
+            LOGGER.error(Markers.SERVER_ERROR, "Could not write exception to error file", e);
         }
     }
 
@@ -130,7 +131,7 @@ public class AsyncBuilder {
             File errorFile = new File(resultDir, BuilderConstants.BUILD_ERROR_FILENAME);
             writeExtenderLogsToFile(extender, errorFile);
             writeExceptionToFile(e, errorFile);
-            LOGGER.error("Client closed connection prematurely, build aborted", e);
+            LOGGER.error(Markers.SERVER_ERROR, "Client closed connection prematurely, build aborted", e);
             isSuccefull = false;
         } catch(Exception e) {
             File errorFile = new File(resultDir, BuilderConstants.BUILD_ERROR_FILENAME);
@@ -171,12 +172,12 @@ public class AsyncBuilder {
                                     LOGGER.info("Cleaned up folder " + path.toString());
                                 }
                             } catch (IOException e) {
-                                LOGGER.error("Could not clear build results  " + path.toString(), e);
+                                LOGGER.error(Markers.SERVER_ERROR, "Could not clear build results  " + path.toString(), e);
                             }
                         });
             }
         } catch (IOException ex) {
-            LOGGER.error("Error during cleanup", ex);
+            LOGGER.error(Markers.SERVER_ERROR, "Error during cleanup", ex);
         }
         LOGGER.debug("Clean result folder finished.");
     }

--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -39,6 +39,7 @@ import com.defold.extender.services.CocoaPodsService.PodSpec;
 import com.defold.extender.services.CocoaPodsService.ResolvedPods;
 
 import com.defold.extender.builders.CSharpBuilder;
+import com.defold.extender.log.Markers;
 
 class Extender {
     private static final Logger LOGGER = LoggerFactory.getLogger(Extender.class);
@@ -363,7 +364,7 @@ class Extender {
                     v = templateExecutor.execute((List<String>) v, context);
                 }
             } catch (Exception e) {
-                LOGGER.error(String.format("Failed to substitute key %s", k));
+                LOGGER.error(Markers.COMPILATION_ERROR, String.format("Failed to substitute key %s", k));
                 throw e;
             }
             context.put(k, v);
@@ -2567,7 +2568,7 @@ class Extender {
             LOGGER.info("Writing log file");
             processExecutor.writeLog(logFile);
         } catch (IOException e) {
-            LOGGER.error("Failed to write log file to {}", logFile.getAbsolutePath());
+            LOGGER.error(Markers.SERVER_ERROR, "Failed to write log file to {}", logFile.getAbsolutePath());
         }
         return logFile;
     }

--- a/server/src/main/java/com/defold/extender/ExtenderController.java
+++ b/server/src/main/java/com/defold/extender/ExtenderController.java
@@ -3,6 +3,7 @@ package com.defold.extender;
 import com.defold.extender.remote.RemoteEngineBuilder;
 import com.defold.extender.remote.RemoteHostConfiguration;
 import com.defold.extender.remote.RemoteInstanceConfig;
+import com.defold.extender.log.Markers;
 import com.defold.extender.metrics.MetricsWriter;
 import com.defold.extender.services.DefoldSdkService;
 import com.defold.extender.services.DataCacheService;
@@ -127,7 +128,7 @@ public class ExtenderController {
 
     @ExceptionHandler({ExtenderException.class})
     public ResponseEntity<String> handleExtenderException(ExtenderException ex) {
-        LOGGER.error("Failed to build extension: " + ex.getOutput());
+        LOGGER.error(Markers.COMPILATION_ERROR, "Failed to build extension: " + ex.getOutput());
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.TEXT_PLAIN);
         return new ResponseEntity<>(ex.getOutput(), headers, HttpStatus.UNPROCESSABLE_ENTITY);
@@ -135,7 +136,7 @@ public class ExtenderController {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleException(Exception ex) {
-        LOGGER.error(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(), ex);
+        LOGGER.error(Markers.SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(), ex);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.TEXT_PLAIN);
         return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(), headers, HttpStatus.INTERNAL_SERVER_ERROR);
@@ -397,14 +398,14 @@ public class ExtenderController {
         try {
             input = request.getInputStream();
         } catch (IOException e) {
-            LOGGER.error("Failed to get input stream: " + e.getMessage());
+            LOGGER.error(Markers.SERVER_ERROR, "Failed to get input stream: " + e.getMessage());
             throw new ExtenderException(e, "Failed to get input stream: " + e.getMessage());
         }
 
         try {
             output = response.getOutputStream();
         } catch (IOException e) {
-            LOGGER.error("Failed to get output stream: " + e.getMessage());
+            LOGGER.error(Markers.SERVER_ERROR, "Failed to get output stream: " + e.getMessage());
             throw new ExtenderException(e, "Failed to get output stream: " + e.getMessage());
         }
 

--- a/server/src/main/java/com/defold/extender/TemplateExecutor.java
+++ b/server/src/main/java/com/defold/extender/TemplateExecutor.java
@@ -1,5 +1,6 @@
 package com.defold.extender;
 
+import com.defold.extender.log.Markers;
 import com.samskivert.mustache.Mustache;
 
 import org.slf4j.Logger;
@@ -21,7 +22,7 @@ public class TemplateExecutor {
             }
             return result;
         } catch (Exception e) {
-            LOGGER.error(String.format("Failed to substitute string '%s'", (String)template));
+            LOGGER.error(Markers.COMPILATION_ERROR, String.format("Failed to substitute string '%s'", (String)template));
             ExtenderUtil.debugPrint(context, 0);
             throw e;
         }
@@ -33,7 +34,7 @@ public class TemplateExecutor {
         	try {
     			out.add(this.execute(template, context));
             } catch (Exception e) {
-                LOGGER.error(String.format("Failed to substitute string in list [..., '%s', ...]", (String)template));
+                LOGGER.error(Markers.COMPILATION_ERROR, String.format("Failed to substitute string in list [..., '%s', ...]", (String)template));
                 ExtenderUtil.debugPrint(context, 0);
                 throw e;
 	        }

--- a/server/src/main/java/com/defold/extender/log/Markers.java
+++ b/server/src/main/java/com/defold/extender/log/Markers.java
@@ -1,0 +1,11 @@
+package com.defold.extender.log;
+
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+
+public class Markers {
+    public static final Marker SERVER_ERROR = MarkerFactory.getMarker("SERVER_ERROR");
+    public static final Marker COMPILATION_ERROR = MarkerFactory.getMarker("COMPILATION_ERROR");
+    public static final Marker INSTANCE_MANAGER_ERROR = MarkerFactory.getMarker("INSTANCE_MANAGER_ERROR");
+    public static final Marker CACHE_ERROR = MarkerFactory.getMarker("CACHE_ERROR");
+}

--- a/server/src/main/java/com/defold/extender/remote/RemoteEngineBuilder.java
+++ b/server/src/main/java/com/defold/extender/remote/RemoteEngineBuilder.java
@@ -5,6 +5,7 @@ import com.defold.extender.ExtenderException;
 import com.defold.extender.metrics.MetricsWriter;
 import com.defold.extender.services.GCPInstanceService;
 import com.defold.extender.Timer;
+import com.defold.extender.log.Markers;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -93,11 +94,11 @@ public class RemoteEngineBuilder {
 
             if (isClientError(response)) {
                 String error = getErrorString(response);
-                LOGGER.error("Client error when building engine remotely:\n{}", error);
+                LOGGER.error(Markers.COMPILATION_ERROR, "Client error when building engine remotely:\n{}", error);
                 throw new ExtenderException("Client error when building engine remotely: " + error);
             } else if (isServerError(response)) {
                 String error = getErrorString(response);
-                LOGGER.error("Server error when building engine remotely:\n{}", error);
+                LOGGER.error(Markers.SERVER_ERROR, "Server error when building engine remotely:\n{}", error);
                 throw new RemoteBuildException("Server error when building engine remotely: " + getStatusReason(response) + ": " + error);
             } else {
                 response.getEntity().writeTo(out);
@@ -177,7 +178,7 @@ public class RemoteEngineBuilder {
                     Files.move(tmpResult.toPath(), targetResult.toPath(), StandardCopyOption.ATOMIC_MOVE);
                 } else {
                     String errorLog = EntityUtils.toString(response.getEntity());
-                    LOGGER.error(String.format("Failed to build source.\n%s", errorLog));
+                    LOGGER.error(Markers.COMPILATION_ERROR, String.format("Failed to build source.\n%s", errorLog));
                     File errorFile = new File(resultDir, BuilderConstants.BUILD_ERROR_FILENAME);
                     PrintWriter writer = new PrintWriter(errorFile);
                     writer.write(errorLog);
@@ -185,7 +186,7 @@ public class RemoteEngineBuilder {
                 }
             } else {
                 String errorLog = EntityUtils.toString(response.getEntity());
-                LOGGER.error(String.format("Failed to build source.\n%s", errorLog));
+                LOGGER.error(Markers.COMPILATION_ERROR,  String.format("Failed to build source.\n%s", errorLog));
                 File errorFile = new File(resultDir, BuilderConstants.BUILD_ERROR_FILENAME);
                 PrintWriter writer = new PrintWriter(errorFile);
                 writer.write(errorLog);
@@ -256,7 +257,7 @@ public class RemoteEngineBuilder {
             try {
                 instanceService.touchInstance(instanceId);
             } catch(Exception exc) {
-                LOGGER.error(String.format("Exception during touch instance '%s'", instanceId), exc);
+                LOGGER.error(Markers.INSTANCE_MANAGER_ERROR, String.format("Exception during touch instance '%s'", instanceId), exc);
             }
         }
     }

--- a/server/src/main/java/com/defold/extender/services/DataCacheService.java
+++ b/server/src/main/java/com/defold/extender/services/DataCacheService.java
@@ -6,6 +6,7 @@ import com.defold.extender.cache.DataCacheFactory;
 import com.defold.extender.cache.info.CacheInfoFileParser;
 import com.defold.extender.cache.info.CacheInfoFileWriter;
 import com.defold.extender.cache.info.CacheInfoWrapper;
+import com.defold.extender.log.Markers;
 import com.defold.extender.cache.CacheKeyGenerator;
 import com.defold.extender.cache.DataCache;
 import org.apache.commons.lang3.StringUtils;
@@ -83,7 +84,7 @@ public class DataCacheService {
                         result.cachedFileSize.addAndGet(fileSize);
                         result.cachedFileCount.addAndGet(fileSize >= fileSizeThreshold ? 1 : 0);
                     } catch (IOException e) {
-                        LOGGER.error("Could not cache file " + path.toString(), e);
+                        LOGGER.error(Markers.CACHE_ERROR, "Could not cache file " + path.toString(), e);
                     }
                 });
 

--- a/server/src/main/java/com/defold/extender/services/DefoldSdkService.java
+++ b/server/src/main/java/com/defold/extender/services/DefoldSdkService.java
@@ -2,6 +2,7 @@ package com.defold.extender.services;
 
 import com.defold.extender.ExtenderException;
 import com.defold.extender.ZipUtils;
+import com.defold.extender.log.Markers;
 import com.defold.extender.metrics.MetricsWriter;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -94,7 +95,7 @@ public class DefoldSdkService {
                 try {
                     FileUtils.deleteDirectory(source.toFile());
                 } catch (IOException e2) {
-                    LOGGER.error("Failed to delete temp sdk directory {}: {}", source.toString(), e2.getMessage());
+                    LOGGER.error(Markers.SERVER_ERROR, "Failed to delete temp sdk directory {}: {}", source.toString(), e2.getMessage());
                 }
             }
         }
@@ -216,7 +217,7 @@ public class DefoldSdkService {
             Move(path, tmpDir.toPath());
             FileUtils.deleteDirectory(tmpDir);
         } catch (IOException e) {
-            LOGGER.error("Failed to delete cached SDK at " + path.toAbsolutePath().toString(), e);
+            LOGGER.error(Markers.CACHE_ERROR, "Failed to delete cached SDK at " + path.toAbsolutePath().toString(), e);
         }
     }
 

--- a/server/src/main/java/com/defold/extender/services/GCPInstanceService.java
+++ b/server/src/main/java/com/defold/extender/services/GCPInstanceService.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.google.cloud.compute.v1.InstancesClient;
 import com.google.cloud.compute.v1.InstancesSettings;
 import com.google.cloud.compute.v1.Operation;
+import com.defold.extender.log.Markers;
 import com.defold.extender.remote.RemoteHostConfiguration;
 import com.defold.extender.remote.RemoteInstanceConfig;
 import com.defold.extender.services.data.GCPInstanceState;
@@ -141,11 +142,11 @@ public class GCPInstanceService {
                     try {
                         suspendInstance(entry.getKey());
                     } catch(TimeoutException exc) {
-                        LOGGER.error(String.format("Suspend '%s' timeouted.", entry.getKey()), exc);
+                        LOGGER.error(Markers.INSTANCE_MANAGER_ERROR, String.format("Suspend '%s' timeouted.", entry.getKey()), exc);
                     } catch(InterruptedException exc) {
-                        LOGGER.error(String.format("Suspend '%s' interrupted.", entry.getKey()), exc);
+                        LOGGER.error(Markers.INSTANCE_MANAGER_ERROR, String.format("Suspend '%s' interrupted.", entry.getKey()), exc);
                     } catch(ExecutionException exc) {
-                        LOGGER.error(String.format("Suspend '%s' failed.", entry.getKey()), exc);
+                        LOGGER.error(Markers.INSTANCE_MANAGER_ERROR, String.format("Suspend '%s' failed.", entry.getKey()), exc);
                     }
             }
         }
@@ -160,7 +161,7 @@ public class GCPInstanceService {
             try {
                 touchInstance(entry.getKey());
             } catch (Exception exc) {
-                LOGGER.error(String.format("Exception during touch instance '%s'", entry.getKey()), exc);
+                LOGGER.error(Markers.INSTANCE_MANAGER_ERROR, String.format("Exception during touch instance '%s'", entry.getKey()), exc);
             }
         }
     }

--- a/server/src/main/java/com/defold/extender/services/RealGradleService.java
+++ b/server/src/main/java/com/defold/extender/services/RealGradleService.java
@@ -6,6 +6,7 @@ import com.defold.extender.ProcessExecutor;
 import com.defold.extender.TemplateExecutor;
 import com.defold.extender.Timer;
 import com.defold.extender.ZipUtils;
+import com.defold.extender.log.Markers;
 import com.defold.extender.metrics.MetricsWriter;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -157,7 +158,7 @@ public class RealGradleService implements GradleServiceInterface {
                 try {
                     FileUtils.deleteDirectory(source.toFile());
                 } catch (IOException e2) {
-                    LOGGER.error("Failed to delete temp directory {}: {}", source.toString(), e2.getMessage());
+                    LOGGER.error(Markers.SERVER_ERROR, "Failed to delete temp directory {}: {}", source.toString(), e2.getMessage());
                 }
             }
         }

--- a/server/src/main/java/com/defold/extender/tracing/ExtenderExecutor.java
+++ b/server/src/main/java/com/defold/extender/tracing/ExtenderExecutor.java
@@ -1,0 +1,69 @@
+package com.defold.extender.tracing;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import io.micrometer.context.ContextExecutorService;
+import io.micrometer.context.ContextScheduledExecutorService;
+import io.micrometer.context.ContextSnapshot;
+import io.micrometer.context.ContextSnapshotFactory;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.RejectedExecutionHandler;
+
+@Configuration(proxyBeanMethods = false)
+class ExtenderExecutor {
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableAsync
+    static class AsyncConfig implements AsyncConfigurer, WebMvcConfigurer {
+
+        @Override
+        public Executor getAsyncExecutor() {
+            return ContextExecutorService.wrap(Executors.newCachedThreadPool(), ContextSnapshot::captureAll);
+        }
+
+        @Override
+        public void configureAsyncSupport(AsyncSupportConfigurer configurer) {
+            configurer.setTaskExecutor(new SimpleAsyncTaskExecutor(r -> new Thread(ContextSnapshotFactory.builder().build().captureAll().wrap(r))));
+        }
+    }
+
+
+    /**
+     * NAME OF THE BEAN IS IMPORTANT!
+     * <p>
+     * We need to wrap this for @Async related things to propagate the context.
+     *
+     * @see EnableAsync
+     */
+    // [Observability] instrumenting executors
+    @Bean(name = "extenderTaskExecutor", destroyMethod = "shutdown")
+    ThreadPoolTaskScheduler threadPoolTaskScheduler() {
+        ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler() {
+            @Override
+            protected ExecutorService initializeExecutor(ThreadFactory threadFactory, RejectedExecutionHandler rejectedExecutionHandler) {
+                ExecutorService executorService = super.initializeExecutor(threadFactory, rejectedExecutionHandler);
+                return ContextExecutorService.wrap(executorService, ContextSnapshot::captureAll);
+            }
+
+
+                @Override
+                public ScheduledExecutorService getScheduledExecutor() throws IllegalStateException {
+                    return ContextScheduledExecutorService.wrap(super.getScheduledExecutor());
+                }
+        };
+        threadPoolTaskScheduler.initialize();
+        return threadPoolTaskScheduler;
+    }
+}

--- a/server/src/main/java/com/defold/extender/tracing/ExtenderTracerInterceptor.java
+++ b/server/src/main/java/com/defold/extender/tracing/ExtenderTracerInterceptor.java
@@ -1,0 +1,30 @@
+package com.defold.extender.tracing;
+
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
+import org.apache.http.HttpException;
+import org.apache.http.HttpMessage;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.protocol.HttpContext;
+
+import java.io.IOException;
+
+
+public class ExtenderTracerInterceptor implements HttpRequestInterceptor {
+
+    private final Tracer tracer;
+    private final Propagator propagator;
+
+    public ExtenderTracerInterceptor(Tracer tracer, Propagator propagator) {
+        this.tracer = tracer;
+        this.propagator = propagator;
+    }
+
+    @Override
+    public void process(HttpRequest request, HttpContext context) throws HttpException, IOException {
+        if (tracer.currentSpan() != null) {
+            propagator.inject(tracer.currentSpan().context(), request, HttpMessage::addHeader);
+        }
+    }
+}

--- a/server/src/main/java/com/defold/extender/tracing/TraceIdInResponseServletFilter.java
+++ b/server/src/main/java/com/defold/extender/tracing/TraceIdInResponseServletFilter.java
@@ -1,0 +1,38 @@
+package com.defold.extender.tracing;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class TraceIdInResponseServletFilter implements Filter {
+
+    public static final String TRACE_ID_HEADER_NAME = "X-TraceId";
+
+    private final Tracer tracer;
+
+    public TraceIdInResponseServletFilter(@Autowired Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        final Span currentSpan = tracer.currentSpan();
+        if (currentSpan != null) {
+            HttpServletResponse resp = (HttpServletResponse) response;
+            resp.addHeader(TRACE_ID_HEADER_NAME, currentSpan.context().traceId());
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -37,6 +37,8 @@ extender:
         lifetime: 1200000
 
 spring:
+    application:
+        name: extender
     servlet:
         multipart:
             enabled: true
@@ -53,8 +55,6 @@ endpoints:
         enabled: true
         sensitive: false
 
-# Suppress info-logging from metrics reporting client
-logging.level.okhttp3.OkHttpClient: WARN
 # Increase thread name size, to make the job name more visible
 logging.pattern.console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.23t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n"
 


### PR DESCRIPTION
* Add functionality to trace workload in distributed system. Now logs has `traceId` and `spanId`. By `traceId` it can be searched all logs related to build request.
* Add logging markers. It helps to categorize errors into several groups.
* Add example of config for structured logging.
* Extender client now can read `traceId` from response header.

Fixes #494 

Example of structured logging:
```
2024-10-09 18:03:37 {"@timestamp":"2024-10-09T15:03:37.512892758Z","@version":"1","message":"Schedule user credentials update","logger_name":"com.defold.extender.services.UserUpdateService","thread_name":"extenderTaskExecutor-1","level":"INFO","level_value":20000,"traceId":"ad11812defd201b5fb6f362eab5a4d7a","spanId":"e5d0e34b41651215"}
2024-10-09 18:03:37 {"@timestamp":"2024-10-09T15:03:37.513635133Z","@version":"1","message":"UserUpdateService - No extender.authentication.users configuration has been set","logger_name":"com.defold.extender.services.UserUpdateService","thread_name":"extenderTaskExecutor-1","level":"INFO","level_value":20000,"traceId":"ad11812defd201b5fb6f362eab5a4d7a","spanId":"e5d0e34b41651215"}
```