### PR TITLE
Set NSPrivacyTracking to true if NSPrivacyTrackingDomains is non-empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ There are two ways to obtain Extender's jars:
 As result you should have 2 jars in `./server/apps/` folder: extender.jar and manifestmergetool.jar.
 
 ### Run
-To run stand-alone Extender instance use folowing script:
+To run stand-alone Extender instance use following script:
 ```sh
     ./server/scripts/standalone/service-standalone.sh start
 ```

--- a/server/manifestmergetool/src/main/java/com/defold/manifestmergetool/PrivacyManifestMerger.java
+++ b/server/manifestmergetool/src/main/java/com/defold/manifestmergetool/PrivacyManifestMerger.java
@@ -111,13 +111,16 @@ public class PrivacyManifestMerger {
     }
 
     private void mergeConfigs(XMLPropertyListConfiguration base, XMLPropertyListConfiguration lib) throws PlistMergeException {
-        Object baseTracking = base.getProperty("NSPrivacyTracking");
-        Object libTracking = lib.getProperty("NSPrivacyTracking");
-
         // merge privacy tracking domains
         ArrayList<String> baseTrackingDomains = getStringArrayList(base, "NSPrivacyTrackingDomains");
         ArrayList<String> libTrackingDomains = getStringArrayList(lib, "NSPrivacyTrackingDomains");
         baseTrackingDomains.addAll(libTrackingDomains);
+        // ITMS-91064: Invalid tracking information - NSPrivacyTracking must be
+        // true if NSPrivacyTrackingDomains isn’t empty.
+        if(!baseTrackingDomains.isEmpty())
+        {
+            base.setProperty("NSPrivacyTracking", true);
+        }
 
         // merge collected data types
         ArrayList<XMLPropertyListConfiguration> baseCollectedDataTypes = getArrayList(base, "NSPrivacyCollectedDataTypes");

--- a/server/manifestmergetool/src/test/java/com/defold/manifestmergetool/ManifestMergeToolTest.java
+++ b/server/manifestmergetool/src/test/java/com/defold/manifestmergetool/ManifestMergeToolTest.java
@@ -758,7 +758,7 @@ public class ManifestMergeToolTest {
             + "<plist version=\"1.0\">\n"
             + "    <dict>\n"
             + "        <key>NSPrivacyTracking</key>\n"
-            + "        <false/>\n"
+            + "        <true/>\n"
             + "\n"
             + "        <key>NSPrivacyCollectedDataTypes</key>\n"
             + "        <array>\n"


### PR DESCRIPTION
This change automatically sets `NSPrivacyTracking ` to true if `NSPrivacyTrackingDomains` is non-empty. This will avoid Apple error `ITMS-91064` when uploading for testing or distribution.

Fixes #901 