### PR TITLE
Update deprecated methods in WebSecurity

### DIFF
--- a/server/src/main/java/com/defold/extender/WebSecurityConfig.java
+++ b/server/src/main/java/com/defold/extender/WebSecurityConfig.java
@@ -19,57 +19,57 @@ public class WebSecurityConfig {
 
 	private InMemoryUserDetailsManager userDetailsManager = new InMemoryUserDetailsManager();
 
-	@Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		for(String platform : authenticatedPlatforms) {
 			switch(platform) {
 				case "android":
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build/armv7-android/**").hasRole("ANDROID")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build/arm64-android/**").hasRole("ANDROID")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build_async/armv7-android/**").hasRole("ANDROID")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build_async/arm64-android/**").hasRole("ANDROID")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build/armv7-android/**").hasRole("ANDROID")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build/arm64-android/**").hasRole("ANDROID")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build_async/armv7-android/**").hasRole("ANDROID")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build_async/arm64-android/**").hasRole("ANDROID")).httpBasic(withDefaults());
 					break;
 				case "ios":
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build/armv7-ios/**").hasRole("IOS")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build/arm64-ios/**").hasRole("IOS")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build/x86_64-ios/**").hasRole("IOS")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build_async/armv7-ios/**").hasRole("IOS")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build_async/arm64-ios/**").hasRole("IOS")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build_async/x86_64-ios/**").hasRole("IOS")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build/armv7-ios/**").hasRole("IOS")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build/arm64-ios/**").hasRole("IOS")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build/x86_64-ios/**").hasRole("IOS")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build_async/armv7-ios/**").hasRole("IOS")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build_async/arm64-ios/**").hasRole("IOS")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build_async/x86_64-ios/**").hasRole("IOS")).httpBasic(withDefaults());
 					break;
 				case "linux":
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build/x86_64-linux/**").hasRole("LINUX")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build_async/x86_64-linux/**").hasRole("LINUX")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build/x86_64-linux/**").hasRole("LINUX")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build_async/x86_64-linux/**").hasRole("LINUX")).httpBasic(withDefaults());
 					break;
 				case "macos":
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build/x86_64-osx/**").hasRole("MACOS")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build_async/x86_64-osx/**").hasRole("MACOS")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build/arm64-osx/**").hasRole("MACOS")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build_async/arm64-osx/**").hasRole("MACOS")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build/x86_64-osx/**").hasRole("MACOS")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build_async/x86_64-osx/**").hasRole("MACOS")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build/arm64-osx/**").hasRole("MACOS")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build_async/arm64-osx/**").hasRole("MACOS")).httpBasic(withDefaults());
 					break;
 				case "windows":
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build/x86_64-win32/**").hasRole("WINDOWS")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build/x86-win32/**").hasRole("WINDOWS")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build_async/x86_64-win32/**").hasRole("WINDOWS")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build_async/x86-win32/**").hasRole("WINDOWS")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build/x86_64-win32/**").hasRole("WINDOWS")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build/x86-win32/**").hasRole("WINDOWS")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build_async/x86_64-win32/**").hasRole("WINDOWS")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build_async/x86-win32/**").hasRole("WINDOWS")).httpBasic(withDefaults());
 					break;
 				case "html5":
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build/js-web/**").hasRole("HTML5")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build/wasm-web/**").hasRole("HTML5")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build_async/js-web/**").hasRole("HTML5")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build_async/wasm-web/**").hasRole("HTML5")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build/js-web/**").hasRole("HTML5")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build/wasm-web/**").hasRole("HTML5")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build_async/js-web/**").hasRole("HTML5")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build_async/wasm-web/**").hasRole("HTML5")).httpBasic(withDefaults());
 					break;
 				case "switch":
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build/arm64-nx64/**").hasRole("SWITCH")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build_async/arm64-nx64/**").hasRole("SWITCH")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build/arm64-nx64/**").hasRole("SWITCH")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build_async/arm64-nx64/**").hasRole("SWITCH")).httpBasic(withDefaults());
 					break;
 				case "ps4":
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build/x86_64-ps4/**").hasRole("PS4")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build_async/x86_64-ps4/**").hasRole("PS4")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build/x86_64-ps4/**").hasRole("PS4")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build_async/x86_64-ps4/**").hasRole("PS4")).httpBasic(withDefaults());
 					break;
 				case "ps5":
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build/x86_64-ps5/**").hasRole("PS5")).httpBasic(withDefaults());
-                    http.authorizeRequests((requests) -> requests.requestMatchers("/build/_async/x86_64-ps5/**").hasRole("PS5")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build/x86_64-ps5/**").hasRole("PS5")).httpBasic(withDefaults());
+                    http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.requestMatchers("/build_async/x86_64-ps5/**").hasRole("PS5")).httpBasic(withDefaults());
 					break;
 			}
 		}
@@ -78,12 +78,13 @@ public class WebSecurityConfig {
         // 	http.authorizeRequests().requestMatchers("/query").hasRole("CACHE").and().httpBasic();
         // 	http.authorizeRequests().requestMatchers("/actuator/prometheus").hasRole("COLLECTOR").and().httpBasic();
         // }
-        http.csrf(csrf -> csrf.disable());
+        http.authorizeHttpRequests((authorizeHttpRequest) -> authorizeHttpRequest.anyRequest().permitAll())
+            .csrf(csrf -> csrf.disable());
         return http.build();
 	}
 
 	@Bean
-	public InMemoryUserDetailsManager userDetailsManagerBean() {
+	InMemoryUserDetailsManager userDetailsManagerBean() {
 		return userDetailsManager;
 	}
 }


### PR DESCRIPTION
It was lots of deprecation warning about `authorizeRequests` (marked as for removal in Spring security 7.x).