### PR TITLE
Migrate server tests to JUnit5

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -41,6 +41,7 @@ targetCompatibility = '17'
 dependencyManagement {
     imports {
         mavenBom 'com.google.cloud:spring-cloud-gcp-dependencies:5.8.0'
+        mavenBom 'org.junit:junit-bom:5.11.4'
     }
 }
 
@@ -72,13 +73,22 @@ dependencies {
     implementation('io.micrometer:micrometer-tracing-bridge-otel:1.4.1')
     runtimeOnly('net.logstash.logback:logstash-logback-encoder:8.0')
     runtimeOnly('io.micrometer:micrometer-registry-influx:1.14.0')
-    runtimeOnly('io.micrometer:micrometer-registry-prometheus:1.13.2')
+    runtimeOnly('io.micrometer:micrometer-registry-prometheus:1.13.2') {
+        exclude group: 'org.junit.jupiter'
+    }
 
-    testImplementation('junit:junit:4.13.2')
+    testImplementation('org.junit.jupiter:junit-jupiter-engine')
+    testImplementation('org.junit.jupiter:junit-jupiter-params')
     testImplementation('org.springframework:spring-test')
-    testImplementation('org.springframework.boot:spring-boot-starter-test')
-    testImplementation('io.micrometer:micrometer-tracing-test')
-    testImplementation('io.micrometer:micrometer-tracing-integration-test')
+    testImplementation('org.springframework.boot:spring-boot-starter-test') {
+        exclude group: 'org.junit.jupiter'
+    }
+    testImplementation('io.micrometer:micrometer-tracing-test') {
+        exclude group: 'org.junit.jupiter'
+    }
+    testImplementation('io.micrometer:micrometer-tracing-integration-test') {
+        exclude group: 'org.junit.jupiter'
+    }
     testImplementation('org.springframework.security:spring-security-test')
 
     testImplementation('org.smali:dexlib2:2.5.2')
@@ -186,4 +196,8 @@ task buildStandalone() {
             into "build/standalone"
         }
     }
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/server/docker/docker-compose.yml
+++ b/server/docker/docker-compose.yml
@@ -211,19 +211,27 @@ services:
     extends:
       file: common-services.yml
       service: test_builder
-    command: ["--spring.config.location=classpath:./,file:/etc/defold/extender/", "--spring.profiles.active=local-dev-app", "--extender.authentication.platforms=linux", "--extender.authentication.users=file:/etc/defold/users/testusers.txt"]
+    command: ["--spring.config.location=classpath:./,file:/etc/defold/extender/", "--spring.profiles.active=local-dev-app", "--extender.authentication.platforms=linux", "--extender.authentication.users=file:/etc/defold/users/testusers.txt", "--server.port=9001"]
     volumes:
       - ./../users:/etc/defold/users:ro
     expose:
-      - "9000"
+      - "9001"
     ports:
-      - "9000:9000"
+      - "9001:9001"
     profiles:
       - auth-test
     networks:
       default:
         aliases:
           - frontend
+    # redefine helathcheck because of another port
+    # see the same configuration in common-services.yml
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:9001/actuator/health
+      interval: 10s
+      timeout: 2s
+      retries: 10
+      start_period: 5s
 # metrics
   grafana:
     image: grafana/grafana

--- a/server/src/test/java/com/defold/extender/ExtenderUtilTest.java
+++ b/server/src/test/java/com/defold/extender/ExtenderUtilTest.java
@@ -1,16 +1,22 @@
 package com.defold.extender;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.*;
-
-import static org.junit.Assert.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ExtenderUtilTest {
 
@@ -18,7 +24,7 @@ public class ExtenderUtilTest {
     private File uploadDir;
     private File buildDir;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         jobDir = Files.createTempDirectory("job123456").toFile();
         uploadDir = new File(jobDir, "upload");
@@ -27,7 +33,7 @@ public class ExtenderUtilTest {
         buildDir.mkdirs();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws IOException {
         if (jobDir != null) {
             FileUtils.deleteDirectory(jobDir);

--- a/server/src/test/java/com/defold/extender/ExtensionManifestValidatorTest.java
+++ b/server/src/test/java/com/defold/extender/ExtensionManifestValidatorTest.java
@@ -1,16 +1,25 @@
 package com.defold.extender;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.Yaml;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.*;
 
 public class ExtensionManifestValidatorTest {
 
@@ -84,15 +93,9 @@ public class ExtensionManifestValidatorTest {
         stringValues.add("./foo");
         context.put("libs", stringValues);
 
-        boolean thrown;
-        try {
-            thrown = false;
+        assertThrows(ExtenderException.class, () -> {
             validator.validate("test_extension", extensionFolder, context);
-        } catch (ExtenderException e) {
-            thrown = true;
-        }
-        assertTrue(thrown);
-
+        });
 
         // FLAGS
 
@@ -123,17 +126,10 @@ public class ExtensionManifestValidatorTest {
         stringValues.add("-Weverything; rm -rf");
         context.put("flags", stringValues);
 
-        try {
-            thrown = false;
+        ExtenderException exc = assertThrows(ExtenderException.class, () -> {
             validator.validate("test_extension", extensionFolder, context);
-        } catch (ExtenderException e) {
-            if (e.toString().contains("rm -rf")) {
-                thrown = true;
-            } else {
-                throw e;
-            }
-        }
-        assertTrue(thrown);
+        });
+        assertTrue(exc.toString().contains("rm -rf"));
     }
 
     @Test
@@ -150,28 +146,19 @@ public class ExtensionManifestValidatorTest {
         context.put("libs", l);
 
         File extensionFolder = new File("ext-folder");
-        boolean thrown = false;
-        try {
-            validator.validate("testExtension", extensionFolder, context);
-        } catch (ExtenderException e) {
-            thrown = true;
-            System.out.println(e.toString());
-        }
 
-        assertFalse(thrown);
+        assertDoesNotThrow(() -> {
+            validator.validate("testExtension", extensionFolder, context);
+        });
 
         l.add("../libfoobar.a");
         context.put("libs", l);
-        try {
+
+        ExtenderException exc = assertThrows(ExtenderException.class, () -> {
             validator.validate("testExtension", extensionFolder, context);
-        } catch (ExtenderException e) {
-            System.out.println(e.toString());
-            if (e.toString().contains("Invalid")) { // expected error
-                thrown = true;
-            } else {
-                throw e;
-            }
-        }
-        assertTrue(thrown);
+        });
+        String exceptionMessage = exc.toString();
+        assertTrue(exceptionMessage.contains("Invalid"));
+        System.out.println(exceptionMessage);
     }
 }

--- a/server/src/test/java/com/defold/extender/TemplateExecutorTest.java
+++ b/server/src/test/java/com/defold/extender/TemplateExecutorTest.java
@@ -1,9 +1,9 @@
 package com.defold.extender;
 
-import org.junit.Test;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/server/src/test/java/com/defold/extender/ZipUtilsTest.java
+++ b/server/src/test/java/com/defold/extender/ZipUtilsTest.java
@@ -1,6 +1,8 @@
 package com.defold.extender;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -11,9 +13,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
 
 public class ZipUtilsTest {
 

--- a/server/src/test/java/com/defold/extender/cache/CacheKeyGeneratorTest.java
+++ b/server/src/test/java/com/defold/extender/cache/CacheKeyGeneratorTest.java
@@ -1,13 +1,14 @@
 package com.defold.extender.cache;
 
-import org.junit.Test;
 import com.defold.extender.TestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 public class CacheKeyGeneratorTest {
 

--- a/server/src/test/java/com/defold/extender/cache/DummyDataCacheTest.java
+++ b/server/src/test/java/com/defold/extender/cache/DummyDataCacheTest.java
@@ -1,17 +1,18 @@
 package com.defold.extender.cache;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DummyDataCacheTest {
 
     private DataCache cache;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         cache = new DummyDataCache();
     }

--- a/server/src/test/java/com/defold/extender/cache/LocalDiskDataCacheTest.java
+++ b/server/src/test/java/com/defold/extender/cache/LocalDiskDataCacheTest.java
@@ -3,8 +3,13 @@ package com.defold.extender.cache;
 import com.defold.extender.TestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -14,14 +19,12 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.junit.Assert.*;
-
 public class LocalDiskDataCacheTest {
 
     private Path baseDirectory;
     private DataCache cache;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         baseDirectory = Files.createTempDirectory("diskCacheTest");
         baseDirectory.toFile().deleteOnExit();

--- a/server/src/test/java/com/defold/extender/cache/info/CacheInfoFileParserTest.java
+++ b/server/src/test/java/com/defold/extender/cache/info/CacheInfoFileParserTest.java
@@ -2,13 +2,14 @@ package com.defold.extender.cache.info;
 
 import com.defold.extender.cache.CacheEntry;
 import com.defold.extender.TestUtils;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 public class CacheInfoFileParserTest {
 
@@ -59,8 +60,6 @@ public class CacheInfoFileParserTest {
         File file = new File(ClassLoader.getSystemResource("upload/old-ne-cache-info.json").toURI());
 
         CacheInfoWrapper info = parser.parse(file);
-        List<CacheEntry> entries = info.getEntries();
-
         assertEquals(0, info.getVersion());
         assertEquals(null, info.getHashType());
     }

--- a/server/src/test/java/com/defold/extender/cache/info/CacheInfoFileWriterTest.java
+++ b/server/src/test/java/com/defold/extender/cache/info/CacheInfoFileWriterTest.java
@@ -1,13 +1,14 @@
 package com.defold.extender.cache.info;
 
 import com.defold.extender.cache.CacheEntry;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 public class CacheInfoFileWriterTest {
 

--- a/server/src/test/java/com/defold/extender/remote/RemoteEngineBuilderTest.java
+++ b/server/src/test/java/com/defold/extender/remote/RemoteEngineBuilderTest.java
@@ -7,15 +7,16 @@ import org.apache.http.StatusLine;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.message.BasicHttpResponse;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Optional;
 import java.io.ByteArrayOutputStream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -28,7 +29,7 @@ public class RemoteEngineBuilderTest {
     private RemoteEngineBuilder remoteEngineBuilder;
     final RemoteInstanceConfig remoteBuilderConfig = new RemoteInstanceConfig("https://test.darwin-build.defold.com", "osx-latest", true);
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         final HttpEntity httpEntity = mock(HttpEntity.class);
 
@@ -61,7 +62,7 @@ public class RemoteEngineBuilderTest {
         assertEquals(content, new String(bytes));
     }
 
-    @Test(expected = RemoteBuildException.class)
+    @Test
     public void buildShouldThrowException() throws IOException, ExtenderException {
         final File directory = mock(File.class);
         final String content = "Internal server error";
@@ -80,6 +81,9 @@ public class RemoteEngineBuilderTest {
                 .sendRequest(anyString(), anyString(), anyString(), any(HttpEntity.class));
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        remoteEngineBuilder.build(remoteBuilderConfig, directory, "armv7-ios", "a6876bc5s", baos);
+        assertThrows(RemoteBuildException.class, () -> {
+            remoteEngineBuilder.build(remoteBuilderConfig, directory, "armv7-ios", "a6876bc5s", baos);
+        });
+        
     }
 }

--- a/server/src/test/java/com/defold/extender/services/CocoaPodsServiceTest.java
+++ b/server/src/test/java/com/defold/extender/services/CocoaPodsServiceTest.java
@@ -1,15 +1,16 @@
 package com.defold.extender.services;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 
 public class CocoaPodsServiceTest {
     private File emptyPodfile;
@@ -18,7 +19,7 @@ public class CocoaPodsServiceTest {
     private File wrongPodfile;
 
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.emptyPodfile = new File("test-data/podfiles/empty.Podfile");
         this.regularPodfile = new File("test-data/podfiles/regular.Podfile");

--- a/server/src/test/java/com/defold/extender/services/DefoldSDKServiceTest.java
+++ b/server/src/test/java/com/defold/extender/services/DefoldSDKServiceTest.java
@@ -2,8 +2,6 @@ package com.defold.extender.services;
 
 import com.defold.extender.ExtenderException;
 
-import org.junit.Ignore;
-import org.junit.Test;
 import io.micrometer.core.instrument.MeterRegistry;
 
 import java.io.File;
@@ -14,15 +12,18 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class DefoldSDKServiceTest {
 
     @Test
-    @Ignore("SDK too large to download on every test round.")
+    @Disabled("SDK too large to download on every test round.")
     public void t() throws IOException, URISyntaxException, ExtenderException {
         DefoldSdkService defoldSdkService = new DefoldSdkService("/tmp/defoldsdk", 3, true, mock(MeterRegistry.class));
         File sdk = defoldSdkService.getSdk("f7778a8f59ef2a8dda5d445f471368e8bd1cb1ac");
@@ -30,7 +31,7 @@ public class DefoldSDKServiceTest {
     }
 
     @Test
-    @Ignore("SDK too large to download on every test round.")
+    @Disabled("SDK too large to download on every test round.")
     public void onlyStoreTheNewest() throws IOException, URISyntaxException, ExtenderException {
         int cacheSize = 3;
         DefoldSdkService defoldSdkService = new DefoldSdkService("/tmp/defoldsdk", cacheSize, true, mock(MeterRegistry.class));

--- a/server/src/test/resources/junit-platform.properties
+++ b/server/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent


### PR DESCRIPTION
* Migrated test classes to JUnit5.
* Made changes to docker compose to eliminate collision between `AuthentificationTest` and `IntegrationTest`. Now two sets of docker containers can be run in parallel.
* Avoid shared resources between test cases (shared folders, etc.)

For local execution 
```
./gradlew :server:test --info
```
on my Mac (Apple M3 Pro, 36 GB) 
took
|Single thread|Parallel|Diff|
|-------------|-------|----|
|56m 12s       |16m 6s|-71.35%|

Fixes #565 
