### PR TITLE
Rotate Cocoapods cache

### DIFF
--- a/server/configs/application-standalone-dev.yml
+++ b/server/configs/application-standalone-dev.yml
@@ -11,7 +11,7 @@ extender:
         enabled: false
     cocoapods:
         enabled: true
-        home-dir-prefix: /usr/local/extender/.cocoapods
+        home-dir-prefix: /tmp/extender/.cocoapods
         repo-update-cron: "0 0 * * * *" # update spec repo every 1 h
         cache-dir-rotate-cron: "0 10 2 * * *" # once per day
         old-cache-clean-cron: "0 10 6 * * *" # once per day after directory rotation

--- a/server/configs/application-standalone-dev.yml
+++ b/server/configs/application-standalone-dev.yml
@@ -9,3 +9,9 @@ extender:
         enabled: false
     remote-builder:
         enabled: false
+    cocoapods:
+        enabled: true
+        home-dir-prefix: /usr/local/extender/.cocoapods
+        repo-update-cron: "0 0 * * * *" # update spec repo every 1 h
+        cache-dir-rotate-cron: "0 10 2 * * *" # once per day
+        old-cache-clean-cron: "0 10 6 * * *" # once per day after directory rotation

--- a/server/src/main/java/com/defold/extender/AsyncBuilder.java
+++ b/server/src/main/java/com/defold/extender/AsyncBuilder.java
@@ -8,6 +8,7 @@ import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.Optional;
 
 import com.defold.extender.log.Markers;
 import com.defold.extender.metrics.MetricsWriter;
@@ -39,12 +40,12 @@ public class AsyncBuilder {
 
     public AsyncBuilder(DefoldSdkService defoldSdkService,
                         GradleService gradleService,
-                        CocoaPodsService cocoaPodsService,
+                        Optional<CocoaPodsService> cocoaPodsService,
                         @Value("${extender.job-result.location}") String jobResultLocation,
                         @Value("${extender.job-result.lifetime:1200000}") long jobResultLifetime) {
         this.defoldSdkService = defoldSdkService;
         this.gradleService = gradleService;
-        this.cocoaPodsService = cocoaPodsService;
+        cocoaPodsService.ifPresent(val -> { this.cocoaPodsService = val; });
         this.jobResultLocation = new File(jobResultLocation);
         this.keepJobDirectory = System.getenv("DM_DEBUG_KEEP_JOB_FOLDER") != null || System.getenv("DM_DEBUG_JOB_FOLDER") != null;
         this.resultLifetime = jobResultLifetime;

--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -44,6 +44,7 @@ import com.defold.extender.services.CocoaPodsService.ResolvedPods;
 import com.defold.extender.builders.CSharpBuilder;
 import com.defold.extender.log.Markers;
 import com.defold.extender.metrics.MetricsWriter;
+import com.defold.extender.process.ProcessExecutor;
 
 class Extender {
     private static final Logger LOGGER = LoggerFactory.getLogger(Extender.class);

--- a/server/src/main/java/com/defold/extender/FrameworkUtil.java
+++ b/server/src/main/java/com/defold/extender/FrameworkUtil.java
@@ -1,30 +1,11 @@
 package com.defold.extender;
 
 import java.io.File;
-import java.io.IOException;
+import java.util.List;
+
+import com.defold.extender.process.ProcessUtils;
 
 public class FrameworkUtil {
-    private static String execCommand(String command, File cwd) throws ExtenderException {
-        ProcessExecutor pe = new ProcessExecutor();
-
-        if (cwd != null) {
-            pe.setCwd(cwd);
-        }
-
-        try {
-            if (pe.execute(command) != 0) {
-                throw new ExtenderException(pe.getOutput());
-            }
-        } catch (IOException | InterruptedException e) {
-            throw new ExtenderException(e, pe.getOutput());
-        }
-
-        return pe.getOutput();
-    }
-    private static String execCommand(String command) throws ExtenderException {
-        return execCommand(command, null);
-    }
-
     /**
      * Check if a framework is dynamically linked
      * Cocoapods (written in Ruby) uses the "macho" gem to do the same thing:
@@ -42,7 +23,9 @@ public class FrameworkUtil {
         if (framework.isDirectory() && filename.endsWith(".framework")) {
             String frameworkName = filename.replace(".framework", "");
             File frameworkBinary = new File(framework, frameworkName);
-            String output = execCommand("file " + frameworkBinary.getAbsolutePath());
+            String output = ProcessUtils.execCommand(List.of(
+                "file",
+                frameworkBinary.getAbsolutePath()), null, null);
             if (output.contains("dynamically linked shared library")) {
                 return true;
             }

--- a/server/src/main/java/com/defold/extender/builders/CSharpBuilder.java
+++ b/server/src/main/java/com/defold/extender/builders/CSharpBuilder.java
@@ -20,8 +20,8 @@ import java.util.ArrayList;
 
 import com.defold.extender.ExtenderException;
 import com.defold.extender.ExtenderUtil;
-import com.defold.extender.ProcessExecutor;
 import com.defold.extender.TemplateExecutor;
+import com.defold.extender.process.ProcessExecutor;
 
 public class CSharpBuilder {
     private static final Logger LOGGER = LoggerFactory.getLogger(CSharpBuilder.class);

--- a/server/src/main/java/com/defold/extender/process/ProcessUtils.java
+++ b/server/src/main/java/com/defold/extender/process/ProcessUtils.java
@@ -1,0 +1,48 @@
+package com.defold.extender.process;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.defold.extender.ExtenderException;
+
+public class ProcessUtils {
+    public static String execCommand(String command) throws ExtenderException {
+        return execCommand(command, null);
+    }
+
+    public static String execCommand(String command, File cwd) throws ExtenderException {
+        return execCommand(command, cwd, null);
+    }
+
+    public static String execCommand(String command, File cwd, Map<String, String> env) throws ExtenderException {
+        List<String> args = Arrays.stream(command.split(" "))
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+        return execCommand(args, cwd, env);
+    }    
+
+    public static String execCommand(List<String> args, File cwd, Map<String, String> env) throws ExtenderException {
+        ProcessExecutor pe = new ProcessExecutor();
+
+        if (cwd != null) {
+            pe.setCwd(cwd);
+        }
+        if (env != null) {
+            pe.putEnv(env);
+        }
+
+        try {
+            if (pe.execute(args) != 0) {
+                throw new ExtenderException(pe.getOutput());
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new ExtenderException(e, pe.getOutput());
+        }
+
+        return pe.getOutput();
+    }
+}

--- a/server/src/main/java/com/defold/extender/services/CocoaPodsService.java
+++ b/server/src/main/java/com/defold/extender/services/CocoaPodsService.java
@@ -372,6 +372,7 @@ public class CocoaPodsService {
     private final String modulemapTemplateContents;
     private final String umbrellaHeaderTemplateContents;
     private @Value("${extender.cocoapods.home-dir-prefix}") String homeDirPrefix;
+    private @Value("${extender.cocoapods.cdn-concurrency:10}") int maxPodCDNConcurrency;
     private Path currentCacheDir;
 
     private final MeterRegistry meterRegistry;
@@ -1274,7 +1275,8 @@ public class CocoaPodsService {
                 "pod",
                 "install",
                 "--verbose"
-            ), workingDir, null);
+            ), workingDir, Map.of("CP_HOME_DIR", this.currentCacheDir.toString(),
+            "COCOAPODS_CDN_MAX_CONCURRENCY", String.valueOf(maxPodCDNConcurrency)));
         LOGGER.debug("\n" + log);
 
         File podFileLock = new File(workingDir, "Podfile.lock");
@@ -1506,8 +1508,6 @@ public class CocoaPodsService {
                 ), null,
                 Map.of("CP_HOME_DIR", this.currentCacheDir.toString()));
             LOGGER.debug("\n" + log);
-
-            updateSpecRepo();
         } catch(ExtenderException exc) {
             LOGGER.warn("Exception during repo init", exc);
         }        
@@ -1569,7 +1569,8 @@ public class CocoaPodsService {
                     "update",
                     "--verbose"
                 ), null,
-                Map.of("CP_HOME_DIR", this.currentCacheDir.toString()));
+                Map.of("CP_HOME_DIR", this.currentCacheDir.toString(),
+                    "COCOAPODS_CDN_MAX_CONCURRENCY", String.valueOf(maxPodCDNConcurrency)));
             LOGGER.debug("\n" + log);
         } catch(ExtenderException exc) {
             LOGGER.warn("Exception during spec repo update", exc);

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -31,6 +31,12 @@ extender:
     gradle:
         enabled: false
         location: /tmp/.gradle
+    cocoapods:
+        enabled: false
+        home-dir-prefix: /tmp/.cocoapods
+        repo-update-cron: "0 0 * * * *" # update spec repo every 1 h
+        cache-dir-rotate-cron: "0 10 2 * * *" # once per day
+        old-cache-clean-cron: "0 10 6 * * *" # once per day after directory rotation
     # refer to README_SECURITY.md for information on securing your server
     authentication:
         # empty string, all platforms allowed without authentication

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -33,6 +33,7 @@ extender:
         location: /tmp/.gradle
     cocoapods:
         enabled: false
+        cdn-concurrency: 10 # value for COCOAPODS_CDN_MAX_CONCURRENCY
         home-dir-prefix: /tmp/.cocoapods
         repo-update-cron: "0 0 * * * *" # update spec repo every 1 h
         cache-dir-rotate-cron: "0 10 2 * * *" # once per day

--- a/server/src/test/java/com/defold/extender/AuthenticationTest.java
+++ b/server/src/test/java/com/defold/extender/AuthenticationTest.java
@@ -4,6 +4,7 @@ import com.defold.extender.client.ExtenderClient;
 import com.defold.extender.client.ExtenderClientException;
 import com.defold.extender.client.ExtenderResource;
 import com.defold.extender.client.FileExtenderResource;
+import com.defold.extender.process.ProcessExecutor;
 import com.google.common.collect.Lists;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterAll;

--- a/server/src/test/java/com/defold/extender/IntegrationTest.java
+++ b/server/src/test/java/com/defold/extender/IntegrationTest.java
@@ -1,6 +1,7 @@
 package com.defold.extender;
 
 import com.defold.extender.client.*;
+import com.defold.extender.process.ProcessExecutor;
 import com.google.common.collect.Lists;
 import org.jf.dexlib2.DexFileFactory;
 import org.jf.dexlib2.Opcodes;


### PR DESCRIPTION
* Implemented pod cache location configuration.
* Implemented pod cache cleanup.
* Implemented spec repo update according to schedule.
* Extract 'execCommand' to common utility class.
* Make CocoapodsService optional.

Cache rotation implmeneted via setting environment variable `CP_HOME_DIR`. According to the schedule service generates new value for that variable and start working with it. All previous cache location stored in the separate file. Scheduled task runs, read that file and remove all unused directories.

That approach helps to control cache size + it can fix issue with downloading specs (because we change directory and spec repository downloads again).

Also scheduled task will update spec repository. Probably it helps to avoid rate limit issues.

Fixes #344 
Possible fix for #680 
