### PR TITLE
Fix swift compilation

### DIFF
--- a/server/src/main/java/com/defold/extender/services/CocoaPodsService.java
+++ b/server/src/main/java/com/defold/extender/services/CocoaPodsService.java
@@ -1133,33 +1133,36 @@ public class CocoaPodsService {
 
         // module map
         // https://guides.cocoapods.org/syntax/podspec.html#module_map
-        spec.iosModuleMap = (String)specJson.get("module_map");
-        spec.osxModuleMap = (String)specJson.get("module_map");
-        if (ios != null) spec.iosModuleMap = (String)ios.get("module_map");
-        if (osx != null) spec.osxModuleMap = (String)osx.get("module_map");
-
-        if (spec.iosModuleMap != null && spec.iosModuleMap.toLowerCase().equals("false")) {
+        if (ios != null) {
+            spec.iosModuleMap = (String)ios.getOrDefault("module_map", "true");
+        } else {
+            spec.iosModuleMap = (String)specJson.getOrDefault("module_map", "true");
+        }
+        String moduleMapValue = spec.iosModuleMap.toLowerCase();
+        if (moduleMapValue.equals("false")) {
             // do not generate a module map
             spec.iosModuleMap = null;
-        }
-        else if (spec.iosModuleMap == null && spec.installed) {
-            if (ExtenderUtil.listFilesMatchingRecursive(spec.dir, "module.modulemap").isEmpty()) {
-                spec.iosModuleMap = createIosModuleMap(spec, jobDir);
-            }
+            LOGGER.info("iOS module map generation skipped for {}", spec.name);
+        } else if (spec.installed && moduleMapValue.equals("true")) {
+            spec.iosModuleMap = createIosModuleMap(spec, jobDir);
         }
         if (spec.iosModuleMap != null) {
             spec.flags.ios.objc.add("-fmodule-map-file=" + spec.iosModuleMap);
             spec.flags.ios.objcpp.add("-fmodule-map-file=" + spec.iosModuleMap);
         }
 
-        if (spec.osxModuleMap != null && spec.osxModuleMap.toLowerCase().equals("false")) {
+        if (osx != null) {
+            spec.osxModuleMap = (String)osx.getOrDefault("module_map", "true");
+        } else {
+            spec.osxModuleMap = (String)specJson.getOrDefault("module_map", "true");
+        }
+        moduleMapValue = spec.osxModuleMap.toLowerCase();
+        if (moduleMapValue.equals("false")) {
             // do not generate a module map
             spec.osxModuleMap = null;
-        }
-        else if (spec.osxModuleMap == null && spec.installed) {
-            if (ExtenderUtil.listFilesMatchingRecursive(spec.dir, "module.modulemap").isEmpty()) {
-                spec.osxModuleMap = createOsxModuleMap(spec, jobDir);
-            }
+            LOGGER.info("OSX module map generation skipped for {}", spec.name);
+        } else if (spec.installed && moduleMapValue.equals("true")) {
+            spec.osxModuleMap = createOsxModuleMap(spec, jobDir);
         }
         if (spec.osxModuleMap != null) {
             spec.flags.osx.objc.add("-fmodule-map-file=" + spec.osxModuleMap);


### PR DESCRIPTION
Now module map and swift header generates every time except of cases when:
1. Pod spec has "module_map" == "false" or
2. Pod spec has "module_map" == "<path_to_module_map>"

According to https://guides.cocoapods.org/syntax/podspec.html#module_map default value is "true"

Fixes https://github.com/defold/extension-ironsource/issues/36