### PR TITLE
Generate a Gradle dependency tree for Android builds

### DIFF
--- a/server/src/main/java/com/defold/extender/services/RealGradleService.java
+++ b/server/src/main/java/com/defold/extender/services/RealGradleService.java
@@ -274,7 +274,7 @@ public class RealGradleService implements GradleServiceInterface {
 
         // add --info for additional logging
         String log = execCommand("gradle downloadDependencies --write-locks --stacktrace --warning-mode all", cwd);
-        LOGGER.info("\n" + log);
+        LOGGER.debug("\n" + log);
 
         Map<String, String> dependencies = parseDependencies(log);
 
@@ -289,7 +289,7 @@ public class RealGradleService implements GradleServiceInterface {
         LOGGER.info("Writing dependency tree");
 
         String treelog = execCommand("gradle dependencies --configuration releaseCompileClasspath", cwd);
-        LOGGER.info("\n" + treelog);
+        LOGGER.debug("\n" + treelog);
 
         Files.write(out.toPath(), treelog.getBytes());
 

--- a/server/src/main/java/com/defold/extender/services/RealGradleService.java
+++ b/server/src/main/java/com/defold/extender/services/RealGradleService.java
@@ -106,10 +106,14 @@ public class RealGradleService implements GradleServiceInterface {
 
         // download, parse and unpack dependencies
         List<File> unpackedDependencies = downloadDependencies(cwd);
-
         // add gradle lockfile to outputs
         // configured in template.build.gradle
         outputFiles.add(new File(buildDirectory, "gradle.lockfile"));
+
+        // write dependency tree and add to outputs
+        File dependencyTreeFile = new File(buildDirectory, "gradle.dependencytree");
+        writeDependencyTree(dependencyTreeFile, cwd);
+        outputFiles.add(dependencyTreeFile);
 
         return unpackedDependencies;
     }
@@ -278,6 +282,18 @@ public class RealGradleService implements GradleServiceInterface {
 
         MetricsWriter.metricsTimer(meterRegistry, "extender.service.gradle.get", System.currentTimeMillis() - methodStart);
         return unpackedDependencies;
+    }
+
+    private void writeDependencyTree(File out, File cwd) throws IOException, ExtenderException {
+        long methodStart = System.currentTimeMillis();
+        LOGGER.info("Writing dependency tree");
+
+        String treelog = execCommand("gradle dependencies --configuration releaseCompileClasspath", cwd);
+        LOGGER.info("\n" + treelog);
+
+        Files.write(out.toPath(), treelog.getBytes());
+
+        MetricsWriter.metricsTimer(meterRegistry, "extender.service.gradle.dependencytree", System.currentTimeMillis() - methodStart);
     }
 
 }


### PR DESCRIPTION
The build result will now include a Gradle dependency tree (`gradle.dependencytree`). This visualization of the dependency tree can be used to figure out how a transitive dependency was included in the final application bundle.

Fixes #647 

Example output from `extension-gpgs`:

```
gradle dependencies --configuration releaseCompileClasspath

> Task :dependencies

------------------------------------------------------------
Root project 'job16439745094295468761'
------------------------------------------------------------

releaseCompileClasspath - Resolved configuration for compilation for variant: release
+--- com.google.android.gms:play-services-base:18.5.0
|    +--- androidx.collection:collection:1.0.0 -> 1.1.0
|    |    \--- androidx.annotation:annotation:1.1.0 -> 1.2.0
|    +--- androidx.core:core:1.2.0 -> 1.8.0
|    |    +--- androidx.annotation:annotation:1.2.0
|    |    +--- androidx.annotation:annotation-experimental:1.1.0
|    |    +--- androidx.lifecycle:lifecycle-runtime:2.3.1 -> 2.5.1
|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.2.0
|    |    |    +--- androidx.arch.core:core-common:2.1.0
|    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.2.0
|    |    |    \--- androidx.lifecycle:lifecycle-common:2.5.1
|    |    |         \--- androidx.annotation:annotation:1.1.0 -> 1.2.0
|    |    \--- androidx.versionedparcelable:versionedparcelable:1.1.1
|    |         +--- androidx.annotation:annotation:1.1.0 -> 1.2.0
|    |         \--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
|    +--- androidx.fragment:fragment:1.0.0 -> 1.5.7
|    |    +--- androidx.activity:activity:1.5.1
|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.2.0
|    |    |    +--- androidx.core:core:1.8.0 (*)
|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.5.1 (*)
|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.5.1
|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.2.0
|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.6.21
|    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21
|    |    |    |         \--- org.jetbrains:annotations:13.0
|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.5.1
|    |    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.2.0
|    |    |    |    +--- androidx.core:core-ktx:1.2.0
|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.41 -> 1.6.21 (*)
|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.2.0
|    |    |    |    |    \--- androidx.core:core:1.2.0 -> 1.8.0 (*)
|    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.5.1
|    |    |    |    |    \--- androidx.lifecycle:lifecycle-common:2.5.1 (*)
|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.5.1 (*)
|    |    |    |    +--- androidx.savedstate:savedstate:1.2.0
|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.2.0
|    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.6.20 -> 1.6.21 (*)
|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.6.21 (*)
|    |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1
|    |    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1
|    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.1
|    |    |    |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.1
|    |    |    |         |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1 (c)
|    |    |    |         |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.1 (c)
|    |    |    |         |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1 (c)
|    |    |    |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0
|    |    |    |         |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.6.0 -> 1.6.21 (*)
|    |    |    |         |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.0
|    |    |    |         |         |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.6.0 -> 1.6.21 (*)
|    |    |    |         |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.0 -> 1.6.21
|    |    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.1 (*)
|    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0 (*)
|    |    |    +--- androidx.savedstate:savedstate:1.2.0 (*)
|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.6.21 (*)
|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.2.0
|    |    +--- androidx.annotation:annotation-experimental:1.0.0 -> 1.1.0
|    |    +--- androidx.collection:collection:1.1.0 (*)
|    |    +--- androidx.core:core-ktx:1.2.0 (*)
|    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.5.1 (*)
|    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.5.1 (*)
|    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.5.1 (*)
|    |    +--- androidx.loader:loader:1.0.0 -> 1.1.0
|    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.2.0
|    |    |    +--- androidx.core:core:1.0.0 -> 1.8.0 (*)
|    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.0.0 -> 2.5.1 (*)
|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.0.0 -> 2.5.1 (*)
|    |    |    \--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
|    |    +--- androidx.savedstate:savedstate:1.2.0 (*)
|    |    +--- androidx.viewpager:viewpager:1.0.0
|    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.2.0
|    |    |    +--- androidx.core:core:1.0.0 -> 1.8.0 (*)
|    |    |    \--- androidx.customview:customview:1.0.0
|    |    |         +--- androidx.annotation:annotation:1.0.0 -> 1.2.0
|    |    |         \--- androidx.core:core:1.0.0 -> 1.8.0 (*)
|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.6.21 (*)
|    +--- com.google.android.gms:play-services-basement:18.4.0
|    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
|    |    +--- androidx.core:core:1.2.0 -> 1.8.0 (*)
|    |    \--- androidx.fragment:fragment:1.1.0 -> 1.5.7 (*)
|    \--- com.google.android.gms:play-services-tasks:18.2.0
|         \--- com.google.android.gms:play-services-basement:18.4.0 (*)
+--- com.google.android.gms:play-services-auth:21.3.0
|    +--- androidx.fragment:fragment:1.5.7 (*)
|    +--- androidx.loader:loader:1.1.0 (*)
|    +--- com.google.android.gms:play-services-auth-api-phone:18.0.2
|    |    +--- com.google.android.gms:play-services-base:18.0.1 -> 18.5.0 (*)
|    |    +--- com.google.android.gms:play-services-basement:18.0.2 -> 18.4.0 (*)
|    |    \--- com.google.android.gms:play-services-tasks:18.0.1 -> 18.2.0 (*)
|    +--- com.google.android.gms:play-services-auth-base:18.0.10
|    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
|    |    +--- com.google.android.gms:play-services-base:18.0.1 -> 18.5.0 (*)
|    |    +--- com.google.android.gms:play-services-basement:18.2.0 -> 18.4.0 (*)
|    |    \--- com.google.android.gms:play-services-tasks:18.0.1 -> 18.2.0 (*)
|    +--- com.google.android.gms:play-services-base:18.5.0 (*)
|    +--- com.google.android.gms:play-services-basement:18.4.0 (*)
|    +--- com.google.android.gms:play-services-fido:20.0.1
|    |    +--- com.google.android.gms:play-services-base:18.0.1 -> 18.5.0 (*)
|    |    +--- com.google.android.gms:play-services-basement:18.0.0 -> 18.4.0 (*)
|    |    \--- com.google.android.gms:play-services-tasks:18.0.1 -> 18.2.0 (*)
|    \--- com.google.android.gms:play-services-tasks:18.2.0 (*)
+--- com.google.android.gms:play-services-games-v2:20.1.2
|    +--- com.google.android.gms:play-services-base:18.5.0 (*)
|    +--- com.google.android.gms:play-services-basement:18.4.0 (*)
|    +--- com.google.android.gms:play-services-drive:17.0.0
|    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
|    |    +--- com.google.android.gms:play-services-base:17.0.0 -> 18.5.0 (*)
|    |    +--- com.google.android.gms:play-services-basement:17.0.0 -> 18.4.0 (*)
|    |    \--- com.google.android.gms:play-services-tasks:17.0.0 -> 18.2.0 (*)
|    \--- com.google.android.gms:play-services-tasks:18.2.0 (*)
+--- com.google.android.gms:play-services-base:{strictly 18.5.0} -> 18.5.0 (c)
+--- com.google.android.gms:play-services-auth:{strictly 21.3.0} -> 21.3.0 (c)
+--- com.google.android.gms:play-services-games-v2:{strictly 20.1.2} -> 20.1.2 (c)
+--- androidx.collection:collection:{strictly 1.1.0} -> 1.1.0 (c)
+--- androidx.core:core:{strictly 1.8.0} -> 1.8.0 (c)
+--- androidx.fragment:fragment:{strictly 1.5.7} -> 1.5.7 (c)
+--- com.google.android.gms:play-services-basement:{strictly 18.4.0} -> 18.4.0 (c)
+--- com.google.android.gms:play-services-tasks:{strictly 18.2.0} -> 18.2.0 (c)
+--- androidx.loader:loader:{strictly 1.1.0} -> 1.1.0 (c)
+--- com.google.android.gms:play-services-auth-api-phone:{strictly 18.0.2} -> 18.0.2 (c)
+--- com.google.android.gms:play-services-auth-base:{strictly 18.0.10} -> 18.0.10 (c)
+--- com.google.android.gms:play-services-fido:{strictly 20.0.1} -> 20.0.1 (c)
+--- com.google.android.gms:play-services-drive:{strictly 17.0.0} -> 17.0.0 (c)
+--- androidx.annotation:annotation:{strictly 1.2.0} -> 1.2.0 (c)
+--- androidx.annotation:annotation-experimental:{strictly 1.1.0} -> 1.1.0 (c)
+--- androidx.lifecycle:lifecycle-runtime:{strictly 2.5.1} -> 2.5.1 (c)
+--- androidx.versionedparcelable:versionedparcelable:{strictly 1.1.1} -> 1.1.1 (c)
+--- androidx.activity:activity:{strictly 1.5.1} -> 1.5.1 (c)
+--- androidx.core:core-ktx:{strictly 1.2.0} -> 1.2.0 (c)
+--- androidx.lifecycle:lifecycle-livedata-core:{strictly 2.5.1} -> 2.5.1 (c)
+--- androidx.lifecycle:lifecycle-viewmodel:{strictly 2.5.1} -> 2.5.1 (c)
+--- androidx.lifecycle:lifecycle-viewmodel-savedstate:{strictly 2.5.1} -> 2.5.1 (c)
+--- androidx.savedstate:savedstate:{strictly 1.2.0} -> 1.2.0 (c)
+--- androidx.viewpager:viewpager:{strictly 1.0.0} -> 1.0.0 (c)
+--- org.jetbrains.kotlin:kotlin-stdlib:{strictly 1.6.21} -> 1.6.21 (c)
+--- androidx.arch.core:core-common:{strictly 2.1.0} -> 2.1.0 (c)
+--- androidx.lifecycle:lifecycle-common:{strictly 2.5.1} -> 2.5.1 (c)
+--- org.jetbrains.kotlinx:kotlinx-coroutines-android:{strictly 1.6.1} -> 1.6.1 (c)
+--- androidx.customview:customview:{strictly 1.0.0} -> 1.0.0 (c)
+--- org.jetbrains.kotlin:kotlin-stdlib-common:{strictly 1.6.21} -> 1.6.21 (c)
+--- org.jetbrains:annotations:{strictly 13.0} -> 13.0 (c)
+--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.6.1} -> 1.6.1 (c)
+--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.6.1} -> 1.6.1 (c)
+--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:{strictly 1.6.0} -> 1.6.0 (c)
+--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:{strictly 1.6.1} -> 1.6.1 (c)
\--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:{strictly 1.6.0} -> 1.6.0 (c)

(c) - A dependency constraint, not a dependency. The dependency affected by the constraint occurs elsewhere in the tree.
(*) - Indicates repeated occurrences of a transitive dependency subtree. Gradle expands transitive dependency subtrees only once per project; repeat occurrences only display the root of the subtree, followed by this annotation.

A web-based, searchable dependency report is available by adding the --scan option.

BUILD SUCCESSFUL in 1s
1 actionable task: 1 executed
```