### PR TITLE
Fix exception during upload caching

### DIFF
--- a/server/src/main/java/com/defold/extender/AsyncBuilder.java
+++ b/server/src/main/java/com/defold/extender/AsyncBuilder.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import com.defold.extender.log.Markers;
 import com.defold.extender.metrics.MetricsWriter;
-import com.defold.extender.services.DataCacheService;
 import com.defold.extender.services.DefoldSdkService;
 import com.defold.extender.services.GradleService;
 import com.defold.extender.services.CocoaPodsService;
@@ -31,7 +30,6 @@ public class AsyncBuilder {
     private static final Logger LOGGER = LoggerFactory.getLogger(AsyncBuilder.class);
 
     private DefoldSdkService defoldSdkService;
-    private DataCacheService dataCacheService;
     private GradleService gradleService;
     private CocoaPodsService cocoaPodsService;
     private File jobResultLocation;
@@ -39,13 +37,11 @@ public class AsyncBuilder {
     private boolean keepJobDirectory = false;
 
     public AsyncBuilder(DefoldSdkService defoldSdkService,
-                        DataCacheService dataCacheService,
                         GradleService gradleService,
                         CocoaPodsService cocoaPodsService,
                         @Value("${extender.job-result.location}") String jobResultLocation,
                         @Value("${extender.job-result.lifetime:1200000}") long jobResultLifetime) {
         this.defoldSdkService = defoldSdkService;
-        this.dataCacheService = dataCacheService;
         this.gradleService = gradleService;
         this.cocoaPodsService = cocoaPodsService;
         this.jobResultLocation = new File(jobResultLocation);

--- a/server/src/main/java/com/defold/extender/cache/GCPDataCache.java
+++ b/server/src/main/java/com/defold/extender/cache/GCPDataCache.java
@@ -13,7 +13,6 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.BlobId;
-import com.defold.extender.AsyncBuilder;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobInfo;
 
@@ -45,7 +44,15 @@ private static final Logger LOGGER = LoggerFactory.getLogger(GCPDataCache.class)
 
     @Override
     public void touch(String key) {
-        // no-op
+        Blob blob = storage.get(this.bucketName, getBlobKey(key));
+        if (blob != null) {
+            try {
+                // metadata can be updated only by copying object to itself
+                blob.copyTo(this.bucketName, key);
+            } catch (StorageException exc) {
+                LOGGER.warn(String.format("Exception when touch object '%s' %s", key, exc.getReason()));
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
The root cause is long-running cache operation. While Extender is uploading cached files to google bucket - remote build can be completed and removed job directory. It leads to exception like "file not found".

* Move upload caching before build start.
* Implement cache entry touch for google bucket implementation.

Fixes #549 