### PR TITLE
Fix cocoapods vendored framework parsing

### DIFF
--- a/server/src/test/java/com/defold/extender/services/cocoapods/CocoaPodsServiceTest.java
+++ b/server/src/test/java/com/defold/extender/services/cocoapods/CocoaPodsServiceTest.java
@@ -164,7 +164,139 @@ public class CocoaPodsServiceTest {
             assertFalse(subspec.flags.osx.cpp.contains(INHERITED_VALUE));
             assertFalse(subspec.flags.osx.objc.contains(INHERITED_VALUE));
             assertFalse(subspec.flags.osx.objcpp.contains(INHERITED_VALUE));
+        }    
+    }
+
+    @Test
+    public void testSpecBraceExpanderVendoredFrameworks() throws ExtenderException, IOException {
+        String jsonSpec = Files.readString(Path.of("test-data/pod_specs/TPNiOS.json"));
+        File workingDir = Files.createTempDirectory("bracer-spec-test").toFile();
+        File podsDir = new File(workingDir, "pods");
+        podsDir.mkdir();
+        File generatedDir = new File(workingDir, "generated");
+        generatedDir.mkdir();
+        workingDir.deleteOnExit();
+        PodSpecParser.CreatePodSpecArgs args = new PodSpecParser.CreatePodSpecArgs.Builder()
+            .setGeneratedDir(generatedDir)
+            .setPodsDir(podsDir)
+            .setSpecJson(jsonSpec)
+            .setWorkingDir(workingDir)
+            .setJobContext(this.jobContext)
+            .build();
+        PodSpec podSpec = PodSpecParser.createPodSpec(args);
+        String[] expectedValues = new String[]{
+            "core/AnyThinkBanner.xcframework",
+            "core/AnyThinkSplash.xcframework",
+            "core/AnyThinkRewardedVideo.xcframework",
+            "core/AnyThinkInterstitial.xcframework",
+            "core/AnyThinkNative.xcframework",
+            "core/AnyThinkMediaVideo.xcframework",
+            "core/AnyThinkSDK.xcframework"
+        };
+        assertArrayEquals(expectedValues, podSpec.subspecs.get(0).vendoredFrameworks.toArray());
+    }
+
+    @Test
+    public void testSpecBraceExpanderSourceFiles() throws ExtenderException, IOException {
+        String jsonSpec = Files.readString(Path.of("test-data/pod_specs/PubNub.json"));
+        File workingDir = Files.createTempDirectory("sources-spec-test").toFile();
+        File podsDir = new File(workingDir, "pods");
+        podsDir.mkdir();
+        File generatedDir = new File(workingDir, "generated");
+        generatedDir.mkdir();
+        workingDir.deleteOnExit();
+        PodSpecParser.CreatePodSpecArgs args = new PodSpecParser.CreatePodSpecArgs.Builder()
+            .setGeneratedDir(generatedDir)
+            .setPodsDir(podsDir)
+            .setSpecJson(jsonSpec)
+            .setWorkingDir(workingDir)
+            .setJobContext(this.jobContext)
+            .build();
+        // create empty files to simulate sources
+        String[] simulatedFiles = new String[]{
+            "PubNub/Core/core1/core11.cpp",
+            "PubNub/Core/core1/core12.cpp",
+            "PubNub/Core/core1/core1.h",
+            "PubNub/Core/core2/core21.cpp",
+            "PubNub/Core/core2/core22.cpp",
+            "PubNub/Core/core2/core2.h",
+
+            "PubNub/Data/data1/data11.cpp",
+            "PubNub/Data/data1/data12.cpp",
+            "PubNub/Data/data1/data1.h",
+            "PubNub/Data/data2/data21.cpp",
+            "PubNub/Data/data2/data22.cpp",
+            "PubNub/Data/data2/data2.h",
+
+            "PubNub/Misc/misc1/misc11.cpp",
+            "PubNub/Misc/misc1/misc12.cpp",
+            "PubNub/Misc/misc1/misc1.h",
+            "PubNub/Misc/misc2/misc21.cpp",
+            "PubNub/Misc/misc2/misc22.cpp",
+            "PubNub/Misc/misc2/misc2.h",
+
+            "PubNub/Network/network1/network11.cpp",
+            "PubNub/Network/network1/network12.cpp",
+            "PubNub/Network/network1/network1.h",
+            "PubNub/Network/network2/network21.cpp",
+            "PubNub/Network/network2/network22.cpp",
+            "PubNub/Network/network2/network2.h"
+        };
+        File pubNubFolder = new File(podsDir, "PubNub");
+        for (String f : simulatedFiles) {
+            File emptyF = new File(pubNubFolder, f);
+            emptyF.getParentFile().mkdirs();
+            emptyF.createNewFile();
         }
-        
+
+        PodSpec podSpec = PodSpecParser.createPodSpec(args);
+        File[] expectedValues = new File[]{
+            new File(pubNubFolder, "PubNub/Core/core1/core11.cpp"),
+            new File(pubNubFolder, "PubNub/Core/core1/core12.cpp"),
+            new File(pubNubFolder, "PubNub/Core/core2/core21.cpp"),
+            new File(pubNubFolder, "PubNub/Core/core2/core22.cpp"),
+
+            new File(pubNubFolder, "PubNub/Data/data1/data11.cpp"),
+            new File(pubNubFolder, "PubNub/Data/data1/data12.cpp"),
+            new File(pubNubFolder, "PubNub/Data/data2/data21.cpp"),
+            new File(pubNubFolder, "PubNub/Data/data2/data22.cpp"),
+
+            new File(pubNubFolder, "PubNub/Misc/misc1/misc11.cpp"),
+            new File(pubNubFolder, "PubNub/Misc/misc1/misc12.cpp"),
+            new File(pubNubFolder, "PubNub/Misc/misc2/misc21.cpp"),
+            new File(pubNubFolder, "PubNub/Misc/misc2/misc22.cpp"),
+
+            new File(pubNubFolder, "PubNub/Network/network1/network11.cpp"),
+            new File(pubNubFolder, "PubNub/Network/network1/network12.cpp"),
+            new File(pubNubFolder, "PubNub/Network/network2/network21.cpp"),
+            new File(pubNubFolder, "PubNub/Network/network2/network22.cpp")
+        };
+        assertArrayEquals(expectedValues, podSpec.subspecs.get(0).sourceFiles.toArray());
+    }
+
+    @Test
+    public void testDefaultSubspecs() throws ExtenderException, IOException {
+        String jsonSpec = Files.readString(Path.of("test-data/pod_specs/Wilddog.json"));
+        File workingDir = Files.createTempDirectory("sources-spec-test").toFile();
+        File podsDir = new File(workingDir, "pods");
+        podsDir.mkdir();
+        File generatedDir = new File(workingDir, "generated");
+        generatedDir.mkdir();
+        workingDir.deleteOnExit();
+        PodSpecParser.CreatePodSpecArgs args = new PodSpecParser.CreatePodSpecArgs.Builder()
+            .setGeneratedDir(generatedDir)
+            .setPodsDir(podsDir)
+            .setSpecJson(jsonSpec)
+            .setWorkingDir(workingDir)
+            .setJobContext(this.jobContext)
+            .build();
+        PodSpec podSpec = PodSpecParser.createPodSpec(args);
+        String[] expectedValues = new String[]{
+            "Public",
+            "Sync",
+            "Auth",
+            "Core"
+        };
+        assertArrayEquals(expectedValues, podSpec.defaultSubspecs.toArray());
     }
 }

--- a/server/test-data/pod_specs/PubNub.json
+++ b/server/test-data/pod_specs/PubNub.json
@@ -1,0 +1,66 @@
+{
+    "name": "PubNub",
+    "version": "4.15.1",
+    "summary": "The PubNub Real-Time Network. Build real-time apps quickly and scale them globally.",
+    "homepage": "https://github.com/pubnub/objective-c",
+    "authors": {
+      "PubNub, Inc.": "support@pubnub.com"
+    },
+    "social_media_url": "https://twitter.com/pubnub",
+    "source": {
+      "git": "https://github.com/pubnub/objective-c.git",
+      "tag": "v4.15.1"
+    },
+    "platforms": {
+      "ios": "9.0",
+      "watchos": "4.0",
+      "osx": "10.11",
+      "tvos": "10.0"
+    },
+    "requires_arc": true,
+    "libraries": "z",
+    "default_subspecs": "Core",
+    "license": {
+      "type": "MIT",
+      "text": "            PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks\n            Copyright (c) 2013 PubNub Inc.\n            http://www.pubnub.com/\n            http://www.pubnub.com/terms\n\n            Permission is hereby granted, free of charge, to any person obtaining a copy\n            of this software and associated documentation files (the \"Software\"), to deal\n            in the Software without restriction, including without limitation the rights\n            to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n            copies of the Software, and to permit persons to whom the Software is\n            furnished to do so, subject to the following conditions:\n\n            The above copyright notice and this permission notice shall be included in\n            all copies or substantial portions of the Software.\n\n            THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n            IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n            FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n            AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n            LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n            OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\n            THE SOFTWARE.\n\n            PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks\n            Copyright (c) 2014 PubNub Inc.\n            http://www.pubnub.com/\n            http://www.pubnub.com/terms\n"
+    },
+    "subspecs": [
+      {
+        "name": "Core",
+        "source_files": [
+          "PubNub/{Core,Data,Misc,Network}/**/*",
+          "PubNub/PubNub.h"
+        ],
+        "private_header_files": [
+          "PubNub/**/*Private.h",
+          "PubNub/Data/{PNEnvelopeInformation}.h",
+          "PubNub/Data/Managers/**/*.h",
+          "PubNub/Data/Models/PNXML.h",
+          "PubNub/Data/Service Objects/PNGenerateFileUploadURLStatus.h",
+          "PubNub/Misc/{PNConstants,PNPrivateStructures}.h",
+          "PubNub/Misc/Helpers/{PNArray,PNChannel,PNData,PNDate,PNDictionary,PNGZIP,PNHelpers,PNJSON,PNLockSupport,PNNumber,PNString,PNURLRequest}.h",
+          "PubNub/Misc/Logger/PNLogMacro.h",
+          "PubNub/Misc/Logger/Data/*.h",
+          "PubNub/Misc/Protocols/PNParser.h",
+          "PubNub/Network/{PNNetwork,PNNetworkResponseSerializer,PNReachability,PNRequestParameters,PNURLBuilder}.h",
+          "PubNub/Network/Requests/Files/PNGenerateFileUploadURLRequest.h",
+          "PubNub/Network/Parsers/**/*.h"
+        ],
+        "pod_target_xcconfig": {
+          "APPLICATION_EXTENSION_API_ONLY": "YES"
+        }
+      },
+      {
+        "name": "Logger",
+        "source_files": [
+          "PubNub/Misc/Logger/{Core,Data}/**/*",
+          "PubNub/Misc/Helpers/{PNLockSupport,PNDefines}.{h,m}"
+        ],
+        "private_header_files": [
+          "PubNub/Misc/Logger/Data/*.h",
+          "PubNub/Misc/Helpers/{PNLockSupport,PNDefines}.h"
+        ]
+      }
+    ]
+}
+  

--- a/server/test-data/pod_specs/TPNiOS.json
+++ b/server/test-data/pod_specs/TPNiOS.json
@@ -1,0 +1,57 @@
+{
+    "name": "TPNiOS",
+    "version": "1.0.0",
+    "summary": "A short description of TPN SDK for iOS.",
+    "description": "TopOn SDK for developer",
+    "homepage": "https://github.com/TPNteam/sdk_ios_cocoapod",
+    "license": {
+      "type": "MIT",
+      "file": "TPNiOS/LICENSE"
+    },
+    "authors": {
+      "topon": "developer@toponad.com"
+    },
+    "source": {
+      "http": "https://topon-sdk-release.oss-cn-hangzhou.aliyuncs.com/TPN_Release/v1.0.0/iOS/TPN_mediation/AnyThinkiOS.zip"
+    },
+    "platforms": {
+      "ios": "9.0"
+    },
+    "static_framework": true,
+    "requires_arc": true,
+    "frameworks": [
+      "SystemConfiguration",
+      "CoreGraphics",
+      "Foundation",
+      "UIKit"
+    ],
+    "pod_target_xcconfig": {
+      "VALID_ARCHS": "arm64 arm64e armv7 armv7s x86_64",
+      "VALID_ARCHS[sdk=iphoneos*]": "arm64 arm64e armv7 armv7s",
+      "VALID_ARCHS[sdk=iphonesimulator*]": "arm64 arm64e x86_64"
+    },
+    "libraries": [
+      "c++",
+      "z",
+      "sqlite3",
+      "xml2",
+      "resolv"
+    ],
+    "default_subspecs": "TPNSDK",
+    "swift_versions": "5.0",
+    "subspecs": [
+      {
+        "name": "TPNSDK",
+        "platforms": {
+          "ios": "9.0"
+        },
+        "vendored_frameworks": [
+          "core/AnyThink{Banner,Splash,RewardedVideo,Interstitial,Native,MediaVideo}.xcframework",
+          "core/AnyThinkSDK.xcframework"
+        ],
+        "resources": "core/AnyThinkSDK.bundle"
+      }
+    ],
+    "swift_version": "5.0"
+}
+  

--- a/server/test-data/pod_specs/Wilddog.json
+++ b/server/test-data/pod_specs/Wilddog.json
@@ -1,0 +1,80 @@
+{
+    "name": "Wilddog",
+    "version": "2.3.6",
+    "summary": "安全可靠的实时通信云",
+    "description": "野狗为企业和开发者提供了可编程的实时数据、语音、视频通信能力，以及身份认证服务，可以安全地构建丰富场景化的实时通信业务。",
+    "homepage": "https://www.wilddog.com/",
+    "license": {
+      "type": "Copy right",
+      "text": "https://www.wilddog.com/terms/sa"
+    },
+    "authors": {
+      "Wilddog": "ceo@wilddog.com"
+    },
+    "source": {
+      "git": "https://github.com/WildDogTeam/wilddog-ios.git",
+      "tag": "2.3.6"
+    },
+    "platforms": {
+      "ios": "7.0"
+    },
+    "preserve_paths": "README.md",
+    "default_subspecs": [
+      "Public",
+      "Sync",
+      "Auth",
+      "Core"
+    ],
+    "subspecs": [
+      {
+        "name": "Public",
+        "source_files": [
+          "Wilddog/Sources/Wilddog.h"
+        ],
+        "preserve_paths": [
+          "Wilddog/Sources/module.modulemap"
+        ],
+        "dependencies": {
+          "WilddogCore": "~>2.0.9"
+        },
+        "user_target_xcconfig": {
+          "HEADER_SEARCH_PATHS": "$(inherited) ${PODS_ROOT}/Wilddog/Wilddog/Sources"
+        }
+      },
+      {
+        "name": "Sync",
+        "dependencies": {
+          "Wilddog/Public": [
+  
+          ],
+          "WilddogSync": "~>2.3.6"
+        }
+      },
+      {
+        "name": "Auth",
+        "dependencies": {
+          "Wilddog/Public": [
+  
+          ],
+          "WilddogAuth": "~>2.0.7"
+        }
+      },
+      {
+        "name": "Core",
+        "dependencies": {
+          "Wilddog/Public": [
+  
+          ]
+        }
+      },
+      {
+        "name": "Video",
+        "dependencies": {
+          "WilddogVideo": [
+  
+          ]
+        }
+      }
+    ]
+}
+  


### PR DESCRIPTION
`vendored_frameworks` can has values with bracers notation like `"core/AnyThink{Banner,Splash,RewardedVideo,Interstitial,Native,MediaVideo}.xcframework"` which should interpret as list of paths. So added bracers expand logic for different spec's files which contains paths. 
Applied the same logic for source paths, header paths, resource, frameworks and weak frameworks.
Also applied logic from #695 to compiler flags.

Based on https://github.com/defold/extender/tree/issue-684-pod-spec-parsing to avoid conflicts.

Fixes #686 