### PR TITLE
Fix modulemap generation

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -38,7 +38,7 @@ repositories {
 dependencyManagement {
     imports {
         // DO NOT update higher 5.8.0 because transitive dependencies has opentelemtry version 1.45.0+
-        // which has breaking changes in comparasion with 1.43.0
+        // which has breaking changes in comparison with 1.43.0
         mavenBom 'com.google.cloud:spring-cloud-gcp-dependencies:5.8.0'
         mavenBom 'org.junit:junit-bom:5.11.4'
     }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -37,7 +37,9 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom 'com.google.cloud:spring-cloud-gcp-dependencies:5.10.0'
+        // DO NOT update higher 5.8.0 because transitive dependencies has opentelemtry version 1.45.0+
+        // which has breaking changes in comparasion with 1.43.0
+        mavenBom 'com.google.cloud:spring-cloud-gcp-dependencies:5.8.0'
         mavenBom 'org.junit:junit-bom:5.11.4'
     }
 }
@@ -66,8 +68,8 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-starter-jetty')
     implementation('org.springframework.boot:spring-boot-starter-security')
     implementation('io.micrometer:micrometer-core:1.14.3')
-    implementation('io.micrometer:micrometer-tracing:1.4.2')
-    implementation('io.micrometer:micrometer-tracing-bridge-otel:1.4.2')
+    implementation('io.micrometer:micrometer-tracing:1.4.1')
+    implementation('io.micrometer:micrometer-tracing-bridge-otel:1.4.1')
 
     implementation('org.projectlombok:lombok:1.18.36')
     annotationProcessor('org.projectlombok:lombok:1.18.36')

--- a/server/src/main/java/com/defold/extender/ProcessExecutor.java
+++ b/server/src/main/java/com/defold/extender/ProcessExecutor.java
@@ -120,12 +120,9 @@ public class ProcessExecutor {
         ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
         List<Callable<Void>> callables = new ArrayList<>();
         for (String command : commands) {
-            callables.add(new Callable<Void>() {
-                @Override
-                public Void call() throws Exception {
-                    processExecutor.execute(command);
-                    return null;
-                }
+            callables.add(() -> {
+                processExecutor.execute(command);
+                return null;
             });
         }
         List<Future<Void>> futures = executor.invokeAll(callables);

--- a/server/src/main/java/com/defold/extender/services/CocoaPodsService.java
+++ b/server/src/main/java/com/defold/extender/services/CocoaPodsService.java
@@ -1143,7 +1143,8 @@ public class CocoaPodsService {
             spec.iosModuleMap = null;
         }
         else if (spec.iosModuleMap == null && spec.installed) {
-            if (ExtenderUtil.listFilesMatchingRecursive(spec.dir, "module.modulemap").isEmpty()) {
+            if (ExtenderUtil.listFilesMatchingRecursive(spec.dir, "module.modulemap").isEmpty()
+                || !spec.swiftSourceFiles.isEmpty()) {
                 spec.iosModuleMap = createIosModuleMap(spec, jobDir);
             }
         }
@@ -1157,7 +1158,8 @@ public class CocoaPodsService {
             spec.osxModuleMap = null;
         }
         else if (spec.osxModuleMap == null && spec.installed) {
-            if (ExtenderUtil.listFilesMatchingRecursive(spec.dir, "module.modulemap").isEmpty()) {
+            if (ExtenderUtil.listFilesMatchingRecursive(spec.dir, "module.modulemap").isEmpty()
+                || !spec.swiftSourceFiles.isEmpty()) {
                 spec.osxModuleMap = createOsxModuleMap(spec, jobDir);
             }
         }

--- a/server/src/main/java/com/defold/extender/services/CocoaPodsService.java
+++ b/server/src/main/java/com/defold/extender/services/CocoaPodsService.java
@@ -1133,36 +1133,33 @@ public class CocoaPodsService {
 
         // module map
         // https://guides.cocoapods.org/syntax/podspec.html#module_map
-        if (ios != null) {
-            spec.iosModuleMap = (String)ios.getOrDefault("module_map", "true");
-        } else {
-            spec.iosModuleMap = (String)specJson.getOrDefault("module_map", "true");
-        }
-        String moduleMapValue = spec.iosModuleMap.toLowerCase();
-        if (moduleMapValue.equals("false")) {
+        spec.iosModuleMap = (String)specJson.get("module_map");
+        spec.osxModuleMap = (String)specJson.get("module_map");
+        if (ios != null) spec.iosModuleMap = (String)ios.get("module_map");
+        if (osx != null) spec.osxModuleMap = (String)osx.get("module_map");
+
+        if (spec.iosModuleMap != null && spec.iosModuleMap.toLowerCase().equals("false")) {
             // do not generate a module map
             spec.iosModuleMap = null;
-            LOGGER.info("iOS module map generation skipped for {}", spec.name);
-        } else if (spec.installed && moduleMapValue.equals("true")) {
-            spec.iosModuleMap = createIosModuleMap(spec, jobDir);
+        }
+        else if (spec.iosModuleMap == null && spec.installed) {
+            if (ExtenderUtil.listFilesMatchingRecursive(spec.dir, "module.modulemap").isEmpty()) {
+                spec.iosModuleMap = createIosModuleMap(spec, jobDir);
+            }
         }
         if (spec.iosModuleMap != null) {
             spec.flags.ios.objc.add("-fmodule-map-file=" + spec.iosModuleMap);
             spec.flags.ios.objcpp.add("-fmodule-map-file=" + spec.iosModuleMap);
         }
 
-        if (osx != null) {
-            spec.osxModuleMap = (String)osx.getOrDefault("module_map", "true");
-        } else {
-            spec.osxModuleMap = (String)specJson.getOrDefault("module_map", "true");
-        }
-        moduleMapValue = spec.osxModuleMap.toLowerCase();
-        if (moduleMapValue.equals("false")) {
+        if (spec.osxModuleMap != null && spec.osxModuleMap.toLowerCase().equals("false")) {
             // do not generate a module map
             spec.osxModuleMap = null;
-            LOGGER.info("OSX module map generation skipped for {}", spec.name);
-        } else if (spec.installed && moduleMapValue.equals("true")) {
-            spec.osxModuleMap = createOsxModuleMap(spec, jobDir);
+        }
+        else if (spec.osxModuleMap == null && spec.installed) {
+            if (ExtenderUtil.listFilesMatchingRecursive(spec.dir, "module.modulemap").isEmpty()) {
+                spec.osxModuleMap = createOsxModuleMap(spec, jobDir);
+            }
         }
         if (spec.osxModuleMap != null) {
             spec.flags.osx.objc.add("-fmodule-map-file=" + spec.osxModuleMap);


### PR DESCRIPTION
I reverted changes that was done in https://github.com/defold/extender/pull/611.
Now modulemap generated in case if no predefined modulemap found or if swift code is presented. In case if user uses framework with precompiled library with modulemap and without other source code - no need to generate and use additional modulemap.

Also reverted back GCP dependencies because it conflict with OpenTelemetry dependency.

Fixes #653 