### PR TITLE
Fix replace symbolCmd with empty string when merge contexts.

### DIFF
--- a/server/src/main/java/com/defold/extender/PlatformConfig.java
+++ b/server/src/main/java/com/defold/extender/PlatformConfig.java
@@ -30,10 +30,10 @@ public class PlatformConfig {
     public String manifestMergeCmd;
     public String bitcodeStripCmd;
     public String proGuardSourceRe;
-    public String proGuardCmd = new String();
-    public String windresCmd = new String();
-    public String symbolCmd = new String();
-    public String symbolsPattern = new String();
+    public String proGuardCmd;
+    public String windresCmd;
+    public String symbolCmd;
+    public String symbolsPattern;
     public List<String> allowedLibs;
     public List<String> allowedFlags;
     public List<String> allowedSymbols;


### PR DESCRIPTION
Some fields in `PlatformConfig` were initialized with empty string. That led to replace `symbolCmd` value with empty string during context's merging.

Example (how it was):
```
common.symbolCmd = ""
osx.symbolCmd = "dsymutil -o {{src}}.dSYM {{src}}"
arm64-osx.symbolCmd = ""
```
And as result `symbolCmd == ""`. If fields initially will be `null` - value of the field won't be replaced.

Example (how it will work after fix):
```
common.symbolCmd = null
osx.symbolCmd = "dsymutil -o {{src}}.dSYM {{src}}"
arm64-osx.symbolCmd = null
```
----> `symbolCmd = "dsymutil -o {{src}}.dSYM {{src}}"`

Fixes #330 