### PR TITLE
Fix NotSupported exception tests

### DIFF
--- a/server/src/main/java/com/defold/extender/ExtenderUtil.java
+++ b/server/src/main/java/com/defold/extender/ExtenderUtil.java
@@ -872,7 +872,7 @@ public class ExtenderUtil
 
     // return a list of two string: platform name like "emsdk" and platform version like "3155"
     @SuppressWarnings("unchecked")
-    public static String[] getSdksForPlatform(String platform, JSONObject mappings) {
+    public static String[] getSdksForPlatform(String platform, JSONObject mappings) throws NullPointerException {
         return ((List<String>) mappings.get(platform)).toArray(new String[2]);
     }
 

--- a/server/src/main/java/com/defold/extender/PlatformNotSupportedException.java
+++ b/server/src/main/java/com/defold/extender/PlatformNotSupportedException.java
@@ -1,7 +1,7 @@
 package com.defold.extender;
 
 public class PlatformNotSupportedException extends ExtenderException {
-    private static String ERROR_MESSAGE = "Platform %s is not supported on the current server. Please, check build server address. If error will persist - create task here https://github.com/defold/extender/issues";
+    private static String ERROR_MESSAGE = "Platform '%s' is not supported on the current server. Please, check build server address. If error will persist - create task here https://github.com/defold/extender/issues";
 
     public PlatformNotSupportedException(String platform) {
         super(String.format(ERROR_MESSAGE, platform));

--- a/server/src/main/java/com/defold/extender/VersionNotSupportedException.java
+++ b/server/src/main/java/com/defold/extender/VersionNotSupportedException.java
@@ -1,7 +1,7 @@
 package com.defold.extender;
 
 public class VersionNotSupportedException extends ExtenderException {
-    private static String ERROR_MESSAGE = "Engine version %s is not supported on the current server. Please, use latest stable version. https://github.com/defold/defold/releases/latest";
+    private static String ERROR_MESSAGE = "Engine version '%s' is not supported on the current server. Please, use latest stable version. https://github.com/defold/defold/releases/latest";
 
     public VersionNotSupportedException(String version) {
         super(String.format(ERROR_MESSAGE, version));

--- a/server/src/test/java/com/defold/extender/IntegrationTest.java
+++ b/server/src/test/java/com/defold/extender/IntegrationTest.java
@@ -17,7 +17,6 @@ import org.slf4j.Logger;
 import org.springframework.boot.logging.LogLevel;
 import org.springframework.boot.logging.LoggingSystem;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -589,6 +588,19 @@ public class IntegrationTest {
         );
 
         ExtenderClientException exc = assertThrows(ExtenderClientException.class, () -> doBuild(sourceFiles, configuration));
-        assertTrue(exc.getMessage().contains("Unsupported engine version"));
+        assertTrue(exc.getMessage().contains("Engine version 'non-exist' is not supported on the current server"));
+    }
+
+    @Test
+    public void testUnsupportedPlatform() throws IOException, ExtenderClientException {
+        TestConfiguration configuration = new TestConfiguration(new DefoldVersion("1aafd0a262ff40214ed7f51302d92fa587c607ef", new Version(1, 10, 4), new String[]{ "x86_64-platform" }) , "x86_64-platform");
+        List<ExtenderResource> sourceFiles = Lists.newArrayList(
+            new FileExtenderResource("test-data/AndroidManifest.xml", "AndroidManifest.xml"),
+            new FileExtenderResource("test-data/ext2/ext.manifest"),
+            new FileExtenderResource("test-data/ext2/src/test_ext.cpp")
+        );
+
+        ExtenderClientException exc = assertThrows(ExtenderClientException.class, () -> doBuild(sourceFiles, configuration));
+        assertTrue(exc.getMessage().contains("Platform 'x86_64-platform' is not supported on the current server"));
     }
 }


### PR DESCRIPTION
Extender's client every non-build error throws as "Failed to communicate with Extender service.". Now client interprets 501 http code separately (that code used for "Unsupported version"/"Unsupported platforms")