### PR TITLE
Move sdk urls to application configuration

### DIFF
--- a/server/src/main/java/com/defold/extender/services/DefoldSdkService.java
+++ b/server/src/main/java/com/defold/extender/services/DefoldSdkService.java
@@ -38,28 +38,11 @@ import java.util.concurrent.ExecutionException;
 @Service
 public class DefoldSdkService {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefoldSdkService.class);
-    private static final String REMOTE_SDK_URL_PATTERNS[] = {
-        "http://d.defold.com/archive/stable/%s/engine/defoldsdk.zip",
-        "http://d.defold.com/archive/%s/engine/defoldsdk.zip",
-        "http://d-switch.defold.com/archive/stable/%s/engine/defoldsdk.zip",
-        "http://d-switch.defold.com/archive/%s/engine/defoldsdk.zip",
-        "http://d-ps4.defold.com/archive/stable/%s/engine/defoldsdk.zip",
-        "http://d-ps4.defold.com/archive/%s/engine/defoldsdk.zip",
-        "http://d-xbox.defold.com/archive/stable/%s/engine/defoldsdk.zip",
-        "http://d-xbox.defold.com/archive/%s/engine/defoldsdk.zip"};
-
-    private static final String REMOTE_MAPPINGS_URL_PATTERNS[] = {
-            "http://d.defold.com/archive/stable/%s/engine/platform.sdks.json",
-            "http://d.defold.com/archive/%s/engine/platform.sdks.json",
-            "http://d-switch.defold.com/archive/stable/%s/engine/platform.sdks.json",
-            "http://d-switch.defold.com/archive/%s/engine/platform.sdks.json",
-            "http://d-ps4.defold.com/archive/stable/%s/engine/platform.sdks.json",
-            "http://d-ps4.defold.com/archive/%s/engine/platform.sdks.json",
-            "http://d-xbox.defold.com/archive/stable/%s/engine/platform.sdks.json",
-            "http://d-xbox.defold.com/archive/%s/engine/platform.sdks.json"};
     private static final String TEST_SDK_DIRECTORY = "a";
     private static final String LOCAL_VERSION = "local";
 
+    private final String[] REMOTE_SDK_URL_PATTERNS;
+    private final String[] REMOTE_MAPPINGS_URL_PATTERNS;
     private final Path baseSdkDirectory;
     private final File dynamoHome;
     private final int cacheSize;
@@ -72,11 +55,15 @@ public class DefoldSdkService {
     DefoldSdkService(@Value("${extender.sdk.location}") String baseSdkDirectory,
                      @Value("${extender.sdk.cache-size}") int cacheSize,
                      @Value("${extender.sdk.cache-clear-on-exit}") boolean cacheClearOnExit,
+                     @Value("${extender.sdk.sdk-urls}") String[] sdkUrlPatterns,
+                     @Value("${extender.sdk.mappings-urls}") String[] mappingsUrlPatterns,
                      MeterRegistry meterRegistry) throws IOException {
         this.baseSdkDirectory = new File(baseSdkDirectory).toPath();
         this.cacheSize = cacheSize;
         this.meterRegistry = meterRegistry;
         this.cacheClearOnExit = cacheClearOnExit;
+        this.REMOTE_SDK_URL_PATTERNS = sdkUrlPatterns;
+        this.REMOTE_MAPPINGS_URL_PATTERNS = mappingsUrlPatterns;
 
         this.dynamoHome = System.getenv("DYNAMO_HOME") != null ? new File(System.getenv("DYNAMO_HOME")) : null;
         this.cacheReferenceCount = new ConcurrentHashMap<>(this.cacheSize + 10);

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -9,6 +9,12 @@ extender:
         # Slightly bigger than production in order to not remove version controlled SDK
         cache-size: 10
         cache-clear-on-exit: true
+        sdk-urls: >
+            "http://d.defold.com/archive/stable/%s/engine/defoldsdk.zip",
+            "http://d.defold.com/archive/%s/engine/defoldsdk.zip"
+        mappings-urls: >
+            "http://d.defold.com/archive/stable/%s/engine/platform.sdks.json",
+            "http://d.defold.com/archive/%s/engine/platform.sdks.json"
     server:
         http:
             idle-timeout: 600000
@@ -19,7 +25,6 @@ extender:
         enabled: false
         build-sleep-timeout: 5000
         build-result-wait-timeout: 1200000
-                
     gradle:
         enabled: false
         location: /tmp/.gradle

--- a/server/src/test/java/com/defold/extender/services/DefoldSDKServiceTest.java
+++ b/server/src/test/java/com/defold/extender/services/DefoldSDKServiceTest.java
@@ -8,14 +8,12 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
@@ -34,6 +32,14 @@ import static org.mockito.Mockito.mock;
 
 public class DefoldSDKServiceTest {
     private static final String folderPath = "/tmp/defoldsdk";
+    private static final String sdkUrls[] = {
+        "http://d.defold.com/archive/stable/%s/engine/defoldsdk.zip",
+        "http://d.defold.com/archive/%s/engine/defoldsdk.zip"
+    };
+    private static final String mappingsUrls[] = {
+        "http://d.defold.com/archive/stable/%s/engine/platform.sdks.json",
+        "http://d.defold.com/archive/%s/engine/platform.sdks.json"
+    };
 
     @BeforeAll
     public static void beforeAll() throws IOException {
@@ -48,7 +54,7 @@ public class DefoldSDKServiceTest {
     @Test
     @Disabled("SDK too large to download on every test round.")
     public void t() throws IOException, ExtenderException {
-        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, 3, true, mock(MeterRegistry.class));
+        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, 3, true, sdkUrls, mappingsUrls, mock(MeterRegistry.class));
         DefoldSdk sdk = defoldSdkService.getSdk("f7778a8f59ef2a8dda5d445f471368e8bd1cb1ac");
         System.out.println(sdk.toFile().getCanonicalFile());
     }
@@ -57,7 +63,7 @@ public class DefoldSDKServiceTest {
     @Disabled("SDK too large to download on every test round.")
     public void onlyStoreTheNewest() throws IOException, ExtenderException {
         int cacheSize = 3;
-        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, cacheSize, true, mock(MeterRegistry.class));
+        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, cacheSize, true, sdkUrls, mappingsUrls, mock(MeterRegistry.class));
 
         String[] sdksToDownload = {
                 "fe2b689302e79b7cf8c0bc7d934f23587b268c8a",
@@ -81,7 +87,7 @@ public class DefoldSDKServiceTest {
 
     @Test
     public void testGetSDK() throws IOException, ExtenderException {
-        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, 3, true, mock(MeterRegistry.class));
+        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, 3, true, sdkUrls, mappingsUrls, mock(MeterRegistry.class));
 
         File dir = new File("/tmp/defoldsdk/notexist");
         assertFalse(Files.exists(dir.toPath()));
@@ -94,7 +100,7 @@ public class DefoldSDKServiceTest {
         final String testSdk = "11d2cd3a9be17b2fc5a2cb5cea59bbfb4af1ca96";
         final int expectedRefCount = 3;
         List<DefoldSdk> sdks = new ArrayList<>();
-        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, 0, true, new SimpleMeterRegistry());
+        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, 0, true, sdkUrls, mappingsUrls, new SimpleMeterRegistry());
 
         // check when several threads request one sdk and that sdk need to be downloaded
         ExecutorService service = Executors.newFixedThreadPool(10);
@@ -154,7 +160,7 @@ public class DefoldSDKServiceTest {
     @Test
     public void testSdkCorrectPath() throws IOException, ExtenderException {
         final String testSdk = "11d2cd3a9be17b2fc5a2cb5cea59bbfb4af1ca96";
-        DefoldSdkService defoldSdkService = new DefoldSdkService("/tmp/defoldsdk_test", 0, true, new SimpleMeterRegistry());
+        DefoldSdkService defoldSdkService = new DefoldSdkService("/tmp/defoldsdk_test", 0, true, sdkUrls, mappingsUrls, new SimpleMeterRegistry());
         try (DefoldSdk sdk = defoldSdkService.getSdk(testSdk)) {
             assertTrue(new File(String.format("%s/extender/build.yml", sdk.toFile().getAbsolutePath())).exists());
         }


### PR DESCRIPTION
Move sdk url patterns and mappings url patterns to application configuration. It allows to configure application in more flexible way.
Use cases:
1. If we want to move buckets with defoldsdks to other place (url will change).
2. End user wants to cache defoldsdk on own side. So user can configure custom address of caching proxy which return defoldsdk if it was cached or requests it from other location and cache it.