### PR TITLE
Cache sdk mappings

### DIFF
--- a/server/src/main/java/com/defold/extender/ExtenderUtil.java
+++ b/server/src/main/java/com/defold/extender/ExtenderUtil.java
@@ -29,8 +29,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
 import org.springframework.core.io.Resource;
 
 public class ExtenderUtil
@@ -833,10 +831,8 @@ public class ExtenderUtil
 
     // return a list of two string: platform name like "emsdk" and platform version like "3155"
     @SuppressWarnings("unchecked")
-    public static String[] getSdksForPlatform(String platform, String mappings) throws ParseException {
-        JSONParser parser = new JSONParser();
-        JSONObject obj = (JSONObject) parser.parse(mappings);
-        return ((List<String>) obj.get(platform)).toArray(new String[2]);
+    public static String[] getSdksForPlatform(String platform, JSONObject mappings) {
+        return ((List<String>) mappings.get(platform)).toArray(new String[2]);
     }
 
     public static File extractFile(ZipFile zipFile, ZipEntry entry, File outputDirectory) throws IOException {

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -8,6 +8,7 @@ extender:
         location: /var/extender/sdk
         # Slightly bigger than production in order to not remove version controlled SDK
         cache-size: 10
+        mappings-cache-size: 20
         cache-clear-on-exit: true
         sdk-urls: >
             http://d.defold.com/archive/stable/%s/engine/defoldsdk.zip,

--- a/server/src/test/java/com/defold/extender/services/DefoldSDKServiceTest.java
+++ b/server/src/test/java/com/defold/extender/services/DefoldSDKServiceTest.java
@@ -8,17 +8,21 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
+import org.json.simple.parser.ParseException;
+import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
@@ -26,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -40,6 +45,8 @@ public class DefoldSDKServiceTest {
         "http://d.defold.com/archive/stable/%s/engine/platform.sdks.json",
         "http://d.defold.com/archive/%s/engine/platform.sdks.json"
     };
+    private static final int sdkCacheSize = 3;
+    private static final int mappingsCacheSize = 3;
 
     @BeforeAll
     public static void beforeAll() throws IOException {
@@ -54,7 +61,8 @@ public class DefoldSDKServiceTest {
     @Test
     @Disabled("SDK too large to download on every test round.")
     public void t() throws IOException, ExtenderException {
-        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, 3, true, sdkUrls, mappingsUrls, mock(MeterRegistry.class));
+        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, sdkCacheSize, true,
+            sdkUrls, mappingsUrls, mappingsCacheSize, mock(MeterRegistry.class));
         DefoldSdk sdk = defoldSdkService.getSdk("f7778a8f59ef2a8dda5d445f471368e8bd1cb1ac");
         System.out.println(sdk.toFile().getCanonicalFile());
     }
@@ -62,8 +70,8 @@ public class DefoldSDKServiceTest {
     @Test
     @Disabled("SDK too large to download on every test round.")
     public void onlyStoreTheNewest() throws IOException, ExtenderException {
-        int cacheSize = 3;
-        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, cacheSize, true, sdkUrls, mappingsUrls, mock(MeterRegistry.class));
+        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, sdkCacheSize, true,
+            sdkUrls, mappingsUrls, mappingsCacheSize, mock(MeterRegistry.class));
 
         String[] sdksToDownload = {
                 "fe2b689302e79b7cf8c0bc7d934f23587b268c8a",
@@ -79,7 +87,7 @@ public class DefoldSDKServiceTest {
 
         List<String> collect = Files.list(Paths.get(folderPath)).map(path -> path.toFile().getName()).collect(Collectors.toList());
 
-        assertEquals(cacheSize, collect.size());
+        assertEquals(sdkCacheSize, collect.size());
         assertTrue(collect.contains("e41438cca6cc1550d4a0131b8fc3858c2a4097f1"));
         assertTrue(collect.contains("7107bc8781535e83cbb30734b32d6b32a3039cd0"));
         assertTrue(collect.contains("f7778a8f59ef2a8dda5d445f471368e8bd1cb1ac"));
@@ -87,7 +95,8 @@ public class DefoldSDKServiceTest {
 
     @Test
     public void testGetSDK() throws IOException, ExtenderException {
-        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, 3, true, sdkUrls, mappingsUrls, mock(MeterRegistry.class));
+        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, sdkCacheSize, true,
+            sdkUrls, mappingsUrls, mappingsCacheSize, mock(MeterRegistry.class));
 
         File dir = new File("/tmp/defoldsdk/notexist");
         assertFalse(Files.exists(dir.toPath()));
@@ -100,7 +109,8 @@ public class DefoldSDKServiceTest {
         final String testSdk = "11d2cd3a9be17b2fc5a2cb5cea59bbfb4af1ca96";
         final int expectedRefCount = 3;
         List<DefoldSdk> sdks = new ArrayList<>();
-        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, 0, true, sdkUrls, mappingsUrls, new SimpleMeterRegistry());
+        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, 0, true,
+            sdkUrls, mappingsUrls, mappingsCacheSize, new SimpleMeterRegistry());
 
         // check when several threads request one sdk and that sdk need to be downloaded
         ExecutorService service = Executors.newFixedThreadPool(10);
@@ -160,12 +170,77 @@ public class DefoldSDKServiceTest {
     @Test
     public void testSdkCorrectPath() throws IOException, ExtenderException {
         final String testSdk = "11d2cd3a9be17b2fc5a2cb5cea59bbfb4af1ca96";
-        DefoldSdkService defoldSdkService = new DefoldSdkService("/tmp/defoldsdk_test", 0, true, sdkUrls, mappingsUrls, new SimpleMeterRegistry());
+        DefoldSdkService defoldSdkService = new DefoldSdkService("/tmp/defoldsdk_test", 0, true,
+            sdkUrls, mappingsUrls, mappingsCacheSize, new SimpleMeterRegistry());
         try (DefoldSdk sdk = defoldSdkService.getSdk(testSdk)) {
             assertTrue(new File(String.format("%s/extender/build.yml", sdk.toFile().getAbsolutePath())).exists());
         }
 
         defoldSdkService.evictCache();
         assertFalse(new File("/tmp/defoldsdk_test", testSdk).exists());
+    }
+
+    @Test
+    public void testMappingsCacheSize() throws IOException, URISyntaxException, ExtenderException, ParseException {
+        String[] mappingsToDownload = {
+            "691478c02875b80e76da65d2f5756394e7a906b1",
+            "e4aaff11f49c941fde1dd93883cf69c6b8abebe4",
+            "3251ca82359cf238a1074e383281e3126547d50b",
+            "edfdbe31830c1f8aa4d96644569ae87a8ea32672",
+            "d01194cf0fb576b516a1dca6af6f643e9e590051"};
+        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, 0, true,
+            sdkUrls, mappingsUrls, mappingsCacheSize, new SimpleMeterRegistry());
+        for (String hash : mappingsToDownload) {
+            defoldSdkService.getPlatformSdkMappings(hash);
+        }
+        assertEquals(mappingsCacheSize, defoldSdkService.mappingsCache.size());
+        String expectedHashes[] = {
+            "3251ca82359cf238a1074e383281e3126547d50b",
+            "edfdbe31830c1f8aa4d96644569ae87a8ea32672",
+            "d01194cf0fb576b516a1dca6af6f643e9e590051"
+        };
+        for (String hash : expectedHashes) {
+            assertTrue(defoldSdkService.mappingsCache.containsKey(hash));
+        }
+    }
+
+    @Test
+    public void testNonExistMappings() throws IOException {
+        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, 0, true,
+            sdkUrls, mappingsUrls, mappingsCacheSize, new SimpleMeterRegistry());
+        assertThrows(ExtenderException.class, () -> defoldSdkService.getPlatformSdkMappings("non-exist"));
+    }
+
+    @Test
+    public void testConcurrentMappingsDownloading() throws IOException, InterruptedException {
+        String[] mappingsToDownload = {
+            "691478c02875b80e76da65d2f5756394e7a906b1",
+            "691478c02875b80e76da65d2f5756394e7a906b1",
+            "691478c02875b80e76da65d2f5756394e7a906b1",
+            "691478c02875b80e76da65d2f5756394e7a906b1",
+            "e4aaff11f49c941fde1dd93883cf69c6b8abebe4",
+            "3251ca82359cf238a1074e383281e3126547d50b",
+            "691478c02875b80e76da65d2f5756394e7a906b1",
+            "edfdbe31830c1f8aa4d96644569ae87a8ea32672",
+            "d01194cf0fb576b516a1dca6af6f643e9e590051"};
+        DefoldSdkService defoldSdkService = new DefoldSdkService(folderPath, 0, true,
+            sdkUrls, mappingsUrls, mappingsCacheSize, new SimpleMeterRegistry());
+        ExecutorService service = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(mappingsToDownload.length);
+        for (final String hash : mappingsToDownload) {
+            service.submit(() -> {
+                try {
+                    defoldSdkService.getPlatformSdkMappings(hash);
+                } catch (ExtenderException|IOException|URISyntaxException|ParseException e) {
+                    e.printStackTrace();
+                }
+                latch.countDown();
+            });
+        }
+        latch.await();
+        assertEquals(mappingsCacheSize, defoldSdkService.mappingsCache.size());
+        for (Map.Entry<String, JSONObject> entry : defoldSdkService.mappingsCache.entrySet()) {
+            assertNotNull(entry.getValue());
+        }
     }
 }


### PR DESCRIPTION
Implement in-memory caching for platform mappings. The size of cache can be configured via `extender.sdk.mappings-cache-size` property. Concurrent downloading of mappings implements in the same manner as it was done for sdk downloading.

Fixes #553