### PR TITLE
Improve health_report implementation

### DIFF
--- a/server/src/main/java/com/defold/extender/services/GCPInstanceService.java
+++ b/server/src/main/java/com/defold/extender/services/GCPInstanceService.java
@@ -114,6 +114,10 @@ public class GCPInstanceService {
         return getInstanceStatus(instanceId).equalsIgnoreCase(Status.RUNNING.toString());
     }
 
+    public boolean isInstanceSuspending(final String instanceId) {
+        return getInstanceStatus(instanceId).equalsIgnoreCase(Status.SUSPENDING.toString());
+    }
+
     // check if instance with 'instanceId' is controlled by the service
     public boolean isInstanceControlled(final String instanceId) {
         return instanceState.containsKey(instanceId);


### PR DESCRIPTION
Check if instance in suspending state when health_report request is arrived. If instance in state other than suspended/suspending/running - return unreachable.

Possible issue: /health_report request arrived when one of the remote builder was in SUSPENDING state. It led to make a HTTP request to instance. But suspended instance didn't respond and didn't abort. Only one thing that I current don't understand is why configured HTTP timeouts didn't triggered?