### PR TITLE
Rework compilation errors handling

### DIFF
--- a/server/src/main/java/com/defold/extender/remote/RemoteEngineBuilder.java
+++ b/server/src/main/java/com/defold/extender/remote/RemoteEngineBuilder.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.Optional;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 @Service
@@ -188,20 +189,20 @@ public class RemoteEngineBuilder {
                     File targetResult = new File(resultDir, BuilderConstants.BUILD_RESULT_FILENAME);
                     Files.move(tmpResult.toPath(), targetResult.toPath(), StandardCopyOption.ATOMIC_MOVE);
                 } else {
-                    String errorLog = EntityUtils.toString(response.getEntity());
-                    LOGGER.error(Markers.COMPILATION_ERROR, String.format("Failed to build source.\n%s", errorLog));
+                    LOGGER.error(Markers.COMPILATION_ERROR, "Failed to build source.");
                     File errorFile = new File(resultDir, BuilderConstants.BUILD_ERROR_FILENAME);
                     PrintWriter writer = new PrintWriter(errorFile);
-                    writer.write(errorLog);
+                    IOUtils.copy(response.getEntity().getContent(), writer, Charset.defaultCharset());
                     writer.close();
+                    EntityUtils.consumeQuietly(response.getEntity());
                 }
             } else {
-                String errorLog = EntityUtils.toString(response.getEntity());
-                LOGGER.error(Markers.COMPILATION_ERROR,  String.format("Failed to build source.\n%s", errorLog));
+                LOGGER.error(Markers.COMPILATION_ERROR,  "Failed to build source.");
                 File errorFile = new File(resultDir, BuilderConstants.BUILD_ERROR_FILENAME);
                 PrintWriter writer = new PrintWriter(errorFile);
-                writer.write(errorLog);
-                writer.close();        
+                IOUtils.copy(response.getEntity().getContent(), writer, Charset.defaultCharset());
+                writer.close();
+                EntityUtils.consumeQuietly(response.getEntity());
             }
             metricsWriter.measureRemoteEngineBuild(buildTimer.start(), platform);
         } catch (Exception e) {

--- a/server/test-data/ext_error_extension/ext.manifest
+++ b/server/test-data/ext_error_extension/ext.manifest
@@ -1,0 +1,1 @@
+name: ext_error_extension

--- a/server/test-data/ext_error_extension/src/test_error_ext.cpp
+++ b/server/test-data/ext_error_extension/src/test_error_ext.cpp
@@ -1,0 +1,19 @@
+
+// The "test-data" folder is part of the upload folder in our integration tests
+// For actual extensions it would be "ext/include/ext.h"
+#include <test-data/ext/include/ext.h>
+#include <stdio.h>
+
+extern "C"
+{
+	void ext_error_extension() // Need to have the symbol specified in the ext.manifest
+	{
+        printf("Hello From TestUseBaseExtension\n");
+        Test();
+		if (UndefinedFunction(13, "function"))
+		{
+			printf("Never reach");
+		}
+	}
+}
+


### PR DESCRIPTION
* Compilation error from remote builder now writes directly to result file without pushing it to logs.
* Add `consumeQuite` to make sure that response entity was fully consumed. Add test to check compilation error.
* Add async build variant to integration test configuration.

Fixes #550 