### PR TITLE
Fix concurrency issues with DefoldSdkService

### DIFF
--- a/server/docker/common-services.yml
+++ b/server/docker/common-services.yml
@@ -4,7 +4,6 @@ services:
     volumes:
       - ./../app/:/app/:ro
       - ./../configs:/etc/defold/extender:ro
-      - ./../test-data/sdk:/var/extender/sdk
     entrypoint: ["java","-Xmx4g","-XX:MaxDirectMemorySize=2g","-jar","/app/extender.jar"]
     user: extender
     environment:

--- a/server/scripts/start-test-server.sh
+++ b/server/scripts/start-test-server.sh
@@ -87,6 +87,13 @@ for (( i=1; i<=$max_retries; i++ )); do
 
   if check_containers_health; then
     echo "All containers are healthy!"
+    CREATED_SERVICES=$(docker compose -p $APPLICATION ps -a --services)
+    for service in $CREATED_SERVICES; do
+      echo "Copy test sdk to $service"
+      docker compose -p $APPLICATION cp "${DIR}/../test-data/sdk/a" "$service:/var/extender/sdk"
+      docker compose -p $APPLICATION exec -u root $service chown -R extender:extender /var/extender/sdk/a
+    done
+
     exit 0
   else
     echo "Some containers are not healthy yet. Retrying in $retry_interval seconds..."

--- a/server/scripts/stop-test-server.sh
+++ b/server/scripts/stop-test-server.sh
@@ -4,20 +4,8 @@ if [ "$APPLICATION" == "" ]; then
 	APPLICATION="extender-test"
 fi
 
-# echo "stop-test-server.sh: Output log result for ${CONTAINER}:"
-
-# docker logs ${CONTAINER}
-
 echo "stop-test-server.sh: Stopping ${APPLICATION}:"
 
 docker compose -p $APPLICATION down
-# docker stop ${CONTAINER}
-
-# echo "stop-test-server.sh: Checking if ${CONTAINER} is still running:"
-
-# while [ "$(docker inspect -f '{{.State.Running}}' ${CONTAINER})" = "true" ]; do
-#     echo "Test server ${CONTAINER} is still running..."
-#     sleep 1
-# done
 
 echo "stop-test-server.sh: Test server ${APPLICATION} exited"

--- a/server/src/main/java/com/defold/extender/ProcessExecutor.java
+++ b/server/src/main/java/com/defold/extender/ProcessExecutor.java
@@ -81,9 +81,10 @@ public class ProcessExecutor {
     }
 
     public void writeLog(File file) throws IOException {
-        FileOutputStream os = new FileOutputStream(file);
-        byte[] strToBytes = getOutput().getBytes();
-        os.write(strToBytes);
+        try (FileOutputStream os = new FileOutputStream(file)) {
+            byte[] strToBytes = getOutput().getBytes();
+            os.write(strToBytes);
+        }
     }
 
     public void putEnv(String key, String value) {

--- a/server/src/main/java/com/defold/extender/services/DefoldSdkService.java
+++ b/server/src/main/java/com/defold/extender/services/DefoldSdkService.java
@@ -108,9 +108,6 @@ public class DefoldSdkService {
             if (sdk == null) {
                 throw new ExtenderException(String.format("The given sdk does not exist: %s", hash));
             }
-            if (!sdk.isValid()) {
-                throw new ExtenderException(String.format("The given sdk still does not exist: %s", hash));
-            }
             evictCache();
             LOGGER.info("Using Defold SDK version {}", hash);
             return DefoldSdk.copyOf(sdk);

--- a/server/src/main/java/com/defold/extender/services/DefoldSdkService.java
+++ b/server/src/main/java/com/defold/extender/services/DefoldSdkService.java
@@ -4,6 +4,8 @@ import com.defold.extender.ExtenderException;
 import com.defold.extender.ZipUtils;
 import com.defold.extender.log.Markers;
 import com.defold.extender.metrics.MetricsWriter;
+import com.defold.extender.services.data.DefoldSdk;
+
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +23,7 @@ import jakarta.annotation.PreDestroy;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -28,6 +31,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Comparator;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 
 @Service
 public class DefoldSdkService {
@@ -60,8 +66,8 @@ public class DefoldSdkService {
     private final boolean cacheClearOnExit;
 
     private final MeterRegistry meterRegistry;
-    // private final Counter counterSdkGet;
-    // private final Counter counterSdkGetDownload;
+    private final ConcurrentHashMap<String, CompletableFuture<DefoldSdk>> operationCache = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Integer> cacheReferenceCount;
 
     DefoldSdkService(@Value("${extender.sdk.location}") String baseSdkDirectory,
                      @Value("${extender.sdk.cache-size}") int cacheSize,
@@ -71,33 +77,14 @@ public class DefoldSdkService {
         this.cacheSize = cacheSize;
         this.meterRegistry = meterRegistry;
         this.cacheClearOnExit = cacheClearOnExit;
-        // this.counterSdkGet = gaugeService.counter("counter.service.sdk.get");
-        // this.counterSdkGetDownload = gaugeService.counter("counter.service.sdk.get.download");
 
         this.dynamoHome = System.getenv("DYNAMO_HOME") != null ? new File(System.getenv("DYNAMO_HOME")) : null;
+        this.cacheReferenceCount = new ConcurrentHashMap<>(this.cacheSize + 10);
 
         LOGGER.info("SDK service using directory {} with cache size {}", baseSdkDirectory, cacheSize);
 
         if (!Files.exists(this.baseSdkDirectory)) {
             Files.createDirectories(this.baseSdkDirectory);
-        }
-    }
-
-    // Helper function to move the SDK directories
-    public static void Move(Path source, Path target) {
-        try {
-            Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
-        } catch (IOException e) {
-            // If the target path suddenly exists, and the source path still exists,
-            // then we failed with the atomic move, and we assume another job succeeded with the download
-            if (Files.exists(source) && Files.exists(target)) {
-                LOGGER.info("Defold SDK version {} was downloaded by another job in the meantime", source.toString());
-                try {
-                    FileUtils.deleteDirectory(source.toFile());
-                } catch (IOException e2) {
-                    LOGGER.error(Markers.SERVER_ERROR, "Failed to delete temp sdk directory {}: {}", source.toString(), e2.getMessage());
-                }
-            }
         }
     }
 
@@ -109,26 +96,45 @@ public class DefoldSdkService {
         return sdkVersion == null || LOCAL_VERSION.equals(sdkVersion) || System.getenv("DYNAMO_HOME") != null;
     }
 
-    public File getSdk(String hash) throws IOException, URISyntaxException, ExtenderException {
-        return isLocalSdk(hash) ? getLocalSdk() : getRemoteSdk(hash);
+    public DefoldSdk getSdk(String hash) throws ExtenderException {
+        if (isLocalSdk(hash)){
+            return getLocalSdk();
+        }
+        // use ConcurrentHashMap with CompletableFuture here to avoid situation when
+        // several builds needs the same defoldsdk which doesn't exist locally. So one build job starts downloading,
+        // all other jobs wait for download complete and all of then continue running.
+        CompletableFuture<DefoldSdk> operation = operationCache.computeIfAbsent(hash, this::getRemoteSdk);
+        try (DefoldSdk sdk = operation.get()){
+            if (sdk == null) {
+                throw new ExtenderException(String.format("The given sdk does not exist: %s", hash));
+            }
+            if (!sdk.isValid()) {
+                throw new ExtenderException(String.format("The given sdk still does not exist: %s", hash));
+            }
+            evictCache();
+            LOGGER.info("Using Defold SDK version {}", hash);
+            return DefoldSdk.copyOf(sdk);
+        } catch (InterruptedException | ExecutionException e) {
+            LOGGER.error(String.format("The given sdk cannot be downloaded: %s", hash), e);
+            throw new ExtenderException(String.format("The given sdk cannot be downloaded: %s", hash));
+        } finally {
+            operationCache.remove(hash);
+        }
     }
 
-    public File getRemoteSdk(String hash) throws IOException, URISyntaxException, ExtenderException {
-        long methodStart = System.currentTimeMillis();
-
-        // Define SDK directory for this version
-        File sdkDirectory = new File(baseSdkDirectory.toFile(), hash);
-
-        // If directory does not exist, create it and download SDK
-        if (!Files.exists(sdkDirectory.toPath())) {
-            File lockFile = new File(baseSdkDirectory.toFile(), "tmp" + hash + ".lock");
-
-            if (lockFile.createNewFile()) { // atomic creation of lock file
-                try {
-                    boolean sdkFound = false;
-                    for (String url_pattern : REMOTE_SDK_URL_PATTERNS) {
-
-                        URL url = new URL(String.format(url_pattern, hash));
+    public CompletableFuture<DefoldSdk> getRemoteSdk(String hash) {
+        return CompletableFuture.supplyAsync(() -> {
+            long methodStart = System.currentTimeMillis();
+            // Define SDK directory for this version
+            File sdkDirectory = new File(baseSdkDirectory.toFile(), hash);
+            File sdkRootDirectory = new File(sdkDirectory, "defoldsdk");
+            DefoldSdk sdk = new DefoldSdk(sdkRootDirectory, hash, this);
+            // If directory does not exist, create it and download SDK
+            if (!Files.exists(sdkDirectory.toPath())) {
+                boolean sdkFound = false;
+                for (String url_pattern : REMOTE_SDK_URL_PATTERNS) {
+                    try {
+                        URL url = URI.create(String.format(url_pattern, hash)).toURL();
 
                         ClientHttpRequestFactory clientHttpRequestFactory = new SimpleClientHttpRequestFactory();
                         ClientHttpRequest request = clientHttpRequestFactory.createRequest(url.toURI(), HttpMethod.GET);
@@ -148,73 +154,67 @@ public class DefoldSdkService {
                             InputStream body = response.getBody();
                             ZipUtils.unzip(body, tmpSdkDirectory.toPath());
 
-                            Move(tmpSdkDirectory.toPath(), sdkDirectory.toPath());
-
+                            Files.move(tmpSdkDirectory.toPath(), sdkDirectory.toPath(), StandardCopyOption.ATOMIC_MOVE);
                             sdkFound = true;
                             break;
                         }
-                    }
-
-                    if (!sdkFound) {
-                        throw new ExtenderException(String.format("The given sdk does not exist: %s", hash));
-                    }
-
-                    // Delete old SDK:s
-                    Comparator<Path> lastModifiedComparator = Comparator.comparing(path -> path.toFile().lastModified());
-
-                    Files
-                            .list(baseSdkDirectory)
-                            .filter(path -> !path.getFileName().toString().startsWith("tmp"))
-                            .sorted(lastModifiedComparator.reversed())
-                            .skip(cacheSize)
-                            .forEach(this::deleteCachedSdk);
-
-                    //counterSdkGetDownload.increment();
-                    MetricsWriter.metricsCounterIncrement(meterRegistry, "extender.service.sdk.get.download", "sdk", hash);
-                } finally {
-                    lockFile.delete();
-                }
-            } else {
-                LOGGER.info("Waiting for Defold SDK version {} to download ...", hash);
-                // We have to wait for the lock file to disappear
-                int seconds = 120; // Downloading an sdk takes ~30-50 seconds
-                while (Files.exists(lockFile.toPath()) && seconds > 0) {
-                    int step = 2;
-                    seconds -= step;
-                    try {
-                        Thread.sleep(step * 1000);
-                    } catch (InterruptedException e) {
-                        // pass
+                    } catch (IOException|URISyntaxException exc) {
+                        LOGGER.error("Error downloading defoldsdk", exc);
                     }
                 }
 
-                // Now check again that the SDK was downloaded
-                if (!Files.exists(sdkDirectory.toPath())) {
-                    throw new ExtenderException(String.format("The given sdk still does not exist: %s", hash));
+                if (!sdkFound) {
+                    sdk.close();
+                    return null;
                 }
+
+                MetricsWriter.metricsCounterIncrement(meterRegistry, "extender.service.sdk.get.download", "sdk", hash);
             }
-        }
-
-        LOGGER.info("Using Defold SDK version {}", hash);
-
-        MetricsWriter.metricsTimer(meterRegistry, "extender.service.sdk.get.duration", System.currentTimeMillis() - methodStart, "sdk", hash);
-
-        return new File(sdkDirectory, "defoldsdk");
+            MetricsWriter.metricsTimer(meterRegistry, "extender.service.sdk.get.duration", System.currentTimeMillis() - methodStart, "sdk", hash);
+            return sdk;
+        });
     }
 
-    public File getLocalSdk() {
+    public DefoldSdk getLocalSdk() {
         LOGGER.info("Using local Defold SDK at {}", dynamoHome.toString());
-        return dynamoHome;
+        return new DefoldSdk(dynamoHome, LOCAL_VERSION, this);
     }
 
     public boolean isLocalSdkSupported() {
         return dynamoHome != null;
     }
 
+    protected void evictCache() {
+        synchronized (cacheReferenceCount) {
+            try {
+                LOGGER.info("Cache eviction called");
+                // Delete old SDK:s
+                Comparator<Path> refCountComparator = Comparator.comparing(path -> getSdkRefCount(path.getFileName().toString()));
+
+                Files
+                        .list(baseSdkDirectory)
+                        .filter(path -> !path.getFileName().toString().startsWith("tmp")
+                                    && !path.toString().endsWith(".delete")
+                                    && !path.getFileName().toString().equals(TEST_SDK_DIRECTORY))
+                        .sorted(refCountComparator.reversed())
+                        .skip(cacheSize)
+                        .forEach(this::deleteCachedSdk);
+            } catch (IOException exc) {
+                LOGGER.error("Error during cache eviction", exc);
+            }
+        }
+    }
+
     private void deleteCachedSdk(Path path) {
+        String sdkHash = path.getFileName().toString();
+        if (getSdkRefCount(sdkHash) != 0) {
+            LOGGER.warn(String.format("Sdk %s remove skipped due to non-zero ref count", sdkHash));
+            return;
+        }
         try {
+            LOGGER.info(String.format("Cleanup sdk %s", path));
             File tmpDir = new File(path.toString() + ".delete");
-            Move(path, tmpDir.toPath());
+            Files.move(path, tmpDir.toPath(), StandardCopyOption.ATOMIC_MOVE);
             FileUtils.deleteDirectory(tmpDir);
         } catch (IOException e) {
             LOGGER.error(Markers.CACHE_ERROR, "Failed to delete cached SDK at " + path.toAbsolutePath().toString(), e);
@@ -222,7 +222,6 @@ public class DefoldSdkService {
     }
 
     @PreDestroy
-    @SuppressWarnings("unused")
     public void destroy() {
         if (!this.cacheClearOnExit) {
             LOGGER.info("Skipping cleanup of SDK cache");
@@ -239,12 +238,12 @@ public class DefoldSdkService {
     }
 
     private String getLocalPlatformSdkMappings(String hash) throws IOException {
-        return new String(Files.readAllBytes(Path.of(getLocalSdk().getAbsolutePath(), "platform.sdks.json")), StandardCharsets.UTF_8);
+        return new String(Files.readAllBytes(Path.of(getLocalSdk().toFile().getAbsolutePath(), "platform.sdks.json")), StandardCharsets.UTF_8);
     }
 
     private String getRemotePlatformSdkMappings(String hash) throws IOException, URISyntaxException, ExtenderException {
         for (String url_pattern : REMOTE_MAPPINGS_URL_PATTERNS) {
-            URL url = new URL(String.format(url_pattern, hash));
+            URL url = URI.create(String.format(url_pattern, hash)).toURL();
 
             ClientHttpRequestFactory clientHttpRequestFactory = new SimpleClientHttpRequestFactory();
             ClientHttpRequest request = clientHttpRequestFactory.createRequest(url.toURI(), HttpMethod.GET);
@@ -266,5 +265,19 @@ public class DefoldSdkService {
 
     public String getPlatformSdkMappings(String hash) throws IOException, URISyntaxException, ExtenderException {
         return isLocalSdk(hash) ? getLocalPlatformSdkMappings(hash) : getRemotePlatformSdkMappings(hash);
+    }
+
+    public void acquireSdk(String hash) {
+        LOGGER.info(String.format("Acquire sdk %s", hash));
+        cacheReferenceCount.compute(hash, ( key, value) -> value == null ? 1 : value + 1);
+    }
+
+    public void releaseSdk(String hash) {
+        LOGGER.info(String.format("Release sdk %s", hash));
+        cacheReferenceCount.compute(hash, (key, value) -> value - 1);
+    }
+
+    public Integer getSdkRefCount(String hash) {
+        return cacheReferenceCount.getOrDefault(hash, 0);
     }
 }

--- a/server/src/main/java/com/defold/extender/services/data/DefoldSdk.java
+++ b/server/src/main/java/com/defold/extender/services/data/DefoldSdk.java
@@ -1,0 +1,52 @@
+package com.defold.extender.services.data;
+
+import java.io.File;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.defold.extender.services.DefoldSdkService;
+
+public class DefoldSdk implements AutoCloseable {
+    private File sdkDir;
+    private String sdkHash;
+    private DefoldSdkService sdkService;
+    private AtomicBoolean isUsed = new AtomicBoolean(true);
+
+    public DefoldSdk(File sdkDir, String sdkHash, DefoldSdkService sdkService) {
+        this.sdkDir = sdkDir;
+        this.sdkHash = sdkHash;
+        this.sdkService = sdkService;
+
+        this.sdkService.acquireSdk(sdkHash);
+    }
+
+    public static DefoldSdk copyOf(DefoldSdk sdk) {
+        return new DefoldSdk(sdk.sdkDir, sdk.sdkHash, sdk.sdkService);
+    }
+
+    public boolean isValid() {
+        return this.sdkDir != null && this.sdkDir.exists();
+    }
+
+    public File toFile() {
+        return this.sdkDir;
+    }
+
+    public String getHash() {
+        return this.sdkHash;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Sdk %s at %s", this.sdkHash, this.sdkDir.toString());
+    }
+
+    @Override
+    public void close() {
+        synchronized (this.isUsed) {
+            if (this.isUsed.get()) {
+                this.sdkService.releaseSdk(this.sdkHash);
+                this.isUsed.set(false);
+            }
+        }
+    }
+}

--- a/server/src/test/java/com/defold/extender/services/DefoldSDKServiceTest.java
+++ b/server/src/test/java/com/defold/extender/services/DefoldSDKServiceTest.java
@@ -1,40 +1,63 @@
 package com.defold.extender.services;
 
 import com.defold.extender.ExtenderException;
+import com.defold.extender.services.data.DefoldSdk;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class DefoldSDKServiceTest {
+    private static final String folderPath = "/tmp/defoldsdk";
 
-    @Test
-    @Disabled("SDK too large to download on every test round.")
-    public void t() throws IOException, URISyntaxException, ExtenderException {
-        DefoldSdkService defoldSdkService = new DefoldSdkService("/tmp/defoldsdk", 3, true, mock(MeterRegistry.class));
-        File sdk = defoldSdkService.getSdk("f7778a8f59ef2a8dda5d445f471368e8bd1cb1ac");
-        System.out.println(sdk.getCanonicalFile());
+    @BeforeAll
+    public static void beforeAll() throws IOException {
+        Files.createDirectories(Path.of(folderPath));
+    }
+
+    @AfterAll
+    public static void afterAll() throws IOException {
+        FileUtils.deleteDirectory(new File(folderPath));
     }
 
     @Test
     @Disabled("SDK too large to download on every test round.")
-    public void onlyStoreTheNewest() throws IOException, URISyntaxException, ExtenderException {
+    public void t() throws IOException, ExtenderException {
+        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, 3, true, mock(MeterRegistry.class));
+        DefoldSdk sdk = defoldSdkService.getSdk("f7778a8f59ef2a8dda5d445f471368e8bd1cb1ac");
+        System.out.println(sdk.toFile().getCanonicalFile());
+    }
+
+    @Test
+    @Disabled("SDK too large to download on every test round.")
+    public void onlyStoreTheNewest() throws IOException, ExtenderException {
         int cacheSize = 3;
-        DefoldSdkService defoldSdkService = new DefoldSdkService("/tmp/defoldsdk", cacheSize, true, mock(MeterRegistry.class));
+        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, cacheSize, true, mock(MeterRegistry.class));
 
         String[] sdksToDownload = {
                 "fe2b689302e79b7cf8c0bc7d934f23587b268c8a",
@@ -48,7 +71,7 @@ public class DefoldSDKServiceTest {
             defoldSdkService.getSdk(sdkHash);
         }
 
-        List<String> collect = Files.list(Paths.get("/tmp/defoldsdk")).map(path -> path.toFile().getName()).collect(Collectors.toList());
+        List<String> collect = Files.list(Paths.get(folderPath)).map(path -> path.toFile().getName()).collect(Collectors.toList());
 
         assertEquals(cacheSize, collect.size());
         assertTrue(collect.contains("e41438cca6cc1550d4a0131b8fc3858c2a4097f1"));
@@ -57,20 +80,86 @@ public class DefoldSDKServiceTest {
     }
 
     @Test
-    public void testGetSDK() throws IOException, URISyntaxException, ExtenderException {
-        DefoldSdkService defoldSdkService = new DefoldSdkService("/tmp/defoldsdk", 3, true, mock(MeterRegistry.class));
+    public void testGetSDK() throws IOException, ExtenderException {
+        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, 3, true, mock(MeterRegistry.class));
 
         File dir = new File("/tmp/defoldsdk/notexist");
         assertFalse(Files.exists(dir.toPath()));
 
-        {
-            boolean thrown = false;
-            try {
-                defoldSdkService.getSdk("notexist");
-            } catch (ExtenderException e) {
-                thrown = true;
-            }
-            assertTrue(thrown);
+        assertThrows(ExtenderException.class, () -> defoldSdkService.getSdk("notexist"));
+    }
+
+    @Test
+    public void testGetSDKRefCount() throws IOException, ExtenderException, InterruptedException {
+        final String testSdk = "11d2cd3a9be17b2fc5a2cb5cea59bbfb4af1ca96";
+        final int expectedRefCount = 3;
+        List<DefoldSdk> sdks = new ArrayList<>();
+        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, 0, true, new SimpleMeterRegistry());
+
+        // check when several threads request one sdk and that sdk need to be downloaded
+        ExecutorService service = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(expectedRefCount);
+        for (int i = 0; i < expectedRefCount; ++i) {
+            service.submit(() -> {
+                try {
+                    sdks.add(defoldSdkService.getSdk(testSdk));
+                } catch (ExtenderException e) {
+                    e.printStackTrace();
+                }
+                latch.countDown();
+            });
         }
+        latch.await();
+        assertEquals(expectedRefCount, defoldSdkService.getSdkRefCount(testSdk));
+
+        // check acquisition with several thread already downloaded sdk
+        CountDownLatch latch2 = new CountDownLatch(expectedRefCount);
+        for (int i = 0; i < expectedRefCount; ++i) {
+            service.submit(() -> {
+                try {
+                    sdks.add(defoldSdkService.getSdk(testSdk));
+                } catch (ExtenderException e) {
+                    e.printStackTrace();
+                }
+                latch2.countDown();
+            });
+        }
+        latch2.await();
+        assertEquals(expectedRefCount * 2, defoldSdkService.getSdkRefCount(testSdk));
+        // check acquisition in sequence
+        for (int i = 0; i < expectedRefCount; ++i) {
+            sdks.add(defoldSdkService.getSdk(testSdk));
+        }
+        assertEquals(expectedRefCount * 3, defoldSdkService.getSdkRefCount(testSdk));
+        for (int i = 0; i < expectedRefCount * 3; ++i) {
+            sdks.get(i).close();
+        }
+        assertEquals(0, defoldSdkService.getSdkRefCount(testSdk));
+
+        try (DefoldSdk sdk = defoldSdkService.getSdk(testSdk)) {
+            throw new Exception("Something happened");
+        } catch (Exception exc) {}
+
+        assertEquals(0, defoldSdkService.getSdkRefCount(testSdk));
+        try (DefoldSdk sdk = defoldSdkService.getSdk(testSdk)) {
+            System.out.println("Normal return from scoped resource");
+        }
+
+        assertEquals(0, defoldSdkService.getSdkRefCount(testSdk));
+
+        defoldSdkService.evictCache();
+        assertFalse(new File("/tmp/defoldsdk", testSdk).exists());
+    }
+
+    @Test
+    public void testSdkCorrectPath() throws IOException, ExtenderException {
+        final String testSdk = "11d2cd3a9be17b2fc5a2cb5cea59bbfb4af1ca96";
+        DefoldSdkService defoldSdkService = new DefoldSdkService("/tmp/defoldsdk_test", 0, true, new SimpleMeterRegistry());
+        try (DefoldSdk sdk = defoldSdkService.getSdk(testSdk)) {
+            assertTrue(new File(String.format("%s/extender/build.yml", sdk.toFile().getAbsolutePath())).exists());
+        }
+
+        defoldSdkService.evictCache();
+        assertFalse(new File("/tmp/defoldsdk_test", testSdk).exists());
     }
 }


### PR DESCRIPTION
PR fixed various issues that poped-up after enable parallel tests execution. All issues were related to how Extender works with defold sdk.
Following issues were resolved:
1. Shared host folder with defold sdks for docker containers that used for testing.
2. Only one task for downloading scheduled when concurrent build job requests the same sdk that doesn't exist at the filesystem.
3. Fix issue with premature defold sdk folder cleanup when one or more build job that used that sdk are in progress.

More comments see in the code.

Fixes #375 

P.S. During local testing a couple of times I faced issue with process start (gradle/compiler/linker). Let's see how it goes when tests runs on CI.