### PR TITLE
Collect only files when Extender search for libraries.

### DIFF
--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -387,9 +387,9 @@ class Extender {
     private List<String> getFrameworks(File dir) {
         List<String> frameworks = new ArrayList<>();
         final String[] platformParts = this.platform.split("-");
-        frameworks.addAll(ExtenderUtil.collectFilesByName(new File(dir, "lib" + File.separator + this.platform), FRAMEWORK_RE)); // e.g. armv64-ios
+        frameworks.addAll(ExtenderUtil.collectDirsByName(new File(dir, "lib" + File.separator + this.platform), FRAMEWORK_RE)); // e.g. armv64-ios
         if (platformParts.length == 2) {
-            frameworks.addAll(ExtenderUtil.collectFilesByName(new File(dir, "lib" + File.separator + platformParts[1]), FRAMEWORK_RE)); // e.g. "ios"
+            frameworks.addAll(ExtenderUtil.collectDirsByName(new File(dir, "lib" + File.separator + platformParts[1]), FRAMEWORK_RE)); // e.g. "ios"
         }
         return frameworks;
     }
@@ -1420,6 +1420,7 @@ class Extender {
             String command = templateExecutor.execute(template, context);
 
             // WINE->clang transition pt2: Replace any redundant ".lib.lib"
+            LOGGER.info(command);
             command = command.replace(".lib.lib", ".lib").replace(".Lib.lib", ".lib").replace(".LIB.lib", ".lib");
 
             processExecutor.execute(command);

--- a/server/src/main/java/com/defold/extender/ExtenderUtil.java
+++ b/server/src/main/java/com/defold/extender/ExtenderUtil.java
@@ -588,6 +588,31 @@ public class ExtenderUtil
         if (dir.exists()) {
             File[] files = dir.listFiles();
             for (File f : files) {
+                if (f.isDirectory()) {
+                    continue;
+                }
+                Matcher m = p.matcher(f.getName());
+                if (m.matches()) {
+                    result.add(m.group(1));
+                }
+            }
+        }
+        Collections.sort(result);
+        return result;
+    }
+
+    static public List<String> collectDirsByName(File dir, String re) {
+        List<String> result = new ArrayList<>();
+        if (re == null) {
+            return result;
+        }
+        Pattern p = Pattern.compile(re);
+        if (dir.exists()) {
+            File[] files = dir.listFiles();
+            for (File f : files) {
+                if (f.isFile()) {
+                    continue;
+                }
                 Matcher m = p.matcher(f.getName());
                 if (m.matches()) {
                     result.add(m.group(1));
@@ -606,6 +631,9 @@ public class ExtenderUtil
         if (dir.exists()) {
             File[] files = dir.listFiles();
             for (File f : files) {
+                if (f.isDirectory()) {
+                    continue;
+                }
                 Matcher m = p.matcher(f.getName());
                 if (m.matches()) {
                     String name = m.group(1);
@@ -630,6 +658,9 @@ public class ExtenderUtil
         if (dir.exists()) {
             File[] files = dir.listFiles();
             for (File f : files) {
+                if (f.isDirectory()) {
+                    continue;
+                }
                 Matcher m = p.matcher(f.getAbsolutePath());
                 if (m.matches()) {
                     result.add(m.group(1));

--- a/server/src/test/java/com/defold/extender/ExtenderTest.java
+++ b/server/src/test/java/com/defold/extender/ExtenderTest.java
@@ -239,13 +239,18 @@ public class ExtenderTest {
     public void testCollectLibraries() {
         // The folder contains a library and a text file
         {
-            List<String> result = ExtenderUtil.collectFilesByName(new File("test-data/ext/lib/x86_64-osx"), "lib(.+).a");
+            List<String> result = ExtenderUtil.collectFilesByName(new File("test-data/ext/lib/x86_64-osx"), "lib(.+)\\.a");
             String[] expected = {"alib"};
             checkArray(expected, result);
         }
         {
-            List<String> result = ExtenderUtil.collectFilesByName(new File("test-data/ext/lib/x86_64-osx"), Extender.FRAMEWORK_RE);
+            List<String> result = ExtenderUtil.collectDirsByName(new File("test-data/ext/lib/x86_64-osx"), Extender.FRAMEWORK_RE);
             String[] expected = {"blib"};
+            checkArray(expected, result);
+        }
+        {
+            List<String> result = ExtenderUtil.collectFilesByName(new File("test-data/ext/lib/x86_64-win32"), "(.+)\\.lib");
+            String[] expected = {"alib"};
             checkArray(expected, result);
         }
     }

--- a/server/test-data/sdk/a/defoldsdk/extender/build.yml
+++ b/server/test-data/sdk/a/defoldsdk/extender/build.yml
@@ -108,7 +108,7 @@ platforms:
     stlibRe:        'lib(.+)\.a'
     writeLibPattern: 'lib%s.a'
     writeExePattern: 'dmengine'
-    sourceRe:       '(?i).*(.cpp|.c|.cc|.mm|.m)'
+    sourceRe:       '(?i).*(\.cpp|\.c|\.cc|\.mm|\.m)'
     allowedLibs:    ['lber','apr-1.0','AVFAudio','netsnmpmibs.25','bsm','form.5.4','tk','QMIParserDynamic','gmalloc','ncurses','heimdal-asn1','iodbcinst','krb5','tidy','curl.4','pmenergy','python2.7','icucore','ecpg','ATCommandStudioDynamic','dtrace_dyld','lzma.5','pcre.0','pgtypes.3.4','pq.5.6','pam.1','netsnmp.5','energytrace','sasl2.2.0.15','python2.6','germantok','cmph','ssh-keychain','xar.1','xml2','pcreposix.0','m','pam.2','apr-1','auto','alias','c++','ipconfig','Match','crypto.35','netsnmpmibs','cups','exslt.0','iodbcinst.2.1.18','pgtypes.3','mx.A','CRFSuite','cupsmime.1','aprutil-1.0','objc.A','edit','crypto.0.9.8','pmsample','des425','gcc_s.10.5','ruby.2.0','crypto.0.9.7','CRFSuite0.12','auditd.0','edit.2','pthread','ecpg.6.5','odfde','tcl8.5','z.1.1.3','netsnmp.5.2.1','cupsppdc.1','util','lapack','extension','ffi','System','iodbcinst.2','dns_services','pcreposix','mx','panel','ldap','readline','IASUnifiedProgress','edit.3','ssl.0.9.7','csfde','python','hunspell-1.2.0.0.0','netsnmp.25','charset.1.0.0','panel.5.4','gssapi_krb5','aprutil-1','cupsimage.2','BSDPClient.A','menu.5.4','info','spindump','marisa','dl','cupsimage','pq.5','com_err','auditd','UniversalAccess','sasl2.2.0.22','ecpg.6','blas','XSEvent','z','form','ktrace','krb5support','DiagnosticMessagesClient','c++abi','expat.1','System_debug','iodbc','tk8.5','Xplugin.1','pcap.A','curl.3','dbm','iconv','ssl','gcc_s.10.4','netsnmp.15.1.2','xar','menu','exslt','odmodule','alias.A','sasl2','charset','sasl2.2','ThaiTokenizer','tidy.A','archive','bz2.1.0.5','netsnmptrapd','ncurses.5.4','pcre','Fosl_dynamic','cblas','pq','System.B_debug','mecab','ipsec.A','ecpg_compat.3.5','f77lapack','cupsppdc','ipsec','netsnmphelpers.25','edit.3.0','tls','z.1.2.5','netsnmp.15','xslt','resolv','sasl2.2.0.1','iconv.2','ecpg_compat','netsnmpagent','krb524','OpenScriptingUtil','dtrace','cupsmime','bz2','AccountPolicyTranslation','netsnmpagent.25','expat','ssl.0.9.8','cups.2','netsnmphelpers','crypto','z.1','netsnmp','sandbox','CoreStorage','util1.0','DHCPServer.A','langid','Match.1','iodbc.2.1.18','xml2.2','quit','prequelite','stdc++.6.0.9','pcap','objc','ecpg_compat.3','ruby','ScreenReader','c++.1','tls.6','System.B','ChineseTokenizer','ssl.35','sqlite3','proc','BSDPClient','k5crypto','network','hunspell-1.2.0','cupscgi.1','sysmon','bz2.1.0','IASAuthReboot','ldap_r','c','termcap','ncurses.5','archive.2','cupscgi','bsm.0','lzma','iconv.2.4.0','xcselect','poll','sandbox.1','gcc_s.1','iodbc.2','curl','Xplugin','krb4','hunspell-1.2','stdc++','netsnmptrapd.25','rpcsvc','pam','clapack','tcl','mecabra','sasl2.2.0.21','resolv.9','compression','charset.1','icucore.A','pgtypes','DHCPServer','systemstats','TelephonyUtilDynamic','ruby.2.0.0','system_notify','system_c','system_secinit','system_dnssd','removefile','system_malloc','system_blocks','copyfile','xpc','mathCommon','unwind','system_platform','dyld','system_network','system_sandbox','dispatch','system_trace','system_info','keymgr','system_kernel','mathCommon.A','system_networkextension','system_coreservices','system_asl','unc','launch','system_coretls','dispatch','system_pthread','system_m','system_configuration','kxld','quarantine','corecrypto','macho','commonCrypto','system_pthread','compiler_rt','cache','sqlite3.0','stdc++.6','xslt.1','mecab.1.0.0','curses','Accelerate','Accounts','AddressBook','AGL','AppKit','AppKitScripting','AppleScriptKit','AppleScriptObjC','ApplicationServices','AudioToolbox','AudioUnit','AudioVideoBridging','Automator','AVFoundation','AVKit','CalendarStore','Carbon','CFNetwork','CloudKit','Cocoa','Collaboration','Contacts','ContactsUI','CoreAudio','CoreAudioKit','CoreBluetooth','CoreData','CoreFoundation','CoreGraphics','CoreImage','CoreLocation','CoreMedia','CoreMediaIO','CoreMIDI','CoreMIDIServer','CoreServices','CoreTelephony','CoreText','CoreVideo','CoreWLAN','CryptoTokenKit','DirectoryService','DiscRecording','DiscRecordingUI','DiskArbitration','DrawSprocket','DVComponentGlue','DVDPlayback','EventKit','ExceptionHandling','FinderSync','ForceFeedback','Foundation','FWAUserLib','GameController','GameKit','GameplayKit','GLKit','GLUT','GSS','Hypervisor','ICADevices','ImageCaptureCore','ImageIO','IMServicePlugIn','InputMethodKit','InstallerPlugins','InstantMessage','IOBluetooth','IOBluetoothUI','IOKit','IOSurface','JavaFrameEmbedding','JavaScriptCore','JavaVM','Kerberos','Kernel','LatentSemanticMapping','LDAP','LocalAuthentication','MapKit','MediaAccessibility','MediaLibrary','MediaToolbox','Message','Metal','MetalKit','ModelIO','MultipeerConnectivity','NetFS','NetworkExtension','NotificationCenter','OpenAL','OpenCL','OpenDirectory','OpenGL','OSAKit','PCSC','Photos','PhotosUI','PreferencePanes','PubSub','Python','QTKit','QuartzCore','Quartz','QuickLook','QuickTime','Ruby','SceneKit','ScreenSaver','ScriptingBridge','Scripting','SecurityFoundation','Security','SecurityInterface','ServiceManagement','Social','SpriteKit','StoreKit','SyncServices','SystemConfiguration','System','Tcl','Tk','TWAIN','vecLib','VideoDecodeAcceleration','VideoToolbox','vmnet','WebKit']
     allowedFlags:   ["-ObjC","-ObjC++","-Wa,{{comma_separated_arg}}","-W{{warning}}","-ansi","--ansi","-std-default={{arg}}","-stdlib=(libstdc\\+\\+|libc\\+\\+)","-w","-std=(c89|c99|c\\+\\+0x|c\\+\\+11|c\\+\\+14|c\\+\\+17|c\\+\\+20)","-Wp,{{comma_separated_arg}}","-W{{warning}}","--extra-warnings","--warn-{{warning}}","--warn-={{warning}}","-ferror-limit={{number}}","-O([0-4]?|fast|s|z)"]
     compileCmd:     'clang++ -c -arch x86_64 -target x86_64-apple-darwin19 -isysroot {{env.SYSROOT}} -nostdinc++ {{#systemIncludes}}-isystem {{{.}}} {{/systemIncludes}} -stdlib=libc++ -m64 -O2 -g -mmacosx-version-min={{env.MACOS_VERSION_MIN}} {{#defines}}-D{{{.}}} {{/defines}} {{#flags}}{{{.}}} {{/flags}} {{#ext.includes}}-I{{{.}}} {{/ext.includes}} {{#ext.frameworkPaths}}-F{{{.}}} {{/ext.frameworkPaths}} {{#includes}}-I{{{.}}} {{/includes}} {{src}} -o{{tgt}}'
@@ -142,8 +142,8 @@ platforms:
 
     exePrefix: 'lib'
     exeExt: '.so'
-    shlibRe: 'lib(.+).so'
-    stlibRe: 'lib(.+).a'
+    shlibRe: 'lib(.+)\.so'
+    stlibRe: 'lib(.+)\.a'
     sourceRe: '(?i).+(\.cpp|\.c|\.cc|\.cxx|\.c\+\+)$'
     javaSourceRe: '(?i).+(\.java)$'
     writeLibPattern: 'lib%s.a'
@@ -183,8 +183,8 @@ platforms:
 
     exePrefix:      ''
     exeExt:         '.js'
-    shlibRe:        'lib(.+).so'
-    stlibRe:        'lib(.+).a'
+    shlibRe:        'lib(.+)\.so'
+    stlibRe:        'lib(.+)\.a'
     sourceRe:       '(?i).*(\.cpp|\.c|\.cc|\.cxx|\.c\+\+)'
     writeLibPattern: 'lib%s.a'
     writeExePattern: 'dmengine.js'
@@ -217,8 +217,8 @@ platforms:
 
     exePrefix:      ''
     exeExt:         '.js'
-    shlibRe:        'lib(.+).so'
-    stlibRe:        'lib(.+).a'
+    shlibRe:        'lib(.+)\.so'
+    stlibRe:        'lib(.+)\.a'
     sourceRe:       '(?i).*(\.cpp|\.c|\.cc|\.cxx|\.c\+\+)'
     writeLibPattern: 'lib%s.a'
     writeExePattern: 'dmengine.js'
@@ -252,8 +252,8 @@ platforms:
 
     exePrefix:      ''
     exeExt:         '.exe'
-    shlibRe:        '(.+).dll'
-    stlibRe:        '(.+).lib'
+    shlibRe:        '(.+)\.dll'
+    stlibRe:        '(.+)\.lib'
     sourceRe:       '(?i).*(\.cpp|\.c|\.cc|\.cxx|\.c\+\+)'
     writeLibPattern: '%s.lib'
     writeExePattern: 'dmengine.exe'
@@ -287,8 +287,8 @@ platforms:
 
     exePrefix:      ''
     exeExt:         '.exe'
-    shlibRe:        '(.+).dll'
-    stlibRe:        '(.+).lib'
+    shlibRe:        '(.+)\.dll'
+    stlibRe:        '(.+)\.lib'
     sourceRe:       '(?i).*(\.cpp|\.c|\.cc|\.cxx|\.c\+\+)'
     writeLibPattern: '%s.lib'
     writeExePattern: 'dmengine.exe'
@@ -318,8 +318,8 @@ platforms:
 
     exePrefix:      ''
     exeExt:         ''
-    shlibRe:        'lib(.+).so'
-    stlibRe:        'lib(.+).a'
+    shlibRe:        'lib(.+)\.so'
+    stlibRe:        'lib(.+)\.a'
     sourceRe:       '(?i).*(\.cpp|\.c|\.cc|\.cxx|\.c\+\+)'
     writeLibPattern: 'lib%s.a'
     writeShLibPattern: 'lib%s.so'


### PR DESCRIPTION
Main part of the fix: https://github.com/defold/defold/pull/9756.

Added additional check if File is directory for case when we want collect only files. For collection osx/ios frameworks separate utility function was created because frameworks is directories.

Fixes #452 