### PR TITLE
Write source list to temp file and pass it as input to compile command

### DIFF
--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -596,10 +596,12 @@ class Extender {
         frameworkPaths.addAll(getFrameworkPaths(pod.dir));
         frameworkPaths.addAll(resolvedPods.getFrameworksSearchPaths());
 
+        File sourceListFile = ExtenderUtil.writeSourceFilesListToTmpFile(pod.swiftSourceFilePaths);
+
         Map<String, Object> context = createContext(manifestContext);
         context.put("ext", ImmutableMap.of("includes", includes, "frameworks", frameworks, "frameworkPaths", frameworkPaths));
         context.put("moduleName", pod.moduleName);
-        context.put("swiftSourceFiles", pod.swiftSourceFilePaths);
+        context.put("swiftSourceFiles", String.format("@%s", sourceListFile.getAbsolutePath()));
         context.put("swiftHeaderPath", pod.swiftModuleHeader.toString());
         context.put("swiftVersion", "5");
         context.put("parallelJobs", String.valueOf(Runtime.getRuntime().availableProcessors()));
@@ -619,10 +621,12 @@ class Extender {
         frameworkPaths.addAll(getFrameworkPaths(pod.dir));
         frameworkPaths.addAll(resolvedPods.getFrameworksSearchPaths());
 
+        File sourceListFile = ExtenderUtil.writeSourceFilesListToTmpFile(pod.swiftSourceFilePaths);
+
         Map<String, Object> context = createContext(manifestContext);
         context.put("ext", ImmutableMap.of("includes", includes, "frameworks", frameworks, "frameworkPaths", frameworkPaths));
         context.put("moduleName", pod.moduleName);
-        context.put("swiftSourceFiles", pod.swiftSourceFilePaths);
+        context.put("swiftSourceFiles", String.format("@%s", sourceListFile.getAbsolutePath()));
         context.put("swiftModulePath", new File(pod.buildDir, pod.moduleName + ".swiftmodule"));
         context.put("swiftVersion", "5");
         context.put("parallelJobs", String.valueOf(Runtime.getRuntime().availableProcessors()));
@@ -668,12 +672,14 @@ class Extender {
         frameworkPaths.addAll(getFrameworkPaths(pod.dir));
         frameworkPaths.addAll(resolvedPods.getFrameworksSearchPaths());
 
+        File sourceFileList = ExtenderUtil.writeSourceFilesListToTmpFile(swiftSourceFilePaths);
+        File primarySourceFile = ExtenderUtil.writeSourceFilesListToTmpFile(Set.of(swiftPrimarySourceFile));
         Map<String, Object> context = createContext(manifestContext);
         context.put("ext", ImmutableMap.of("includes", includes, "frameworks", frameworks, "frameworkPaths", frameworkPaths));
         context.put("tgt", ExtenderUtil.getRelativePath(jobDirectory, o));
         context.put("moduleName", pod.moduleName);
-        context.put("swiftPrimarySourceFile", swiftPrimarySourceFile);
-        context.put("swiftSourceFiles", swiftSourceFilePaths);
+        context.put("swiftPrimarySourceFile", String.format("@%s", primarySourceFile.getAbsolutePath()));
+        context.put("swiftSourceFiles", String.format("@%s", sourceFileList.getAbsolutePath()));
         context.put("swiftVersion", "5");
         String command = templateExecutor.execute(this.platformConfig.compileSwiftCmd, context);
         // LOGGER.info("swift-frontend command to compile swift source file: " + command);

--- a/server/src/main/java/com/defold/extender/ExtenderUtil.java
+++ b/server/src/main/java/com/defold/extender/ExtenderUtil.java
@@ -32,6 +32,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.commons.io.filefilter.TrueFileFilter;
+import org.apache.commons.text.StringEscapeUtils;
 import org.json.simple.JSONObject;
 import org.springframework.core.io.Resource;
 
@@ -915,5 +916,15 @@ public class ExtenderUtil
             hexString.append(String.format("%02x", b));
         }
         return hexString.toString();
+    }
+
+    public static File writeSourceFilesListToTmpFile(Set<String> fileList) throws IOException {
+        File resultFile = Files.createTempFile(null, "sourcelist").toFile();
+        Set<String> escapedList = new HashSet<>();
+        fileList.forEach((elem) -> {
+            escapedList.add(StringEscapeUtils.escapeXSI(elem));
+        });
+        FileUtils.writeLines(resultFile, escapedList);
+        return resultFile;
     }
 }

--- a/server/src/test/java/com/defold/extender/ExtenderUtilTest.java
+++ b/server/src/test/java/com/defold/extender/ExtenderUtilTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class ExtenderUtilTest {
 
@@ -296,5 +297,26 @@ public class ExtenderUtilTest {
         assertEquals(expectedSha, calculatedSha);
 
         assertThrows(FileNotFoundException.class, () -> ExtenderUtil.calculateSHA256(new FileInputStream("test-data/checksum_sdk/non-exist.zip")));
+    }
+
+    @Test
+    public void testWriteSourceListToTempFile() throws IOException {
+        Set<String> sources = Set.of("/path/path1/path2/path3/source1.swift",
+            "/path/path4/path2/path3/source2.swift",
+            "/path/path1 space/path8/path3 space/source3.swift",
+            "/path/path4/path2/path/source4 space.swift",
+            "/path/path6/path7 space/path3/source5.swift");
+
+        Set<String> expected = Set.of("/path/path1/path2/path3/source1.swift",
+            "/path/path4/path2/path3/source2.swift",
+            "/path/path1\\ space/path8/path3\\ space/source3.swift",
+            "/path/path4/path2/path/source4\\ space.swift",
+            "/path/path6/path7\\ space/path3/source5.swift");
+        File resFile = ExtenderUtil.writeSourceFilesListToTmpFile(sources);
+        assertTrue(resFile.exists());
+        List<String> writtenLines = FileUtils.readLines(resFile, StandardCharsets.UTF_8);
+        assertEquals(expected.size(), writtenLines.size());
+        assertTrue(expected.containsAll(writtenLines));
+        assertTrue(writtenLines.containsAll(expected));
     }
 }


### PR DESCRIPTION
Write list of source files list to temporary file in escape form. It helps avoid problem when `ProcessExecutor` split input string command by space and intepret as separate arguments.

Fixes #701 