### PR TITLE
Implemented source code upload as archive instead of separate files as multipart form

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     testImplementation('commons-io:commons-io:2.18.0')
     testImplementation("org.mockito:mockito-core:5.+")
     testImplementation('org.junit.jupiter:junit-jupiter-engine:5.11.4')
+    testImplementation('org.junit.jupiter:junit-jupiter-params:5.11.4')
+    testImplementation('org.apache.james:apache-mime4j:0.8.13')
 }
 
 test {

--- a/client/src/test/java/com/defold/extender/client/ExtenderClientCacheTest.java
+++ b/client/src/test/java/com/defold/extender/client/ExtenderClientCacheTest.java
@@ -1,0 +1,232 @@
+package com.defold.extender.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+
+public class ExtenderClientCacheTest {
+    @Test
+    public void testClientCacheHash() throws IOException, InterruptedException, ExtenderClientException {
+        TestUtils.writeToFile("build/a", "a");
+        TestUtils.writeToFile("build/b", "a");
+        TestUtils.writeToFile("build/c", "b");
+
+        ExtenderClientCache cache = new ExtenderClientCache(new File("."));
+
+        {
+            File file1 = new File("build/a");
+            File file2 = new File("build/b");
+            File file3 = new File("build/c");
+            FileExtenderResource file1Res = new FileExtenderResource(file1);
+            FileExtenderResource file2Res = new FileExtenderResource(file2);
+            FileExtenderResource file3Res = new FileExtenderResource(file3);
+            assertEquals(cache.getHash(file1Res), cache.getHash(file2Res));
+            assertNotEquals(cache.getHash(file1Res), cache.getHash(file3Res));
+        }
+
+        Thread.sleep(1000);
+
+        TestUtils.writeToFile("build/b", "b");
+
+        {
+            File file1 = new File("build/a");
+            File file2 = new File("build/b");
+            FileExtenderResource file1Res = new FileExtenderResource(file1);
+            FileExtenderResource file2Res = new FileExtenderResource(file2);
+
+            assertNotEquals(cache.getHash(file1Res), cache.getHash(file2Res));
+        }
+
+        FileUtils.deleteQuietly(new File("build/a"));
+        FileUtils.deleteQuietly(new File("build/b"));
+        FileUtils.deleteQuietly(new File("build/c"));
+    }
+
+    @Test
+    public void testClientCacheSignatureHash() throws IOException, ExtenderClientException {
+        File a = new File("build/a");
+        File b = new File("build/b");
+        FileExtenderResource aRes = new FileExtenderResource(a);
+        FileExtenderResource bRes = new FileExtenderResource(b);
+
+        TestUtils.writeToFile("build/a", "a");
+        TestUtils.writeToFile("build/b", "b");
+
+        List<ExtenderResource> files1 = new ArrayList<>();
+        files1.add(aRes);
+        files1.add(bRes);
+
+
+        List<ExtenderResource> files2 = new ArrayList<>();
+        files2.add(bRes);
+        files2.add(aRes);
+
+        String platform = "osx";
+        String sdkVersion = "abc456";
+        ExtenderClientCache cache = new ExtenderClientCache(new File("."));
+
+        assertEquals(cache.getHash(files1), cache.getHash(files2));
+        assertEquals(cache.calcKey(platform, sdkVersion, files1), cache.calcKey(platform, sdkVersion, files2));
+
+        files2.add(aRes);
+
+        assertNotEquals(cache.getHash(files1), cache.getHash(files2));
+        assertNotEquals(cache.calcKey(platform, sdkVersion, files1), cache.calcKey(platform, sdkVersion, files2));
+
+        FileUtils.deleteQuietly(new File("build/a"));
+        FileUtils.deleteQuietly(new File("build/b"));
+    }
+
+    @Test
+    public void testClientCacheValidBuild() throws IOException, InterruptedException, ExtenderClientException {
+        File a = new File("build/a");
+        File b = new File("build/b");
+        File c = new File("build/c");
+        FileExtenderResource aRes = new FileExtenderResource(a);
+        FileExtenderResource bRes = new FileExtenderResource(b);
+        FileExtenderResource cRes = new FileExtenderResource(c);
+
+        a.deleteOnExit();
+        b.deleteOnExit();
+        c.deleteOnExit();
+
+        TestUtils.writeToFile("build/a", "a");
+        TestUtils.writeToFile("build/b", "b");
+        TestUtils.writeToFile("build/c", "c");
+
+        List<ExtenderResource> files = new ArrayList<>();
+        files.add(aRes);
+        files.add(bRes);
+
+        String platform = "osx";
+        String sdkVersion = "abc456";
+        ExtenderClientCache cache = new ExtenderClientCache(new File("."));
+
+        if (cache.getCacheFile().exists()) {
+            cache.getCacheFile().delete();
+        }
+
+        String key = null;
+        // Is doesn't exist yet, so false
+        key = cache.calcKey(platform, sdkVersion, files);
+        assertEquals(false, cache.isCached(platform, key));
+
+        File build = cache.getCachedBuildFile(platform);
+        build.deleteOnExit();
+
+        TestUtils.writeToFile(build.getAbsolutePath(), (new Date()).toString());
+        cache.put(platform, key, build);
+
+        // It should exist now, so true
+        assertEquals(true, cache.isCached(platform, key));
+
+        // Changing a source file should invalidate the file
+        Thread.sleep(1000);
+        TestUtils.writeToFile("build/b", "bb");
+        key = cache.calcKey(platform, sdkVersion, files);
+
+        assertEquals(false, cache.isCached(platform, key));
+
+        // If we update the build, is should be cached
+        cache.put(platform, key, build);
+        assertEquals(true, cache.isCached(platform, key));
+
+        // Add a "new" file to the list, but let it have an old timestamp
+        files.add(cRes);
+        key = cache.calcKey(platform, sdkVersion, files);
+
+        assertEquals(false, cache.isCached(platform, key));
+
+        // If we update the build, is should be cached
+        cache.put(platform, key, build);
+        assertEquals(true, cache.isCached(platform, key));
+
+        // Remove one file
+        files.remove(0);
+        key = cache.calcKey(platform, sdkVersion, files);
+
+        assertEquals(false, cache.isCached(platform, key));
+
+        // If we update the build, is should be cached
+        cache.put(platform, key, build);
+        assertEquals(true, cache.isCached(platform, key));
+    }
+
+    private static String calcChecksum(File file) throws IOException, NoSuchAlgorithmException {
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        byte[] data = Files.readAllBytes(file.toPath());
+        md.update(data);
+        byte[] digest = md.digest();
+        return new BigInteger(1, digest).toString(16);
+    }
+
+    @Test
+    public void testClientCachePersistence() throws IOException, ExtenderClientException, NoSuchAlgorithmException {
+        File a = new File("build/a");
+        FileExtenderResource aRes = new FileExtenderResource(a);
+        a.deleteOnExit();
+        TestUtils.writeToFile("build/a", "a");
+
+        List<ExtenderResource> files = new ArrayList<>();
+        files.add(aRes);
+
+        String platform = "osx";
+        String sdkVersion = "abc456";
+        File cacheDir = new File(".");
+
+
+        String key;
+        {
+            ExtenderClientCache cache = new ExtenderClientCache(cacheDir);
+            key = cache.calcKey(platform, sdkVersion, files);
+
+            if (cache.getCacheFile().exists()) {
+                cache.getCacheFile().delete();
+            }
+            assertFalse(cache.getCacheFile().exists());
+        }
+
+        // Start with an empty cache
+        String checksum = null;
+        {
+            ExtenderClientCache cache = new ExtenderClientCache(cacheDir);
+
+            assertEquals(false, cache.isCached(platform, key));
+
+            // Write the build, and update the cache
+            File build = File.createTempFile("test", "build");
+            build.deleteOnExit();
+            TestUtils.writeToFile(build.getAbsolutePath(), (new Date()).toString());
+            cache.put(platform, key, build);
+
+            checksum = calcChecksum(build);
+        }
+
+        // Now, lets create another cache, and check that we get a cached version
+        {
+            ExtenderClientCache cache = new ExtenderClientCache(cacheDir);
+
+            assertEquals(true, cache.isCached(platform, key));
+
+            File build = File.createTempFile("test2", "build");
+            cache.get(platform, key, build);
+
+            String checksum2 = calcChecksum(build);
+
+            assertEquals(checksum, checksum2);
+        }
+    }
+}

--- a/client/src/test/java/com/defold/extender/client/ExtenderClientTest.java
+++ b/client/src/test/java/com/defold/extender/client/ExtenderClientTest.java
@@ -1,6 +1,6 @@
 package com.defold.extender.client;
 
-import org.apache.commons.io.FileUtils;
+import org.apache.http.HttpEntity;
 import org.apache.http.StatusLine;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.entity.EntityBuilder;
@@ -9,44 +9,40 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.james.mime4j.dom.BinaryBody;
+import org.apache.james.mime4j.dom.Body;
+import org.apache.james.mime4j.dom.Entity;
+import org.apache.james.mime4j.dom.Message;
+import org.apache.james.mime4j.dom.Multipart;
+import org.apache.james.mime4j.message.DefaultMessageBuilder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.math.BigInteger;
-import java.nio.file.Files;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-import java.util.regex.Matcher;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 public class ExtenderClientTest extends Mockito {
-
-    private void writeToFile(String path, String msg) throws IOException {
-        File f = new File(path);
-        FileWriter fwr = new FileWriter(f);
-        fwr.write(msg);
-        fwr.flush();
-        fwr.close();
-        f.setLastModified(Instant.now().toEpochMilli() + 23);
-    }
-
     @BeforeAll
     public static void beforeClass() {
         File buildDir = new File("build");
@@ -60,330 +56,19 @@ public class ExtenderClientTest extends Mockito {
     }
 
     @Test
-    public void testClientCacheHash() throws IOException, InterruptedException, ExtenderClientException {
-        writeToFile("build/a", "a");
-        writeToFile("build/b", "a");
-        writeToFile("build/c", "b");
-
-        ExtenderClientCache cache = new ExtenderClientCache(new File("."));
-
-        {
-            File file1 = new File("build/a");
-            File file2 = new File("build/b");
-            File file3 = new File("build/c");
-            FileExtenderResource file1Res = new FileExtenderResource(file1);
-            FileExtenderResource file2Res = new FileExtenderResource(file2);
-            FileExtenderResource file3Res = new FileExtenderResource(file3);
-            assertEquals(cache.getHash(file1Res), cache.getHash(file2Res));
-            assertNotEquals(cache.getHash(file1Res), cache.getHash(file3Res));
-        }
-
-        Thread.sleep(1000);
-
-        writeToFile("build/b", "b");
-
-        {
-            File file1 = new File("build/a");
-            File file2 = new File("build/b");
-            FileExtenderResource file1Res = new FileExtenderResource(file1);
-            FileExtenderResource file2Res = new FileExtenderResource(file2);
-
-            assertNotEquals(cache.getHash(file1Res), cache.getHash(file2Res));
-        }
-
-        FileUtils.deleteQuietly(new File("build/a"));
-        FileUtils.deleteQuietly(new File("build/b"));
-        FileUtils.deleteQuietly(new File("build/c"));
-    }
-
-    @Test
-    public void testClientCacheSignatureHash() throws IOException, ExtenderClientException {
-        File a = new File("build/a");
-        File b = new File("build/b");
-        FileExtenderResource aRes = new FileExtenderResource(a);
-        FileExtenderResource bRes = new FileExtenderResource(b);
-
-        writeToFile("build/a", "a");
-        writeToFile("build/b", "b");
-
-        List<ExtenderResource> files1 = new ArrayList<>();
-        files1.add(aRes);
-        files1.add(bRes);
-
-
-        List<ExtenderResource> files2 = new ArrayList<>();
-        files2.add(bRes);
-        files2.add(aRes);
-
-        String platform = "osx";
-        String sdkVersion = "abc456";
-        ExtenderClientCache cache = new ExtenderClientCache(new File("."));
-
-        assertEquals(cache.getHash(files1), cache.getHash(files2));
-        assertEquals(cache.calcKey(platform, sdkVersion, files1), cache.calcKey(platform, sdkVersion, files2));
-
-        files2.add(aRes);
-
-        assertNotEquals(cache.getHash(files1), cache.getHash(files2));
-        assertNotEquals(cache.calcKey(platform, sdkVersion, files1), cache.calcKey(platform, sdkVersion, files2));
-
-        FileUtils.deleteQuietly(new File("build/a"));
-        FileUtils.deleteQuietly(new File("build/b"));
-    }
-
-    @Test
-    public void testClientCacheValidBuild() throws IOException, InterruptedException, ExtenderClientException {
-        File a = new File("build/a");
-        File b = new File("build/b");
-        File c = new File("build/c");
-        FileExtenderResource aRes = new FileExtenderResource(a);
-        FileExtenderResource bRes = new FileExtenderResource(b);
-        FileExtenderResource cRes = new FileExtenderResource(c);
-
-        a.deleteOnExit();
-        b.deleteOnExit();
-        c.deleteOnExit();
-
-        writeToFile("build/a", "a");
-        writeToFile("build/b", "b");
-        writeToFile("build/c", "c");
-
-        List<ExtenderResource> files = new ArrayList<>();
-        files.add(aRes);
-        files.add(bRes);
-
-        String platform = "osx";
-        String sdkVersion = "abc456";
-        ExtenderClientCache cache = new ExtenderClientCache(new File("."));
-
-        if (cache.getCacheFile().exists()) {
-            cache.getCacheFile().delete();
-        }
-
-        String key = null;
-        // Is doesn't exist yet, so false
-        key = cache.calcKey(platform, sdkVersion, files);
-        assertEquals(false, cache.isCached(platform, key));
-
-        File build = cache.getCachedBuildFile(platform);
-        build.deleteOnExit();
-
-        writeToFile(build.getAbsolutePath(), (new Date()).toString());
-        cache.put(platform, key, build);
-
-        // It should exist now, so true
-        assertEquals(true, cache.isCached(platform, key));
-
-        // Changing a source file should invalidate the file
-        Thread.sleep(1000);
-        writeToFile("build/b", "bb");
-        key = cache.calcKey(platform, sdkVersion, files);
-
-        assertEquals(false, cache.isCached(platform, key));
-
-        // If we update the build, is should be cached
-        cache.put(platform, key, build);
-        assertEquals(true, cache.isCached(platform, key));
-
-        // Add a "new" file to the list, but let it have an old timestamp
-        files.add(cRes);
-        key = cache.calcKey(platform, sdkVersion, files);
-
-        assertEquals(false, cache.isCached(platform, key));
-
-        // If we update the build, is should be cached
-        cache.put(platform, key, build);
-        assertEquals(true, cache.isCached(platform, key));
-
-        // Remove one file
-        files.remove(0);
-        key = cache.calcKey(platform, sdkVersion, files);
-
-        assertEquals(false, cache.isCached(platform, key));
-
-        // If we update the build, is should be cached
-        cache.put(platform, key, build);
-        assertEquals(true, cache.isCached(platform, key));
-    }
-
-    private static String calcChecksum(File file) throws IOException, NoSuchAlgorithmException {
-        MessageDigest md = MessageDigest.getInstance("SHA-256");
-        byte[] data = Files.readAllBytes(file.toPath());
-        md.update(data);
-        byte[] digest = md.digest();
-        return new BigInteger(1, digest).toString(16);
-    }
-
-    @Test
-    public void testClientCachePersistence() throws IOException, ExtenderClientException, NoSuchAlgorithmException {
-        File a = new File("build/a");
-        FileExtenderResource aRes = new FileExtenderResource(a);
-        a.deleteOnExit();
-        writeToFile("build/a", "a");
-
-        List<ExtenderResource> files = new ArrayList<>();
-        files.add(aRes);
-
-        String platform = "osx";
-        String sdkVersion = "abc456";
-        File cacheDir = new File(".");
-
-
-        String key;
-        {
-            ExtenderClientCache cache = new ExtenderClientCache(cacheDir);
-            key = cache.calcKey(platform, sdkVersion, files);
-
-            if (cache.getCacheFile().exists()) {
-                cache.getCacheFile().delete();
-            }
-            assertFalse(cache.getCacheFile().exists());
-        }
-
-        // Start with an empty cache
-        String checksum = null;
-        {
-            ExtenderClientCache cache = new ExtenderClientCache(cacheDir);
-
-            assertEquals(false, cache.isCached(platform, key));
-
-            // Write the build, and update the cache
-            File build = File.createTempFile("test", "build");
-            build.deleteOnExit();
-            writeToFile(build.getAbsolutePath(), (new Date()).toString());
-            cache.put(platform, key, build);
-
-            checksum = calcChecksum(build);
-        }
-
-        // Now, lets create another cache, and check that we get a cached version
-        {
-            ExtenderClientCache cache = new ExtenderClientCache(cacheDir);
-
-            assertEquals(true, cache.isCached(platform, key));
-
-            File build = File.createTempFile("test2", "build");
-            cache.get(platform, key, build);
-
-            String checksum2 = calcChecksum(build);
-
-            assertEquals(checksum, checksum2);
-        }
-    }
-
-    @Test
-    public void testClientGetSource() throws IOException {
-        List<ExtenderResource> files = null;
-
-        String platform = "x86-osx";
-        files = getExtensionSource(new File("../server/test-data/testproject/a"), platform);
-        assertEquals(0, files.size());
-
-        files = getExtensionSource(new File("../server/test-data/testproject/b"), platform);
-        assertEquals(4, files.size());
-
-        files = getExtensionSource(new File("../server/test-data/testproject"), platform);
-        assertEquals(4, files.size());
-    }
-
-    private static List<ExtenderResource> getExtensionSource(File root, String platform) throws IOException {
-        List<ExtenderResource> source = new ArrayList<>();
-        List<File> extensions = listExtensionFolders(root);
-
-        for (File f : extensions) {
-
-            source.add(new FileExtenderResource(f.getAbsolutePath() + File.separator + ExtenderClient.extensionFilename));
-            source.addAll(listFilesRecursive(new File(f.getAbsolutePath() + File.separator + "include")));
-            source.addAll(listFilesRecursive(new File(f.getAbsolutePath() + File.separator + "src")));
-            source.addAll(listFilesRecursive(new File(f.getAbsolutePath() + File.separator + "lib" + File.separator + platform)));
-
-            String[] platformParts = platform.split("-");
-            if (platformParts.length == 2) {
-                source.addAll(listFilesRecursive(new File(f.getAbsolutePath() + File.separator + "lib" + File.separator + platformParts[1])));
-            }
-        }
-        return source;
-    }
-
-    private static List<File> listExtensionFolders(File dir) throws IOException {
-        if (!dir.isDirectory()) {
-            throw new IOException("Path is not a directory: " + dir.getAbsolutePath());
-        }
-
-        List<File> folders = new ArrayList<>();
-
-        File[] files = dir.listFiles();
-        for (File f : files) {
-            Matcher m = ExtenderClient.extensionPattern.matcher(f.getName());
-            if (m.matches()) {
-                folders.add(dir);
-                return folders;
-            }
-            if (f.isDirectory()) {
-                folders.addAll(listExtensionFolders(f));
-            }
-        }
-        return folders;
-    }
-
-    private static List<ExtenderResource> listFilesRecursive(File dir) {
-        List<ExtenderResource> output = new ArrayList<>();
-        if (!dir.isDirectory()) {
-            return output; // the extensions doesn't have to have all folders that we look for
-        }
-
-        File[] files = dir.listFiles();
-        for (File f : files) {
-            if (f.isFile()) {
-                output.add(new FileExtenderResource(f));
-            } else {
-                output.addAll(listFilesRecursive(f));
-            }
-        }
-        return output;
-    }
-
-    @Test
-    public void testClientHasExtensions() {
-        assertFalse(hasExtensions(new File("../server/test-data/testproject/a")));
-        assertTrue(hasExtensions(new File("../server/test-data/testproject/b")));
-        assertTrue(hasExtensions(new File("../server/test-data/testproject")));
-    }
-
-    @Test
     public void testClientHeaders() throws Exception {
-        class MockHttpClient extends DefaultHttpClient {
-            public HttpUriRequest request;
-
-            @Override
-            public CloseableHttpResponse execute(HttpUriRequest request) {
-                this.request = request;
-                CloseableHttpResponse response = mock(CloseableHttpResponse.class);
-                StatusLine statusLine = mock(StatusLine.class);
-                when(response.getStatusLine()).thenReturn(statusLine);
-                when(statusLine.getStatusCode()).thenReturn(200);
-                return response;
-            }
-        };
-
         try {
             final String HDR_NAME_1 = "x-custom-defold-header1";
             final String HDR_VALUE_1 = "my custom header1";
             final String HDR_NAME_2 = "x-custom-defold-header2";
             final String HDR_VALUE_2 = "my custom header2";
-            MockHttpClient httpClient = new MockHttpClient();
-            File cacheDir = new File("build");
-            Class<?> mockExtenderClientClass = Class.forName("com.defold.extender.client.ExtenderClient");
-            ExtenderClient extenderClient = (ExtenderClient) mockExtenderClientClass.getDeclaredConstructor(String.class, File.class).newInstance("http://localhost", cacheDir);
-            Field field = mockExtenderClientClass.getDeclaredField("httpClient");
-            field.setAccessible(true);
-            field.set(extenderClient, httpClient);
+            DefaultHttpClient httpClient = Mockito.mock(DefaultHttpClient.class);
 
+            ExtenderClient extenderClient = new ExtenderClient(null, null, httpClient, "http://localhost");
             extenderClient.setHeader(HDR_NAME_1, HDR_VALUE_1);
             extenderClient.setHeader(HDR_NAME_2, HDR_VALUE_2);
-            extenderClient.health();
 
-            HttpUriRequest request = httpClient.request;
+            HttpUriRequest request = extenderClient.createGetRequest("http://localhost/health");
             assertEquals(HDR_VALUE_1, request.getFirstHeader(HDR_NAME_1).getValue());
             assertEquals(HDR_VALUE_2, request.getFirstHeader(HDR_NAME_2).getValue());
         }
@@ -424,9 +109,9 @@ public class ExtenderClientTest extends Mockito {
         b.deleteOnExit();
         c.deleteOnExit();
 
-        writeToFile("build/a", "a");
-        writeToFile("build/b", "b");
-        writeToFile("build/c", "c");
+        TestUtils.writeToFile("build/a", "a");
+        TestUtils.writeToFile("build/b", "b");
+        TestUtils.writeToFile("build/c", "c");
 
         List<ExtenderResource> inputFiles = new ArrayList<>();
         inputFiles.add(aRes);
@@ -445,26 +130,94 @@ public class ExtenderClientTest extends Mockito {
         
     }
 
-    /*
-        Scans a directory and returns true if there are extensions available
-    */
-    private static boolean hasExtensions(File dir) {
-        File[] files = dir.listFiles();
-        if (!dir.exists()) {
-            return false;
-        }
-        for (File f : files) {
-            Matcher m = ExtenderClient.extensionPattern.matcher(f.getName());
-            if (m.matches()) {
-                return true;
-            }
+    private static Stream<Arguments> uploadData() {
+        return Stream.of(
+            Arguments.of("{\"files\":[{\"cached\":true,\"path\":\"build/a\"},{\"cached\":true,\"path\":\"build/b\"},{\"cached\":false,\"path\":\"build/c\"}]}", List.of("build/c")),
+            Arguments.of("{\"files\":[]}", List.of("build/a", "build/b", "build/c")),
+            Arguments.of(null, List.of("build/a", "build/b", "build/c"))
+        );
+    }
 
-            if (f.isDirectory()) {
-                if (hasExtensions(f)) {
-                    return true;
+    @ParameterizedTest()
+    @MethodSource("uploadData")
+    public void testUploadStructure(String cacheResponse, List<String> expectedFilenames) throws Exception {
+        try {
+            ExtenderClient extenderClient = Mockito.mock(ExtenderClient.class);
+            when(extenderClient.queryCache(anyList())).thenReturn(cacheResponse);
+            when(extenderClient.createBuildRequestPayload(anyList())).thenCallRealMethod();
+
+            File a = new File("build/a");
+            File b = new File("build/b");
+            File c = new File("build/c");
+            FileExtenderResource aRes = new FileExtenderResource(a);
+            FileExtenderResource bRes = new FileExtenderResource(b);
+            FileExtenderResource cRes = new FileExtenderResource(c);
+
+            a.deleteOnExit();
+            b.deleteOnExit();
+            c.deleteOnExit();
+
+            TestUtils.writeToFile("build/a", "a");
+            TestUtils.writeToFile("build/b", "b");
+            TestUtils.writeToFile("build/c", "c");
+
+            List<ExtenderResource> inputFiles = new ArrayList<>();
+            inputFiles.add(aRes);
+            inputFiles.add(bRes);
+            inputFiles.add(cRes);
+
+
+            HttpEntity entity = extenderClient.createBuildRequestPayload(inputFiles);
+            assertNotNull(entity);
+            
+            DefaultMessageBuilder builder = new DefaultMessageBuilder();
+            builder.setContentDecoding(true);
+
+            String headers = "Content-Type: " + entity.getContentType().getValue() + "\r\n\r\n";
+
+            byte[] byteHeader = headers.getBytes();
+            byte[] byteBody = EntityUtils.toByteArray(entity);
+            byte[] res = new byte[byteHeader.length + byteBody.length];
+            for (int i = 0; i < byteHeader.length; ++i) {
+                res[i] = byteHeader[i];
+            }
+            for (int i = byteHeader.length; i < byteHeader.length + byteBody.length; ++i) {
+                res[i] = byteBody[i - byteHeader.length];
+            }
+            Message message = builder.parseMessage(new ByteArrayInputStream(res));
+            Body body = message.getBody();
+
+            assertTrue(body instanceof Multipart);
+            Multipart multipart = (Multipart) body;
+            List<Entity> parts = multipart.getBodyParts();
+
+            Entity sourceCodeArchiveEntity = null;
+
+            for (Entity part : parts) {
+                if (part.getFilename().equals(ExtenderClient.SOURCE_CODE_ARCHIVE_MAGIC_NAME)) {
+                    sourceCodeArchiveEntity = part;
+                    break;
                 }
             }
+            assertNotNull(sourceCodeArchiveEntity);
+            assertTrue(sourceCodeArchiveEntity.getBody() instanceof BinaryBody);
+            BinaryBody archiveBody = (BinaryBody)sourceCodeArchiveEntity.getBody();
+            ZipInputStream zis = new ZipInputStream(archiveBody.getInputStream());
+            ZipEntry zipEntry = zis.getNextEntry();
+            List<String> zipEntriesFilenames = new ArrayList<>();
+            while (zipEntry != null) {
+                zipEntriesFilenames.add(zipEntry.getName());
+                zipEntry = zis.getNextEntry();
+            }
+            assertTrue(
+                expectedFilenames.size() == zipEntriesFilenames.size() &&
+                expectedFilenames.containsAll(zipEntriesFilenames) &&
+                zipEntriesFilenames.containsAll(expectedFilenames)
+            );
         }
-        return false;
+        catch (Exception e) {
+            System.out.println("ERROR LOG:");
+            throw e;
+        }
     }
 }

--- a/client/src/test/java/com/defold/extender/client/FileExtenderResourceTest.java
+++ b/client/src/test/java/com/defold/extender/client/FileExtenderResourceTest.java
@@ -1,0 +1,118 @@
+package com.defold.extender.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+
+import org.junit.jupiter.api.Test;
+
+public class FileExtenderResourceTest {
+        @Test
+    public void testClientGetSource() throws IOException {
+        List<ExtenderResource> files = null;
+
+        String platform = "x86-osx";
+        files = getExtensionSource(new File("../server/test-data/testproject/a"), platform);
+        assertEquals(0, files.size());
+
+        files = getExtensionSource(new File("../server/test-data/testproject/b"), platform);
+        assertEquals(4, files.size());
+
+        files = getExtensionSource(new File("../server/test-data/testproject"), platform);
+        assertEquals(4, files.size());
+    }
+
+    private static List<ExtenderResource> getExtensionSource(File root, String platform) throws IOException {
+        List<ExtenderResource> source = new ArrayList<>();
+        List<File> extensions = listExtensionFolders(root);
+
+        for (File f : extensions) {
+
+            source.add(new FileExtenderResource(f.getAbsolutePath() + File.separator + ExtenderClient.extensionFilename));
+            source.addAll(listFilesRecursive(new File(f.getAbsolutePath() + File.separator + "include")));
+            source.addAll(listFilesRecursive(new File(f.getAbsolutePath() + File.separator + "src")));
+            source.addAll(listFilesRecursive(new File(f.getAbsolutePath() + File.separator + "lib" + File.separator + platform)));
+
+            String[] platformParts = platform.split("-");
+            if (platformParts.length == 2) {
+                source.addAll(listFilesRecursive(new File(f.getAbsolutePath() + File.separator + "lib" + File.separator + platformParts[1])));
+            }
+        }
+        return source;
+    }
+
+    private static List<File> listExtensionFolders(File dir) throws IOException {
+        if (!dir.isDirectory()) {
+            throw new IOException("Path is not a directory: " + dir.getAbsolutePath());
+        }
+
+        List<File> folders = new ArrayList<>();
+
+        File[] files = dir.listFiles();
+        for (File f : files) {
+            Matcher m = ExtenderClient.extensionPattern.matcher(f.getName());
+            if (m.matches()) {
+                folders.add(dir);
+                return folders;
+            }
+            if (f.isDirectory()) {
+                folders.addAll(listExtensionFolders(f));
+            }
+        }
+        return folders;
+    }
+
+    private static List<ExtenderResource> listFilesRecursive(File dir) {
+        List<ExtenderResource> output = new ArrayList<>();
+        if (!dir.isDirectory()) {
+            return output; // the extensions doesn't have to have all folders that we look for
+        }
+
+        File[] files = dir.listFiles();
+        for (File f : files) {
+            if (f.isFile()) {
+                output.add(new FileExtenderResource(f));
+            } else {
+                output.addAll(listFilesRecursive(f));
+            }
+        }
+        return output;
+    }
+
+
+    /*
+        Scans a directory and returns true if there are extensions available
+    */
+    private static boolean hasExtensions(File dir) {
+        File[] files = dir.listFiles();
+        if (!dir.exists()) {
+            return false;
+        }
+        for (File f : files) {
+            Matcher m = ExtenderClient.extensionPattern.matcher(f.getName());
+            if (m.matches()) {
+                return true;
+            }
+
+            if (f.isDirectory()) {
+                if (hasExtensions(f)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Test
+    public void testClientHasExtensions() {
+        assertFalse(hasExtensions(new File("../server/test-data/testproject/a")));
+        assertTrue(hasExtensions(new File("../server/test-data/testproject/b")));
+        assertTrue(hasExtensions(new File("../server/test-data/testproject")));
+    }
+}

--- a/client/src/test/java/com/defold/extender/client/TestUtils.java
+++ b/client/src/test/java/com/defold/extender/client/TestUtils.java
@@ -1,0 +1,17 @@
+package com.defold.extender.client;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.time.Instant;
+
+public class TestUtils {
+    public static void writeToFile(String path, String msg) throws IOException {
+        File f = new File(path);
+        FileWriter fwr = new FileWriter(f);
+        fwr.write(msg);
+        fwr.flush();
+        fwr.close();
+        f.setLastModified(Instant.now().toEpochMilli() + 23);
+    }
+}

--- a/server/src/main/java/com/defold/extender/ExtenderController.java
+++ b/server/src/main/java/com/defold/extender/ExtenderController.java
@@ -56,6 +56,8 @@ public class ExtenderController {
     // Used to verify the uploaded filenames
     private static final Pattern FILENAME_RE = Pattern.compile("^([\\w ](?:[\\w+\\-\\/ @]|(?:\\.[\\w+\\-\\/ ]*))+)$");
 
+    private static final String SOURCE_CODE_ARCHIVE_MAGIC_NAME = "__source_code__.zip";
+
     private final DefoldSdkService defoldSdkService;
     private final DataCacheService dataCacheService;
     private final MeterRegistry meterRegistry;
@@ -383,6 +385,13 @@ public class ExtenderController {
             if (DM_DEBUG_JOB_UPLOAD != null) {
                 System.out.printf("    %s\n", file.toPath());
             }
+        }
+
+        // check if source code archive presented
+        File sourceCodeArchive = new File(uploadDirectory, SOURCE_CODE_ARCHIVE_MAGIC_NAME);
+        if (sourceCodeArchive.exists()) {
+            LOGGER.debug("Source code archive found. Unarchiving...");
+            ZipUtils.unzip(new FileInputStream(sourceCodeArchive), uploadDirectory.toPath());
         }
     }
 


### PR DESCRIPTION
Now source file are collected into zip archive which uploads to the Extender as one of the field of multipart form. It's allowed to save backward compatibility on Extender's side with old client which send sources as separated field of multipart form.

New approach helps to avoid limitation on form parts amount in Jetty.

Side notes:
* Restructure client code a bit to better testing
* Split client's test into separate files per class

Fixed #590