### PR TITLE
Fix sdk mapping download when mapping doesn't exist initially

### DIFF
--- a/server/src/main/java/com/defold/extender/services/DefoldSdkService.java
+++ b/server/src/main/java/com/defold/extender/services/DefoldSdkService.java
@@ -361,6 +361,8 @@ public class DefoldSdkService {
             return result;
         } catch (InterruptedException|ExecutionException exc) {
             LOGGER.error(String.format("Mappings downloading %s was interrupted", hash), exc);
+        } finally {
+            mappingsDownloadOperationCache.remove(hash);
         }
         throw new ExtenderException(String.format("Cannot find platform sdks mappings for hash: %s", hash));
     }


### PR DESCRIPTION
Fixed #807 

### Technical details
The issue was in how Extender manage concurrent requests of sdk mappings. When request is done - Extender doesn't clear information about operation. So next request instantly fails because reuses previous result.