### PR TITLE
Consume http response in case of HTTP error

### DIFF
--- a/client/src/main/java/com/defold/extender/client/ExtenderClient.java
+++ b/client/src/main/java/com/defold/extender/client/ExtenderClient.java
@@ -190,6 +190,7 @@ public class ExtenderClient {
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
                 return EntityUtils.toString(response.getEntity()).replace("\\/", "/");
             } else {
+                EntityUtils.consumeQuietly(response.getEntity());
                 return null; // Caching is not supported
             }
         } catch (Exception e) {
@@ -398,6 +399,7 @@ public class ExtenderClient {
         addAuthorizationHeader(request);
         addHeaders(request);
         HttpResponse response = httpClient.execute(request);
+        EntityUtils.consumeQuietly(response.getEntity());
         if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
             return true;
         }

--- a/client/src/main/java/com/defold/extender/client/ExtenderClientCache.java
+++ b/client/src/main/java/com/defold/extender/client/ExtenderClientCache.java
@@ -82,7 +82,7 @@ public class ExtenderClientCache {
     /** Gets the cache storage file
      */
     public File getCacheFile() {
-        return new File(cacheDir.getAbsolutePath() + File.separator + this.cacheFile);
+        return new File(cacheDir.getAbsolutePath() + File.separator + ExtenderClientCache.cacheFile);
     }
 
     /** Calculates a key to identify a build

--- a/client/src/main/java/com/defold/extender/client/FileExtenderResource.java
+++ b/client/src/main/java/com/defold/extender/client/FileExtenderResource.java
@@ -7,7 +7,6 @@ import java.nio.file.Files;
 public class FileExtenderResource implements ExtenderResource {
     private File file = null;
     private String filePath;
-    private String fileAbsPath;
 
     public FileExtenderResource(String filePath) {
         this(new File(filePath));
@@ -21,7 +20,6 @@ public class FileExtenderResource implements ExtenderResource {
     FileExtenderResource(File file) {
         this.file = file;
         this.filePath = file.getPath();
-        this.fileAbsPath = file.getAbsolutePath();
     }
 
     @Override

--- a/client/src/test/java/com/defold/extender/client/ExtenderClientTest.java
+++ b/client/src/test/java/com/defold/extender/client/ExtenderClientTest.java
@@ -18,6 +18,8 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.security.MessageDigest;
@@ -340,7 +342,7 @@ public class ExtenderClientTest extends Mockito {
     }
 
     @Test
-    public void testClientHeaders() throws IOException {
+    public void testClientHeaders() throws Exception {
         class MockHttpClient extends DefaultHttpClient {
             public HttpUriRequest request;
 
@@ -362,7 +364,12 @@ public class ExtenderClientTest extends Mockito {
             final String HDR_VALUE_2 = "my custom header2";
             MockHttpClient httpClient = new MockHttpClient();
             File cacheDir = new File("build");
-            ExtenderClient extenderClient = new ExtenderClient(httpClient, "http://localhost", cacheDir);
+            Class<?> mockExtenderClientClass = Class.forName("com.defold.extender.client.ExtenderClient");
+            ExtenderClient extenderClient = (ExtenderClient) mockExtenderClientClass.getDeclaredConstructor(String.class, File.class).newInstance("http://localhost", cacheDir);
+            Field field = mockExtenderClientClass.getDeclaredField("httpClient");
+            field.setAccessible(true);
+            field.set(extenderClient, httpClient);
+
             extenderClient.setHeader(HDR_NAME_1, HDR_VALUE_1);
             extenderClient.setHeader(HDR_NAME_2, HDR_VALUE_2);
             extenderClient.health();
@@ -378,7 +385,7 @@ public class ExtenderClientTest extends Mockito {
     }
 
     @Test(expected = ExtenderClientException.class)
-    public void testClientHandleHTTPError() throws ClientProtocolException, IOException, ExtenderClientException {
+    public void testClientHandleHTTPError() throws ClientProtocolException, IOException, ExtenderClientException, ClassNotFoundException, InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException, NoSuchFieldException {
         DefaultHttpClient httpClient = Mockito.mock(DefaultHttpClient.class);
         CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
         StatusLine statusLine = Mockito.mock(StatusLine.class);
@@ -417,7 +424,12 @@ public class ExtenderClientTest extends Mockito {
         inputFiles.add(bRes);
         inputFiles.add(cRes);
 
-        ExtenderClient extenderClient = new ExtenderClient(httpClient, "http://localhost", cacheDir);
+        Class<?> mockExtenderClientClass = Class.forName("com.defold.extender.client.ExtenderClient");
+        ExtenderClient extenderClient = (ExtenderClient) mockExtenderClientClass.getDeclaredConstructor(String.class, File.class).newInstance("http://localhost", cacheDir);
+        Field field = mockExtenderClientClass.getDeclaredField("httpClient");
+        field.setAccessible(true);
+        field.set(extenderClient, httpClient);
+
         extenderClient.build("js-web", "aaaaaaaa", inputFiles, targetDir, log, true);
     }
 

--- a/server/src/main/java/com/defold/extender/services/HealthReporterService.java
+++ b/server/src/main/java/com/defold/extender/services/HealthReporterService.java
@@ -79,6 +79,7 @@ public class HealthReporterService {
                             updateOperationalStatus(platformOperationalStatus, platform, false);
                         }
                     } else {
+                        EntityUtils.consumeQuietly(response.getEntity());
                         updateOperationalStatus(platformOperationalStatus, platform, false);
                     }
                 } catch(Exception exc) {


### PR DESCRIPTION
* Possible problem was that response for `/query` returns HTTP error and Extender doesn't consume response stream.
* Replace `DefaultHttpClient` with preconfigured http client.
* Http client now stop sending request body if server returns one of 4XX code (https://lists.apache.org/thread/p38b3lrjt4vhyqthwhqcq3vsx3dpr3wj)
* Remove ExtenderClient constructor which accepts http client as argument.
* Add traceId to log file.
* Improve log file content in case of non-compilation error.

Fixes #528 