### PR TITLE
Fix cleanup task

### DIFF
--- a/server/src/main/java/com/defold/extender/AsyncBuilder.java
+++ b/server/src/main/java/com/defold/extender/AsyncBuilder.java
@@ -167,7 +167,7 @@ public class AsyncBuilder {
         try {
             if (jobResultLocation.exists())
             {
-                Files.walk(jobResultLocation.toPath())
+                Files.list(jobResultLocation.toPath())
                         .filter(Files::isDirectory)
                         .filter(path -> ! jobResultLocation.toPath().equals(path))
                         .forEach(path -> {


### PR DESCRIPTION
Replace `Files.walk` with `Files.list` to iterate through directories without recursion.

Fixes #820 