### PR TITLE
Send gradle log to client

### DIFF
--- a/server/src/main/java/com/defold/extender/AsyncBuilder.java
+++ b/server/src/main/java/com/defold/extender/AsyncBuilder.java
@@ -118,12 +118,12 @@ public class AsyncBuilder {
                 }
 
                 // Build engine
-                List<File> outputFiles = extender.build();
+                extender.build();
                 metricsWriter.measureEngineBuild(platform);
 
                 // Zip files
                 String zipFilename = jobDirectory.getAbsolutePath() + File.separator + BuilderConstants.BUILD_RESULT_FILENAME;
-                File zipFile = ZipUtils.zip(outputFiles, buildDirectory, zipFilename);
+                File zipFile = ZipUtils.zip(extender.getOutputFiles(), buildDirectory, zipFilename);
                 metricsWriter.measureZipFiles(zipFile);
 
                 // Write zip file to result directory

--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -74,6 +74,7 @@ class Extender {
     private List<File> extDirs;
     private List<File> manifests;       // The list of ext.manifests found in the upload
     private List<File> gradlePackages;
+    private List<File> outputFiles;
     private ResolvedPods resolvedPods;
     private int nameCounter = 0;
 
@@ -186,6 +187,7 @@ class Extender {
         this.buildDirectory = builder.buildDirectory;
         this.metricsWriter = builder.metricsWriter;
         this.gradlePackages = new ArrayList<>();
+        this.outputFiles = new ArrayList<>();
 
         // Read config from SDK
         this.config = Extender.loadYaml(this.jobDirectory, new File(builder.sdk.getPath() + "/extender/build.yml"), Configuration.class);
@@ -2728,7 +2730,7 @@ class Extender {
 
     void resolve(GradleService gradleService) throws ExtenderException {
         try {
-            gradlePackages = gradleService.resolveDependencies(this.platformConfig.context, jobDirectory, useJetifier);
+            gradlePackages = gradleService.resolveDependencies(this.platformConfig.context, jobDirectory, buildDirectory, useJetifier, outputFiles);
         }
         catch (IOException e) {
             throw new ExtenderException(e, "Failed to resolve Gradle dependencies. " + e.getMessage());
@@ -2744,9 +2746,7 @@ class Extender {
         }
     }
 
-    List<File> build() throws ExtenderException {
-        List<File> outputFiles = new ArrayList<>();
-
+    void build() throws ExtenderException {
         outputFiles.addAll(buildManifests(platform));
 
         if (shouldBuildLibrary())
@@ -2770,6 +2770,9 @@ class Extender {
         if (log.exists()) {
             outputFiles.add(log);
         }
+    }
+
+    List<File> getOutputFiles() {
         return outputFiles;
     }
 }

--- a/server/src/main/java/com/defold/extender/services/GradleService.java
+++ b/server/src/main/java/com/defold/extender/services/GradleService.java
@@ -23,9 +23,9 @@ public class GradleService {
         Gauge.builder("extender.job.gradle.cacheSize", this, GradleService::getCacheSize).baseUnit(BaseUnits.BYTES).register(registry);
     }
 
-    public List<File> resolveDependencies(Map<String, Object> env, File cwd, Boolean useJetifier)
+    public List<File> resolveDependencies(Map<String, Object> env, File cwd, File buildDirectory, Boolean useJetifier, List<File> outputFiles)
         throws IOException, ExtenderException {
-        return gradleService.resolveDependencies(env, cwd, useJetifier);
+        return gradleService.resolveDependencies(env, cwd, buildDirectory, useJetifier, outputFiles);
     }
 
     public long getCacheSize() {

--- a/server/src/main/java/com/defold/extender/services/GradleServiceInterface.java
+++ b/server/src/main/java/com/defold/extender/services/GradleServiceInterface.java
@@ -9,7 +9,7 @@ import com.defold.extender.ExtenderException;
 
 public interface GradleServiceInterface {
     // Resolve dependencies, download them, extract to
-    public List<File> resolveDependencies(Map<String, Object> env, File cwd, Boolean useJetifier) throws IOException, ExtenderException;
+    public List<File> resolveDependencies(Map<String, Object> env, File cwd, File buildDirectory, Boolean useJetifier, List<File> outputFiles) throws IOException, ExtenderException;
     
     public long getCacheSize() throws IOException;
 }

--- a/server/src/main/java/com/defold/extender/services/MockGradleService.java
+++ b/server/src/main/java/com/defold/extender/services/MockGradleService.java
@@ -14,7 +14,7 @@ import com.defold.extender.ExtenderException;
 @ConditionalOnProperty(name = "extender.gradle.enabled", havingValue = "false", matchIfMissing = true)
 public class MockGradleService implements GradleServiceInterface {
     @Override
-    public List<File> resolveDependencies(Map<String, Object> env, File cwd, Boolean useJetifier)
+    public List<File> resolveDependencies(Map<String, Object> env, File cwd, File buildDirectory, Boolean useJetifier, List<File> outputFiles)
             throws IOException, ExtenderException {
         return List.of();
     }

--- a/server/src/main/java/com/defold/extender/services/RealGradleService.java
+++ b/server/src/main/java/com/defold/extender/services/RealGradleService.java
@@ -275,7 +275,7 @@ public class RealGradleService implements GradleServiceInterface {
         // add --info for additional logging
         String log = execCommand("gradle downloadDependencies --stacktrace --warning-mode all", cwd);
         LOGGER.info("\n" + log);
-        return dependencies;
+        return log;
     }
 
 }

--- a/server/src/main/resources/template.build.gradle
+++ b/server/src/main/resources/template.build.gradle
@@ -38,6 +38,11 @@ java {
 apply from: "{{{.}}}"
 {{/gradle-files}}
 
+dependencyLocking {
+    lockAllConfigurations()
+    lockFile = file("$projectDir/build/gradle.lockfile")
+}
+
 task downloadDependencies {
     doLast {
         project.configurations.releaseRuntimeClasspath.getResolvedConfiguration().getResolvedArtifacts().each {


### PR DESCRIPTION
Android builds will send back a `gradle.lockfile` which contains output from gradle while resolving dependencies ([format](https://docs.gradle.org/current/userguide/dependency_locking.html#structure_of_lock_files)).

Example:

```
# This is a Gradle generated file for dependency locking.
# Manual edits can break the build and are not advised.
# This file is expected to be part of source control.
androidx.annotation:annotation-experimental:1.1.0=releaseRuntimeClasspath
androidx.annotation:annotation-jvm:1.6.0=releaseRuntimeClasspath
androidx.annotation:annotation:1.6.0=releaseRuntimeClasspath
androidx.arch.core:core-common:2.1.0=releaseRuntimeClasspath
androidx.arch.core:core-runtime:2.1.0=releaseRuntimeClasspath
androidx.asynclayoutinflater:asynclayoutinflater:1.0.0=releaseRuntimeClasspath
androidx.browser:browser:1.4.0=releaseRuntimeClasspath
androidx.collection:collection:1.1.0=releaseRuntimeClasspath
androidx.concurrent:concurrent-futures:1.1.0=releaseRuntimeClasspath
androidx.coordinatorlayout:coordinatorlayout:1.0.0=releaseRuntimeClasspath
androidx.core:core-ktx:1.8.0=releaseRuntimeClasspath
androidx.core:core:1.8.0=releaseRuntimeClasspath
androidx.cursoradapter:cursoradapter:1.0.0=releaseRuntimeClasspath
androidx.customview:customview:1.0.0=releaseRuntimeClasspath
androidx.documentfile:documentfile:1.0.0=releaseRuntimeClasspath
androidx.drawerlayout:drawerlayout:1.0.0=releaseRuntimeClasspath
androidx.fragment:fragment:1.0.0=releaseRuntimeClasspath
androidx.interpolator:interpolator:1.0.0=releaseRuntimeClasspath
androidx.legacy:legacy-support-core-ui:1.0.0=releaseRuntimeClasspath
androidx.legacy:legacy-support-core-utils:1.0.0=releaseRuntimeClasspath
androidx.lifecycle:lifecycle-common:2.3.1=releaseRuntimeClasspath
androidx.lifecycle:lifecycle-livedata-core:2.1.0=releaseRuntimeClasspath
androidx.lifecycle:lifecycle-livedata:2.1.0=releaseRuntimeClasspath
androidx.lifecycle:lifecycle-process:2.3.1=releaseRuntimeClasspath
androidx.lifecycle:lifecycle-runtime:2.3.1=releaseRuntimeClasspath
androidx.lifecycle:lifecycle-service:2.1.0=releaseRuntimeClasspath
androidx.lifecycle:lifecycle-viewmodel:2.0.0=releaseRuntimeClasspath
androidx.loader:loader:1.0.0=releaseRuntimeClasspath
androidx.localbroadcastmanager:localbroadcastmanager:1.0.0=releaseRuntimeClasspath
androidx.print:print:1.0.0=releaseRuntimeClasspath
androidx.privacysandbox.ads:ads-adservices-java:1.0.0-beta05=releaseRuntimeClasspath
androidx.privacysandbox.ads:ads-adservices:1.0.0-beta05=releaseRuntimeClasspath
androidx.room:room-common:2.2.5=releaseRuntimeClasspath
androidx.room:room-runtime:2.2.5=releaseRuntimeClasspath
androidx.slidingpanelayout:slidingpanelayout:1.0.0=releaseRuntimeClasspath
androidx.sqlite:sqlite-framework:2.1.0=releaseRuntimeClasspath
androidx.sqlite:sqlite:2.1.0=releaseRuntimeClasspath
androidx.startup:startup-runtime:1.0.0=releaseRuntimeClasspath
androidx.swiperefreshlayout:swiperefreshlayout:1.0.0=releaseRuntimeClasspath
androidx.tracing:tracing:1.0.0=releaseRuntimeClasspath
androidx.versionedparcelable:versionedparcelable:1.1.1=releaseRuntimeClasspath
androidx.viewpager:viewpager:1.0.0=releaseRuntimeClasspath
androidx.work:work-runtime:2.7.0=releaseRuntimeClasspath
com.google.android.gms:play-services-ads-base:22.6.0=releaseRuntimeClasspath
com.google.android.gms:play-services-ads-identifier:18.0.0=releaseRuntimeClasspath
com.google.android.gms:play-services-ads-lite:22.6.0=releaseRuntimeClasspath
com.google.android.gms:play-services-ads:22.6.0=releaseRuntimeClasspath
com.google.android.gms:play-services-appset:16.0.1=releaseRuntimeClasspath
com.google.android.gms:play-services-base:18.0.0=releaseRuntimeClasspath
com.google.android.gms:play-services-basement:18.2.0=releaseRuntimeClasspath
com.google.android.gms:play-services-measurement-base:20.1.2=releaseRuntimeClasspath
com.google.android.gms:play-services-measurement-sdk-api:20.1.2=releaseRuntimeClasspath
com.google.android.gms:play-services-tasks:18.0.1=releaseRuntimeClasspath
com.google.android.ump:user-messaging-platform:2.1.0=releaseRuntimeClasspath
com.google.code.findbugs:jsr305:3.0.2=releaseRuntimeClasspath
com.google.errorprone:error_prone_annotations:2.11.0=releaseRuntimeClasspath
com.google.guava:failureaccess:1.0.1=releaseRuntimeClasspath
com.google.guava:guava:31.1-android=releaseRuntimeClasspath
com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava=releaseRuntimeClasspath
com.google.j2objc:j2objc-annotations:1.3=releaseRuntimeClasspath
org.checkerframework:checker-qual:3.12.0=releaseRuntimeClasspath
org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21=releaseRuntimeClasspath
org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.20=releaseRuntimeClasspath
org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20=releaseRuntimeClasspath
org.jetbrains.kotlin:kotlin-stdlib:1.8.21=releaseRuntimeClasspath
org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.1=releaseRuntimeClasspath
org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.1=releaseRuntimeClasspath
org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1=releaseRuntimeClasspath
org.jetbrains:annotations:23.0.0=releaseRuntimeClasspath
empty=
```

Fixes #644 