### PR TITLE
Fix qemu version

### DIFF
--- a/.github/workflows/docker-env-build.yml
+++ b/.github/workflows/docker-env-build.yml
@@ -94,6 +94,9 @@ jobs:
         password: ${{ secrets.DOCKER_REGISTRY_JSON_KEY }}
     - name: Set up QEMU
       uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3.4.0
+      with:
+        platforms: amd64,arm64
+        image: tonistiigi/binfmt:qemu-v7.0.0
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
     - name: Build and push


### PR DESCRIPTION
With the latest version there was a segmentation fault during `apt-get install` step.

More info https://github.com/tonistiigi/binfmt/issues/240