### PR TITLE
Make custom thread pool size configurable.

### DIFF
--- a/server/src/main/java/com/defold/extender/AsyncBuilder.java
+++ b/server/src/main/java/com/defold/extender/AsyncBuilder.java
@@ -83,7 +83,7 @@ public class AsyncBuilder {
         }
     }
 
-    @Async
+    @Async(value="extenderTaskExecutor")
     public void asyncBuildEngine(MetricsWriter metricsWriter, String platform, String sdkVersion,
             File jobDirectory, File uploadDirectory, File buildDirectory) throws IOException {
         String jobName = jobDirectory.getName();

--- a/server/src/main/java/com/defold/extender/tracing/ExtenderExecutor.java
+++ b/server/src/main/java/com/defold/extender/tracing/ExtenderExecutor.java
@@ -1,5 +1,6 @@
 package com.defold.extender.tracing;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
@@ -23,6 +24,9 @@ import java.util.concurrent.RejectedExecutionHandler;
 
 @Configuration(proxyBeanMethods = false)
 class ExtenderExecutor {
+
+    @Value("${extender.tasks.executor.pool-size:35}")
+    private int executorPoolSize;
 
     @Configuration(proxyBeanMethods = false)
     @EnableAsync
@@ -63,6 +67,7 @@ class ExtenderExecutor {
                     return ContextScheduledExecutorService.wrap(super.getScheduledExecutor());
                 }
         };
+        threadPoolTaskScheduler.setPoolSize(executorPoolSize);
         threadPoolTaskScheduler.initialize();
         return threadPoolTaskScheduler;
     }


### PR DESCRIPTION
To achieve sharing `traceId` and `spanId` across different thread's context custom task executor was implemented. By default it creates thread pool with size = 1.
```
A standard implementation of Spring's TaskScheduler interface, wrapping a native java.util.concurrent.ScheduledThreadPoolExecutor and providing all applicable configuration options for it. The default number of scheduler threads is 1; a higher number can be configured through setPoolSize.          <------------------------

This is Spring's traditional scheduler variant, staying as close as possible to java.util.concurrent.ScheduledExecutorService semantics. Task execution happens on the scheduler thread(s) rather than on separate execution threads. As a consequence, a ScheduledFuture handle (e.g. from schedule(Runnable, Instant)) represents the actual completion of the provided task (or series of repeated tasks).
```
As a result every build task that goes to remote build stall all other build task. So processing was almost single-threaded.

So fix add config option to allow set pool size from the application properties. By default pool size is 35. That pool size used for remote build/async build/scheduled task (like cleanup build folder, update users, etc.)

Also mark `AsyncBuilder.asyncBuildEngine` to use custom executor.