### PR TITLE
Added flags for debug source remapping

### DIFF
--- a/server/src/main/java/com/defold/extender/ExtensionManifestValidator.java
+++ b/server/src/main/java/com/defold/extender/ExtensionManifestValidator.java
@@ -47,7 +47,7 @@ class ExtensionManifestValidator {
                 }
 
                 if (!f.exists()) {
-                    LOGGER.warn("The include path '%s' does not exist:", f);
+                    LOGGER.warn("The include path '{}' does not exist:", f);
                 }
             }
         }


### PR DESCRIPTION
Flag `-fdebug-compilation-dir` was set by compiler to current working dir. Now we use that flag to prefix source path in the debug information. Value for that flag takes from appmanifest (the same as we do for build variant, withSymbols flag, etc.)


Fixes #259 