### PR TITLE
Fixed issue with open sockets in case of cache upload fail

### DIFF
--- a/server/src/main/java/com/defold/extender/cache/GCPDataCache.java
+++ b/server/src/main/java/com/defold/extender/cache/GCPDataCache.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.FileInputStream;
 import java.nio.channels.Channels;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +26,8 @@ private static final Logger LOGGER = LoggerFactory.getLogger(GCPDataCache.class)
     private String bucketName;
     private String prefix;
 
+    private Set<String> currentUploads = new HashSet<>();
+
     public GCPDataCache(final String bucketName, final String prefix) {
         this.storage = StorageOptions.getDefaultInstance().getService();
         this.bucketName = bucketName;
@@ -39,7 +43,7 @@ private static final Logger LOGGER = LoggerFactory.getLogger(GCPDataCache.class)
     @Override
     public boolean exists(String key) {
         Blob blob = storage.get(this.bucketName, getBlobKey(key));
-        return blob != null;
+        return blob != null && blob.exists();
     }
 
     @Override
@@ -51,7 +55,7 @@ private static final Logger LOGGER = LoggerFactory.getLogger(GCPDataCache.class)
                 // metadata can be updated only by copying object to itself
                 blob.copyTo(this.bucketName, fullKey);
             } catch (StorageException exc) {
-                LOGGER.warn(String.format("Exception when touch object '%s' %s", fullKey, exc.getReason()));
+                LOGGER.warn("Exception when touch object '{}' {}", fullKey, exc.getReason());
             }
         }
     }
@@ -62,28 +66,29 @@ private static final Logger LOGGER = LoggerFactory.getLogger(GCPDataCache.class)
         BlobId blobId = BlobId.of(this.bucketName, blobKey);
         BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
     
-        // Optional: set a generation-match precondition to avoid potential race
-        // conditions and data corruptions. The request returns a 412 error if the
-        // preconditions are not met.
-        Storage.BlobWriteOption precondition;
-        if (this.storage.get(this.bucketName, blobKey) == null) {
-          // For a target object that does not yet exist, set the DoesNotExist precondition.
-          // This will cause the request to fail if the object is created before the request runs.
-          precondition = Storage.BlobWriteOption.doesNotExist();
-        } else {
-          // If the destination already exists in your bucket, instead set a generation-match
-          // precondition. This will cause the request to fail if the existing object's generation
-          // changes before the request runs.
-          precondition =
-              Storage.BlobWriteOption.generationMatch(
-                  this.storage.get(this.bucketName, blobKey).getGeneration());
-        }
-        try {
-            this.storage.createFrom(blobInfo, new FileInputStream(file), precondition);
-        } catch (StorageException storageExc) {
-            // in case if some concurrent requests uploads the same thing at the same time precondition can fail
-            // we can catch exception and continue working without any issue because file was uploaded by another job
-            LOGGER.info(String.format("Failed upload cache object with key %s", blobKey), storageExc);
+        Blob blob = this.storage.get(this.bucketName, blobKey);
+        if (blob == null) {
+            // For a target object that does not yet exist, set the DoesNotExist precondition.
+            // This will cause the request to fail if the object is created before the request runs.
+            Storage.BlobWriteOption precondition = Storage.BlobWriteOption.doesNotExist();
+            synchronized (currentUploads) {
+                if (currentUploads.contains(blobKey)) {
+                    LOGGER.debug("File with key {} is already uploading", blobKey);
+                    return;
+                }
+                currentUploads.add(blobKey);
+            }
+            try (InputStream in = new FileInputStream(file)) {
+                this.storage.createFrom(blobInfo, in, precondition);
+            } catch (StorageException storageExc) {
+                // in case if some concurrent requests uploads the same thing at the same time precondition can fail
+                // we can catch exception and continue working without any issue because file was uploaded by another job
+                LOGGER.info("Failed upload cache object with key {}", blobKey, storageExc);
+            } finally {
+                synchronized (currentUploads) {
+                    currentUploads.remove(blobKey);
+                }
+            }
         }
     }
     

--- a/server/src/main/java/com/defold/extender/services/DataCacheService.java
+++ b/server/src/main/java/com/defold/extender/services/DataCacheService.java
@@ -181,12 +181,8 @@ public class DataCacheService {
         return file.getParentFile().exists() || file.getParentFile().mkdirs();
     }
 
-    private long downloadFile(CacheEntry entry, File destination) throws ExtenderException, IOException {
+    private long downloadFile(CacheEntry entry, File destination) throws IOException {
         try (InputStream inputStream = dataCache.get(entry.getKey())) {
-            if (inputStream == null) {
-                throw new ExtenderException(String.format("Cache object %s (%s) was not found", entry.getPath(), entry.getKey()));
-            }
-
             return Files.copy(
                     inputStream,
                     destination.toPath(),


### PR DESCRIPTION
In that PR only uploading issue is solved.
Before start uploading we add key to special set to synchronize operations between several threads.

The second issue with concurrent download/update will be solved on GCS bucket configuration's side.

Fixes #690 