### PR TITLE
Add custom log enhancer to add more information to GCP LogEntry.

### DIFF
--- a/server/src/main/java/com/defold/extender/log/ExtenderLogEnhancer.java
+++ b/server/src/main/java/com/defold/extender/log/ExtenderLogEnhancer.java
@@ -1,0 +1,22 @@
+package com.defold.extender.log;
+
+import com.google.cloud.logging.LogEntry.Builder;
+import com.google.cloud.logging.LoggingEnhancer;
+import com.google.cloud.logging.logback.LoggingEventEnhancer;
+
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+public class ExtenderLogEnhancer implements LoggingEnhancer, LoggingEventEnhancer {
+    @Override
+    public void enhanceLogEntry(Builder builder) {
+        if (ExtenderLogEnhancerConfiguration.isInitialized()) {
+            builder.setResource(ExtenderLogEnhancerConfiguration.getMonitoredResource());
+        }
+    }
+
+    @Override
+    public void enhanceLogEntry(Builder builder, ILoggingEvent e) {
+        enhanceLogEntry(builder);
+    }
+}

--- a/server/src/main/java/com/defold/extender/log/ExtenderLogEnhancerConfiguration.java
+++ b/server/src/main/java/com/defold/extender/log/ExtenderLogEnhancerConfiguration.java
@@ -1,0 +1,44 @@
+package com.defold.extender.log;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import com.google.cloud.MonitoredResource;
+import com.google.cloud.spring.core.DefaultGcpProjectIdProvider;
+
+@Component
+public class ExtenderLogEnhancerConfiguration {
+    
+    private String instanceName;
+    private String applicationName;
+    private String instanceLocation;
+    private String projectId;
+    private MonitoredResource monitoredResource;
+
+    private static ExtenderLogEnhancerConfiguration instance;
+    private ExtenderLogEnhancerConfiguration(@Autowired Environment env) {
+        if (instance != null) {
+            throw new IllegalStateException("ExtenderLogEnhancerConfiguration already initialized");
+        }
+        instance = this;
+        this.instanceName = env.getProperty("management.metrics.tags.instance", "unknown");
+        this.applicationName = env.getProperty("management.metrics.tags.application", "unknown");
+        this.instanceLocation = env.getProperty("extender.logging.instance-location", "europe-west1-b");
+        this.projectId = new DefaultGcpProjectIdProvider().getProjectId();
+        this.monitoredResource = MonitoredResource.newBuilder("generic_node")
+                                            .addLabel("project_id", projectId)
+                                            .addLabel("location", instanceLocation)
+                                            .addLabel("namespace", applicationName)
+                                            .addLabel("node_id", instanceName)
+                                            .build();
+    }
+
+    public static boolean isInitialized() {
+        return instance != null;
+    }
+
+    public static MonitoredResource getMonitoredResource() {
+        return instance != null ? instance.monitoredResource : null;
+    }
+}


### PR DESCRIPTION
Custom log enhancer allows to add more fields to LogEntry that pushed to Stackdriver. It's useful in case when external instances pushes some logs to GCP.
Example how to configure Stackdriver appender:
```xml
<appender name="STACKDRIVER_CUSTOM" class="com.google.cloud.spring.logging.LoggingAppender">
  <log>${STACKDRIVER_LOG_NAME}</log> <!-- Optional : default spring.log -->
  <loggingEventEnhancer>com.google.cloud.spring.logging.TraceIdLoggingEnhancer</loggingEventEnhancer>
  <loggingEventEnhancer>com.defold.extender.log.ExtenderLogEnhancer</loggingEventEnhancer>
  <flushLevel>${STACKDRIVER_LOG_FLUSH_LEVEL}</flushLevel> <!-- Optional : default OFF -->
</appender>
```
How it looks like in Cloud logging
<img width="1360" alt="Screenshot 2024-10-15 at 15 56 37" src="https://github.com/user-attachments/assets/96b7f46b-0135-48e1-acd5-aca6643a43f0">

