### PR TITLE
Add Podfile.lock to build results

### DIFF
--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -1017,6 +1017,13 @@ class Extender {
             }
         }
 
+        if (resolvedPods.podFileLock != null) {
+            LOGGER.info("buildPods - adding Podfile.lock to build output");
+            File destPodFileLock = new File(buildDirectory, "Podfile.lock");
+            FileUtils.copyFile(resolvedPods.podFileLock, destPodFileLock);
+            outputFiles.add(destPodFileLock);
+        }
+
         return outputFiles;
     }
 

--- a/server/src/main/java/com/defold/extender/services/CocoaPodsService.java
+++ b/server/src/main/java/com/defold/extender/services/CocoaPodsService.java
@@ -70,6 +70,7 @@ public class CocoaPodsService {
         public File frameworksDir;
         public File generatedDir;
         public String platformMinVersion;
+        public File podFileLock;
 
         // In the functions below we also get the values from the parent spec
         // if one exists. A parent spec inherits all of its subspecs (unless a 
@@ -147,7 +148,8 @@ public class CocoaPodsService {
             sb.append("pods dir: " + podsDir + "\n");
             sb.append("frameworks Dir: " + frameworksDir + "\n");
             sb.append("generated dir: " + generatedDir + "\n");
-            sb.append("platform min version: " + platformMinVersion);
+            sb.append("platform min version: " + platformMinVersion + "\n");
+            sb.append("podfile.lock: " + podFileLock);
             return sb.toString();
         }
     }
@@ -1393,6 +1395,7 @@ public class CocoaPodsService {
         resolvedPods.podsDir = new File(workingDir, "Pods");
         resolvedPods.frameworksDir = frameworksDir;
         resolvedPods.generatedDir = generatedDir;
+        resolvedPods.podFileLock = new File(workingDir, "Podfile.lock");
 
         LOGGER.info("Resolved Cocoapod dependencies");
         LOGGER.info(resolvedPods.toString());


### PR DESCRIPTION
Podfile.lock now return as part of build result. Podfile.lock is located in `<project_root>/build/arm64-ios/` or `<project_root>/build/x86_64-ios/`

Fixes #470