### PR TITLE
Tentative fix for stalled build and status request on macOS after socket error

### DIFF
--- a/.github/workflows/codeql-scanning.yml
+++ b/.github/workflows/codeql-scanning.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Autobuild
         uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       - name: Perform analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3

--- a/server/README_METRICS.md
+++ b/server/README_METRICS.md
@@ -27,4 +27,5 @@ Below is the table with metrics description that collected inside application. T
 |extender.service.gradle.unpack    |Timer        |Milliseconds |How long Gradle was unpacking dependencies                                       |
 |extender.service.gradle.get       |Timer        |Milliseconds |How long Gradle dependencies step was going                                      |
 |extender.versionInfo              |Gauge        |Unit         |Always return 1. Labels contains git tag and git commit sha with current version |
-|extender.build.target             |Counter      |Unit         |How many build by target was made ('engine', 'plugins', 'library'                |
+|extender.build.target             |Counter      |Unit         |How many build by target was made ('engine', 'plugins', 'library')               |
+|extender.service.remoteBuilder.reconnect|Counter      |Unit         |How many times a request to a remote builder was retried on a fresh connection after a network error. Labels contain the builder host:port and the operation ('build_async', 'job_status', 'job_result') |

--- a/server/README_METRICS.md
+++ b/server/README_METRICS.md
@@ -1,24 +1,24 @@
 # Application metrics
 Below is the table with metrics description that collected inside application. That table doesn't include standard Spring and JVM metrics.
 
-|Metric                            |Type         |Unit         |Description                                                                           d d|
+|Metric                            |Type         |Unit         |Description                                                                      |
 |----------------------------------|-------------|-------------|---------------------------------------------------------------------------------|
 |extender.job.requestSize          |Distribution |Bytes        |Build request payload size                                                       |
 |extender.job.zipSize              |Distribution |Bytes        |Archive with build result size                                                   |
 |extender.job.cache.uploadSize     |Distribution |Bytes        |How much data was cached during the build                                        |
 |extender.job.cache.uploadCount    |Distribution |Files        |How many files were cached during the build                                      |
 |extender.job.cache.downloadSize   |Distribution |Bytes        |How much data was pulled from cache during the build                             |
-|extender.job.cache.downloadCount  |Distribution |Files        |How many filed were pulled from cache during the build                           |
+|extender.job.cache.downloadCount  |Distribution |Files        |How many files were pulled from cache during the build                           |
 |extender.job.receive              |Timer        |Milliseconds |How long build request was receiving                                             |
 |extender.job.sdkDownload          |Timer        |Milliseconds |How long Defold sdk was downloading                                             |
-|extender.job.sdk                  |Counter      |Unit         |How many timer exact Defold sdk was used for building                            |
+|extender.job.sdk                  |Counter      |Unit         |How many times exact Defold sdk was used for building                            |
 |extender.job.gradle.download      |Timer        |Milliseconds |How long Gradle was downloading dependencies                                     |
 |extender.job.cocoapods.install    |Timer        |Milliseconds |How long Cocoapods was installing dependencies                                   |
 |extender.job.build                |Timer        |Milliseconds |How long build was                                                               |
 |extender.job.remoteBuild          |Timer        |Milliseconds |How long the remote build was                                                    |
 |extender.job.zip                  |Timer        |Milliseconds |How long result was zipping                                                      |
 |extender.job.write                |Timer        |Milliseconds |How long response with result was sending                                        |
-|extender.job.cache.upload         |Timer        |MIlliseconds |How long cache uploading operation was                                           |
+|extender.job.cache.upload         |Timer        |Milliseconds |How long cache uploading operation was                                           |
 |extender.job.cache.download       |Timer        |Milliseconds |How long cache downloading operation was                                         |
 |extender.build.task               |Counter      |Unit         |How many builds were handled                                                     |
 |extender.service.cocoapods.get    |Timer        |Milliseconds |How long Cocoapods dependecies downloading was                                   |

--- a/server/src/main/java/com/defold/extender/remote/RemoteEngineBuilder.java
+++ b/server/src/main/java/com/defold/extender/remote/RemoteEngineBuilder.java
@@ -9,6 +9,7 @@ import com.defold.extender.services.DataCacheService;
 import com.defold.extender.services.GCPInstanceService;
 import com.defold.extender.tracing.ExtenderTracerInterceptor;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.propagation.Propagator;
 
@@ -18,18 +19,24 @@ import com.defold.extender.log.Markers;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.SocketConfig;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.client.utils.URIUtils;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +52,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -58,8 +66,10 @@ import java.nio.charset.Charset;
 public class RemoteEngineBuilder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RemoteEngineBuilder.class);
+    private static final String RECONNECT_METRIC_ID = "extender.service.remoteBuilder.reconnect";
 
     private GCPInstanceService instanceService;
+    private final MeterRegistry meterRegistry;
     private File jobResultLocation;
     private long buildSleepTimeout;
     private long buildResultWaitTimeout;
@@ -78,9 +88,11 @@ public class RemoteEngineBuilder {
                             @Value("${extender.remote-builder.max-connections:${extender.tasks.executor.pool-size:35}}") int maxConnections,
                             @Value("${extender.remote-builder.result-download-retries:3}") int resultDownloadRetries,
                             @Value("${extender.remote-builder.result-download-retry-delay:5000}") long resultDownloadRetryDelay,
+                            @Autowired MeterRegistry meterRegistry,
                             @Autowired Tracer tracer,
                             @Autowired Propagator propogator) {
         instanceService.ifPresent(val -> { LOGGER.info("Instance client is initialized"); this.instanceService = val; });
+        this.meterRegistry = meterRegistry;
         this.buildSleepTimeout = buildSleepTimeout;
         this.buildResultWaitTimeout = buildResultWaitTimeout;
         this.resultDownloadRetries = resultDownloadRetries;
@@ -107,8 +119,37 @@ public class RemoteEngineBuilder {
             .setDefaultRequestConfig(requestConfig)
             .evictExpiredConnections()
             .evictIdleConnections(60, TimeUnit.SECONDS)
+            .setRetryHandler(this::shouldRetryRequest)
             .addInterceptorLast(new ExtenderTracerInterceptor(tracer, propogator))
             .build();
+    }
+
+    // Same retry policy as the client default, but every granted retry runs on a fresh
+    // connection, so count it as a reconnect to make per-builder network flakiness visible.
+    private boolean shouldRetryRequest(IOException exception, int executionCount, HttpContext context) {
+        if (!DefaultHttpRequestRetryHandler.INSTANCE.retryRequest(exception, executionCount, context)) {
+            return false;
+        }
+        HttpClientContext clientContext = HttpClientContext.adapt(context);
+        countReconnect(clientContext.getTargetHost(), requestOperation(clientContext.getRequest()));
+        return true;
+    }
+
+    private void countReconnect(HttpHost builderHost, String operation) {
+        MetricsWriter.metricsCounterIncrement(meterRegistry, RECONNECT_METRIC_ID,
+            "host", builderHost != null ? builderHost.toHostString() : "unknown",
+            "operation", operation);
+    }
+
+    private static String requestOperation(HttpRequest request) {
+        try {
+            // request paths are /build_async/<platform>/<sdk>, /job_status, /job_result
+            String path = URI.create(request.getRequestLine().getUri()).getPath();
+            String[] segments = path.split("/");
+            return segments.length > 1 ? segments[1] : "unknown";
+        } catch (Exception e) {
+            return "unknown";
+        }
     }
 
     @Async(value="extenderTaskExecutor")
@@ -210,6 +251,7 @@ public class RemoteEngineBuilder {
     private void downloadResult(final RemoteInstanceConfig remoteInstanceConfig, String jobId, int jobStatus, File resultDir)
             throws IOException, InterruptedException {
         final String resultUrl = String.format("%s/job_result?jobId=%s", remoteInstanceConfig.getUrl(), jobId);
+        final HttpHost builderHost = URIUtils.extractHost(URI.create(remoteInstanceConfig.getUrl()));
         for (int attempt = 0; ; ++attempt) {
             touchInstance(remoteInstanceConfig.getInstanceId());
             try (CloseableHttpResponse resultResponse = httpClient.execute(new HttpGet(resultUrl))) {
@@ -235,6 +277,7 @@ public class RemoteEngineBuilder {
                     throw e;
                 }
                 LOGGER.warn(String.format("Failed to download result of job %s (retry %d of %d)", jobId, attempt + 1, resultDownloadRetries), e);
+                countReconnect(builderHost, "job_result");
                 Thread.sleep(resultDownloadRetryDelay);
             }
         }

--- a/server/src/main/java/com/defold/extender/remote/RemoteEngineBuilder.java
+++ b/server/src/main/java/com/defold/extender/remote/RemoteEngineBuilder.java
@@ -18,14 +18,16 @@ import com.defold.extender.log.Markers;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
-import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.FileBody;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
@@ -46,6 +48,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import java.nio.charset.Charset;
@@ -60,12 +63,16 @@ public class RemoteEngineBuilder {
     private long buildSleepTimeout;
     private long buildResultWaitTimeout;
     private boolean keepJobDirectory = false;
-    protected final HttpClient httpClient;
+    protected final CloseableHttpClient httpClient;
 
     public RemoteEngineBuilder(Optional<GCPInstanceService> instanceService,
                             @Value("${extender.job-result.location}") String jobResultLocation,
                             @Value("${extender.remote-builder.build-sleep-timeout:5000}") long buildSleepTimeout,
                             @Value("${extender.remote-builder.build-result-wait-timeout:1200000}") long buildResultWaitTimeout,
+                            @Value("${extender.remote-builder.connect-timeout:30000}") int connectTimeout,
+                            @Value("${extender.remote-builder.connection-request-timeout:30000}") int connectionRequestTimeout,
+                            @Value("${extender.remote-builder.socket-timeout:600000}") int socketTimeout,
+                            @Value("${extender.remote-builder.max-connections:${extender.tasks.executor.pool-size:35}}") int maxConnections,
                             @Autowired Tracer tracer,
                             @Autowired Propagator propogator) {
         instanceService.ifPresent(val -> { LOGGER.info("Instance client is initialized"); this.instanceService = val; });
@@ -73,8 +80,23 @@ public class RemoteEngineBuilder {
         this.buildResultWaitTimeout = buildResultWaitTimeout;
         this.jobResultLocation = new File(jobResultLocation);
         this.keepJobDirectory = System.getenv("DM_DEBUG_KEEP_JOB_FOLDER") != null || System.getenv("DM_DEBUG_JOB_FOLDER") != null;
+
+        RequestConfig requestConfig = RequestConfig.custom()
+            .setConnectTimeout(connectTimeout)
+            .setConnectionRequestTimeout(connectionRequestTimeout)
+            .setSocketTimeout(socketTimeout)
+            .build();
+
+        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+        connectionManager.setMaxTotal(maxConnections);
+        connectionManager.setDefaultMaxPerRoute(maxConnections);
+
         this.httpClient  = HttpClientBuilder
             .create()
+            .setConnectionManager(connectionManager)
+            .setDefaultRequestConfig(requestConfig)
+            .evictExpiredConnections()
+            .evictIdleConnections(socketTimeout, TimeUnit.MILLISECONDS)
             .addInterceptorLast(new ExtenderTracerInterceptor(tracer, propogator))
             .build();
     }
@@ -90,7 +112,7 @@ public class RemoteEngineBuilder {
         String jobName = jobDirectory.getName();
         Thread.currentThread().setName(String.format("async-build-%s", jobName));
         File resultDir = new File(jobResultLocation.getAbsolutePath(), jobName);
-        resultDir.mkdir();
+        resultDir.mkdirs();
 
         final HttpEntity httpEntity;
         Timer buildTimer = new Timer();
@@ -114,9 +136,17 @@ public class RemoteEngineBuilder {
             request.setEntity(httpEntity);
     
             touchInstance(remoteInstanceConfig.getInstanceId());
-            HttpResponse response = httpClient.execute(request);
-            // copied from ExtenderClient. Think about code deduplication.
-            if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+            try (CloseableHttpResponse response = httpClient.execute(request)) {
+                // copied from ExtenderClient. Think about code deduplication.
+                if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                    LOGGER.error(Markers.COMPILATION_ERROR,  "Failed to build source.");
+                    File errorFile = new File(resultDir, BuilderConstants.BUILD_ERROR_FILENAME);
+                    try (PrintWriter writer = new PrintWriter(errorFile)) {
+                        IOUtils.copy(response.getEntity().getContent(), writer, Charset.defaultCharset());
+                    }
+                    return;
+                }
+
                 String jobId = EntityUtils.toString(response.getEntity());
                 LOGGER.info(String.format("Remote async build posted. Wait job id: %s", jobId));
                 long currentTime = System.currentTimeMillis();
@@ -125,8 +155,9 @@ public class RemoteEngineBuilder {
                 while (System.currentTimeMillis() - currentTime < buildResultWaitTimeout) {
                     touchInstance(remoteInstanceConfig.getInstanceId());
                     HttpGet statusRequest = new HttpGet(String.format("%s/job_status?jobId=%s", remoteInstanceConfig.getUrl(), jobId));
-                    response = httpClient.execute(statusRequest);
-                    jobStatus = Integer.valueOf(EntityUtils.toString(response.getEntity()));
+                    try (CloseableHttpResponse statusResponse = httpClient.execute(statusRequest)) {
+                        jobStatus = Integer.valueOf(EntityUtils.toString(statusResponse.getEntity()));
+                    }
                     if (jobStatus != 0) {
                         LOGGER.info(String.format("Job %s status is %d", jobId, jobStatus));
                         break;
@@ -138,36 +169,29 @@ public class RemoteEngineBuilder {
                     PrintWriter writer = new PrintWriter(errorFile);
                     writer.write(String.format("Job %s result cannot be defined during %d", jobId, buildResultWaitTimeout));
                     writer.close();
+                    return;
                 }
                 touchInstance(remoteInstanceConfig.getInstanceId());
                 HttpGet resultRequest = new HttpGet(String.format("%s/job_result?jobId=%s", remoteInstanceConfig.getUrl(), jobId));
-                response = httpClient.execute(resultRequest);
-                LOGGER.info(String.format("Job %s result got.", jobId));
-                if (jobStatus == BuilderConstants.JobStatus.SUCCESS.ordinal()) {
-                    // Write zip file to result directory
-                    File tmpResult = new File(resultDir, BuilderConstants.BUILD_RESULT_FILENAME + ".tmp");
-                    OutputStream os = new FileOutputStream(tmpResult);
-                    IOUtils.copy(response.getEntity().getContent(), os);
-                    os.close();
-                    File targetResult = new File(resultDir, BuilderConstants.BUILD_RESULT_FILENAME);
-                    Files.move(tmpResult.toPath(), targetResult.toPath(), StandardCopyOption.ATOMIC_MOVE);
-                } else {
-                    LOGGER.error(Markers.COMPILATION_ERROR, "Failed to build source.");
-                    File errorFile = new File(resultDir, BuilderConstants.BUILD_ERROR_FILENAME);
-                    PrintWriter writer = new PrintWriter(errorFile);
-                    IOUtils.copy(response.getEntity().getContent(), writer, Charset.defaultCharset());
-                    writer.close();
-                    EntityUtils.consumeQuietly(response.getEntity());
+                try (CloseableHttpResponse resultResponse = httpClient.execute(resultRequest)) {
+                    LOGGER.info(String.format("Job %s result got.", jobId));
+                    if (jobStatus == BuilderConstants.JobStatus.SUCCESS.ordinal()) {
+                        // Write zip file to result directory
+                        File tmpResult = new File(resultDir, BuilderConstants.BUILD_RESULT_FILENAME + ".tmp");
+                        try (OutputStream os = new FileOutputStream(tmpResult)) {
+                            IOUtils.copy(resultResponse.getEntity().getContent(), os);
+                        }
+                        File targetResult = new File(resultDir, BuilderConstants.BUILD_RESULT_FILENAME);
+                        Files.move(tmpResult.toPath(), targetResult.toPath(), StandardCopyOption.ATOMIC_MOVE);
+                    } else {
+                        LOGGER.error(Markers.COMPILATION_ERROR, "Failed to build source.");
+                        File errorFile = new File(resultDir, BuilderConstants.BUILD_ERROR_FILENAME);
+                        try (PrintWriter writer = new PrintWriter(errorFile)) {
+                            IOUtils.copy(resultResponse.getEntity().getContent(), writer, Charset.defaultCharset());
+                        }
+                    }
                 }
-            } else {
-                LOGGER.error(Markers.COMPILATION_ERROR,  "Failed to build source.");
-                File errorFile = new File(resultDir, BuilderConstants.BUILD_ERROR_FILENAME);
-                PrintWriter writer = new PrintWriter(errorFile);
-                IOUtils.copy(response.getEntity().getContent(), writer, Charset.defaultCharset());
-                writer.close();
-                EntityUtils.consumeQuietly(response.getEntity());
             }
-            metricsWriter.measureRemoteEngineBuild(buildTimer.start(), platform);
         } catch (Exception e) {
             File errorFile = new File(resultDir, BuilderConstants.BUILD_ERROR_FILENAME);
             PrintWriter writer = new PrintWriter(errorFile);

--- a/server/src/main/java/com/defold/extender/remote/RemoteEngineBuilder.java
+++ b/server/src/main/java/com/defold/extender/remote/RemoteEngineBuilder.java
@@ -20,6 +20,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.SocketConfig;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
@@ -62,6 +63,8 @@ public class RemoteEngineBuilder {
     private File jobResultLocation;
     private long buildSleepTimeout;
     private long buildResultWaitTimeout;
+    private int resultDownloadRetries;
+    private long resultDownloadRetryDelay;
     private boolean keepJobDirectory = false;
     protected final CloseableHttpClient httpClient;
 
@@ -71,13 +74,17 @@ public class RemoteEngineBuilder {
                             @Value("${extender.remote-builder.build-result-wait-timeout:1200000}") long buildResultWaitTimeout,
                             @Value("${extender.remote-builder.connect-timeout:30000}") int connectTimeout,
                             @Value("${extender.remote-builder.connection-request-timeout:30000}") int connectionRequestTimeout,
-                            @Value("${extender.remote-builder.socket-timeout:600000}") int socketTimeout,
+                            @Value("${extender.remote-builder.socket-timeout:120000}") int socketTimeout,
                             @Value("${extender.remote-builder.max-connections:${extender.tasks.executor.pool-size:35}}") int maxConnections,
+                            @Value("${extender.remote-builder.result-download-retries:3}") int resultDownloadRetries,
+                            @Value("${extender.remote-builder.result-download-retry-delay:5000}") long resultDownloadRetryDelay,
                             @Autowired Tracer tracer,
                             @Autowired Propagator propogator) {
         instanceService.ifPresent(val -> { LOGGER.info("Instance client is initialized"); this.instanceService = val; });
         this.buildSleepTimeout = buildSleepTimeout;
         this.buildResultWaitTimeout = buildResultWaitTimeout;
+        this.resultDownloadRetries = resultDownloadRetries;
+        this.resultDownloadRetryDelay = resultDownloadRetryDelay;
         this.jobResultLocation = new File(jobResultLocation);
         this.keepJobDirectory = System.getenv("DM_DEBUG_KEEP_JOB_FOLDER") != null || System.getenv("DM_DEBUG_JOB_FOLDER") != null;
 
@@ -90,13 +97,16 @@ public class RemoteEngineBuilder {
         PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
         connectionManager.setMaxTotal(maxConnections);
         connectionManager.setDefaultMaxPerRoute(maxConnections);
+        // detect connections half-closed by flaky networks instead of failing the next request on them
+        connectionManager.setValidateAfterInactivity(5000);
+        connectionManager.setDefaultSocketConfig(SocketConfig.custom().setSoKeepAlive(true).build());
 
         this.httpClient  = HttpClientBuilder
             .create()
             .setConnectionManager(connectionManager)
             .setDefaultRequestConfig(requestConfig)
             .evictExpiredConnections()
-            .evictIdleConnections(socketTimeout, TimeUnit.MILLISECONDS)
+            .evictIdleConnections(60, TimeUnit.SECONDS)
             .addInterceptorLast(new ExtenderTracerInterceptor(tracer, propogator))
             .build();
     }
@@ -171,26 +181,7 @@ public class RemoteEngineBuilder {
                     writer.close();
                     return;
                 }
-                touchInstance(remoteInstanceConfig.getInstanceId());
-                HttpGet resultRequest = new HttpGet(String.format("%s/job_result?jobId=%s", remoteInstanceConfig.getUrl(), jobId));
-                try (CloseableHttpResponse resultResponse = httpClient.execute(resultRequest)) {
-                    LOGGER.info(String.format("Job %s result got.", jobId));
-                    if (jobStatus == BuilderConstants.JobStatus.SUCCESS.ordinal()) {
-                        // Write zip file to result directory
-                        File tmpResult = new File(resultDir, BuilderConstants.BUILD_RESULT_FILENAME + ".tmp");
-                        try (OutputStream os = new FileOutputStream(tmpResult)) {
-                            IOUtils.copy(resultResponse.getEntity().getContent(), os);
-                        }
-                        File targetResult = new File(resultDir, BuilderConstants.BUILD_RESULT_FILENAME);
-                        Files.move(tmpResult.toPath(), targetResult.toPath(), StandardCopyOption.ATOMIC_MOVE);
-                    } else {
-                        LOGGER.error(Markers.COMPILATION_ERROR, "Failed to build source.");
-                        File errorFile = new File(resultDir, BuilderConstants.BUILD_ERROR_FILENAME);
-                        try (PrintWriter writer = new PrintWriter(errorFile)) {
-                            IOUtils.copy(resultResponse.getEntity().getContent(), writer, Charset.defaultCharset());
-                        }
-                    }
-                }
+                downloadResult(remoteInstanceConfig, jobId, jobStatus, resultDir);
             }
         } catch (Exception e) {
             File errorFile = new File(resultDir, BuilderConstants.BUILD_ERROR_FILENAME);
@@ -210,6 +201,41 @@ public class RemoteEngineBuilder {
             }
             else {
                 LOGGER.info("Keeping job directory due to debug flags");
+            }
+        }
+    }
+
+    // The job result stays on the builder for extender.job-result.lifetime, so a download
+    // interrupted by a network error can be retried instead of failing the finished build.
+    private void downloadResult(final RemoteInstanceConfig remoteInstanceConfig, String jobId, int jobStatus, File resultDir)
+            throws IOException, InterruptedException {
+        final String resultUrl = String.format("%s/job_result?jobId=%s", remoteInstanceConfig.getUrl(), jobId);
+        for (int attempt = 0; ; ++attempt) {
+            touchInstance(remoteInstanceConfig.getInstanceId());
+            try (CloseableHttpResponse resultResponse = httpClient.execute(new HttpGet(resultUrl))) {
+                if (jobStatus == BuilderConstants.JobStatus.SUCCESS.ordinal()) {
+                    // Write zip file to result directory
+                    File tmpResult = new File(resultDir, BuilderConstants.BUILD_RESULT_FILENAME + ".tmp");
+                    try (OutputStream os = new FileOutputStream(tmpResult)) {
+                        IOUtils.copy(resultResponse.getEntity().getContent(), os);
+                    }
+                    File targetResult = new File(resultDir, BuilderConstants.BUILD_RESULT_FILENAME);
+                    Files.move(tmpResult.toPath(), targetResult.toPath(), StandardCopyOption.ATOMIC_MOVE);
+                    LOGGER.info(String.format("Job %s result got.", jobId));
+                } else {
+                    LOGGER.error(Markers.COMPILATION_ERROR, "Failed to build source.");
+                    File errorFile = new File(resultDir, BuilderConstants.BUILD_ERROR_FILENAME);
+                    try (PrintWriter writer = new PrintWriter(errorFile)) {
+                        IOUtils.copy(resultResponse.getEntity().getContent(), writer, Charset.defaultCharset());
+                    }
+                }
+                return;
+            } catch (IOException e) {
+                if (attempt >= resultDownloadRetries) {
+                    throw e;
+                }
+                LOGGER.warn(String.format("Failed to download result of job %s (retry %d of %d)", jobId, attempt + 1, resultDownloadRetries), e);
+                Thread.sleep(resultDownloadRetryDelay);
             }
         }
     }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -30,8 +30,11 @@ extender:
         build-result-wait-timeout: 1200000
         connect-timeout: 30000
         connection-request-timeout: 30000
-        socket-timeout: 600000
+        # per-read inactivity limit; a download making progress is never cut off
+        socket-timeout: 120000
         max-connections: 35
+        result-download-retries: 3
+        result-download-retry-delay: 5000
     gradle:
         enabled: false
         location: /tmp/.gradle

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -28,6 +28,10 @@ extender:
         enabled: false
         build-sleep-timeout: 5000
         build-result-wait-timeout: 1200000
+        connect-timeout: 30000
+        connection-request-timeout: 30000
+        socket-timeout: 600000
+        max-connections: 35
     gradle:
         enabled: false
         location: /tmp/.gradle

--- a/server/src/test/java/com/defold/extender/remote/RemoteEngineBuilderTest.java
+++ b/server/src/test/java/com/defold/extender/remote/RemoteEngineBuilderTest.java
@@ -48,11 +48,13 @@ public class RemoteEngineBuilderTest {
     private WireMockServer builderMock;
     private ExecutorService executor;
     private Path resultLocation;
+    private SimpleMeterRegistry meterRegistry;
 
     @BeforeEach
     public void setUp() throws Exception {
         builderMock = new WireMockServer(WireMockConfiguration.options().dynamicPort());
         builderMock.start();
+        meterRegistry = new SimpleMeterRegistry();
         executor = Executors.newCachedThreadPool(runnable -> {
             Thread thread = new Thread(runnable);
             thread.setDaemon(true);
@@ -79,8 +81,14 @@ public class RemoteEngineBuilderTest {
             35,
             resultDownloadRetries,
             100,
+            meterRegistry,
             new SimpleTracer(),
             Propagator.NOOP);
+    }
+
+    private double reconnectCount(String operation) {
+        return meterRegistry.counter("extender.service.remoteBuilder.reconnect",
+            "host", "localhost:" + builderMock.port(), "operation", operation).count();
     }
 
     private RemoteInstanceConfig mockInstanceConfig() {
@@ -173,6 +181,38 @@ public class RemoteEngineBuilderTest {
             "Build result was not downloaded although the builder had it ready for a retry");
         assertArrayEquals(resultZip, Files.readAllBytes(buildResult));
         assertEquals(2, builderMock.findAll(getRequestedFor(urlPathEqualTo("/job_result"))).size());
+        assertEquals(1.0, reconnectCount("job_result"),
+            "The retried result download must be counted as a reconnect to the builder");
+    }
+
+    // A connection dropped before the response arrives (e.g. closed by a NAT or the builder
+    // restarting) is retried by the HTTP client on a fresh connection and shows up in metrics
+    @Test
+    @Timeout(60)
+    public void droppedStatusConnectionIsRetriedAndCounted() throws Exception {
+        builderMock.stubFor(post(urlPathMatching("/build_async/.*"))
+                .willReturn(aResponse().withStatus(200).withBody("reconnect-job")));
+        builderMock.stubFor(get(urlPathEqualTo("/job_status")).inScenario("dropped connection")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse().withFault(Fault.EMPTY_RESPONSE))
+                .willSetStateTo("recovered"));
+        builderMock.stubFor(get(urlPathEqualTo("/job_status")).inScenario("dropped connection")
+                .whenScenarioStateIs("recovered")
+                .willReturn(aResponse().withStatus(200)
+                        .withBody(String.valueOf(BuilderConstants.JobStatus.SUCCESS.ordinal()))));
+        final byte[] resultZip = new byte[] {0x50, 0x4b, 0x03, 0x04, 0x42};
+        builderMock.stubFor(get(urlPathEqualTo("/job_result"))
+                .willReturn(aResponse().withStatus(200).withBody(resultZip)));
+
+        Path resultDir = submitBuild(createBuilder(1), "reconnect");
+
+        Path buildResult = resultDir.resolve(BuilderConstants.BUILD_RESULT_FILENAME);
+        assertTrue(waitFor(() -> buildResult.toFile().exists(), 15_000),
+            "Build did not recover from a dropped status poll connection");
+        assertEquals(2, builderMock.findAll(getRequestedFor(urlPathEqualTo("/job_status"))).size());
+        assertEquals(1.0, reconnectCount("job_status"),
+            "The client-level retry of the status poll must be counted as a reconnect");
+        assertEquals(0.0, reconnectCount("job_result"));
     }
 
     @Test

--- a/server/src/test/java/com/defold/extender/remote/RemoteEngineBuilderTest.java
+++ b/server/src/test/java/com/defold/extender/remote/RemoteEngineBuilderTest.java
@@ -1,89 +1,190 @@
-// package com.defold.extender.remote;
+package com.defold.extender.remote;
 
-// import com.defold.extender.ExtenderException;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-// import org.apache.http.HttpEntity;
-// import org.apache.http.StatusLine;
-// import org.apache.http.entity.ByteArrayEntity;
-// import org.apache.http.entity.ContentType;
-// import org.apache.http.message.BasicHttpResponse;
-// import org.junit.jupiter.api.BeforeEach;
-// import org.junit.jupiter.api.Test;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
 
-// import java.io.File;
-// import java.io.IOException;
-// import java.util.Optional;
-// import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
-// import static org.junit.jupiter.api.Assertions.assertEquals;
-// import static org.junit.jupiter.api.Assertions.assertThrows;
-// import static org.mockito.ArgumentMatchers.any;
-// import static org.mockito.ArgumentMatchers.anyString;
-// import static org.mockito.Mockito.doReturn;
-// import static org.mockito.Mockito.mock;
-// import static org.mockito.Mockito.spy;
-// import io.micrometer.tracing.test.simple.SimpleTracer;
+import com.defold.extender.BuilderConstants;
+import com.defold.extender.metrics.MetricsWriter;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
 
-// public class RemoteEngineBuilderTest {
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.tracing.propagation.Propagator;
+import io.micrometer.tracing.test.simple.SimpleTracer;
 
-//     private RemoteEngineBuilder remoteEngineBuilder;
-//     final RemoteInstanceConfig remoteBuilderConfig = new RemoteInstanceConfig("https://test.darwin-build.defold.com", "osx-latest", true);
+public class RemoteEngineBuilderTest {
 
-//     @BeforeEach
-//     public void setUp() throws IOException {
-//         final HttpEntity httpEntity = mock(HttpEntity.class);
+    private static final long BUILD_SLEEP_TIMEOUT = 100;
+    private static final long BUILD_RESULT_WAIT_TIMEOUT = 10_000;
+    private static final int SOCKET_TIMEOUT = 2_000;
 
-//         remoteEngineBuilder = spy(new RemoteEngineBuilder(Optional.empty(), "/var/tmp/results", 5000, 240000, new SimpleTracer(), null));
-//         doReturn(httpEntity).when(remoteEngineBuilder).buildHttpEntity(any(File.class));
-//     }
+    @TempDir
+    Path tmpDir;
 
-//     @Test
-//     public void buildSuccessfully() throws IOException, ExtenderException {
-//         final File directory = mock(File.class);
-//         final String content = "hejhej";
+    private WireMockServer builderMock;
+    private ExecutorService executor;
+    private Path resultLocation;
 
-//         HttpEntity httpEntity = new ByteArrayEntity(content.getBytes(), ContentType.MULTIPART_FORM_DATA);
+    @BeforeEach
+    public void setUp() throws Exception {
+        builderMock = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        builderMock.start();
+        executor = Executors.newCachedThreadPool(runnable -> {
+            Thread thread = new Thread(runnable);
+            thread.setDaemon(true);
+            return thread;
+        });
+        resultLocation = Files.createDirectories(tmpDir.resolve("results"));
+    }
 
-//         StatusLine statusLine = mock(StatusLine.class);
-//         doReturn(200).when(statusLine).getStatusCode();
+    @AfterEach
+    public void tearDown() {
+        executor.shutdownNow();
+        builderMock.stop();
+    }
 
-//         BasicHttpResponse response = mock(BasicHttpResponse.class);
-//         doReturn(httpEntity).when(response).getEntity();
-//         doReturn(statusLine).when(response).getStatusLine();
+    private RemoteEngineBuilder createBuilder(int resultDownloadRetries) {
+        return new RemoteEngineBuilder(
+            Optional.empty(),
+            resultLocation.toString(),
+            BUILD_SLEEP_TIMEOUT,
+            BUILD_RESULT_WAIT_TIMEOUT,
+            SOCKET_TIMEOUT,
+            SOCKET_TIMEOUT,
+            SOCKET_TIMEOUT,
+            35,
+            resultDownloadRetries,
+            100,
+            new SimpleTracer(),
+            Propagator.NOOP);
+    }
 
-//         doReturn(response)
-//                 .when(remoteEngineBuilder)
-//                 .sendRequest(anyString(), anyString(), anyString(), any(HttpEntity.class));
+    private RemoteInstanceConfig mockInstanceConfig() {
+        return new RemoteInstanceConfig(String.format("http://localhost:%d", builderMock.port()), "osx-latest", true);
+    }
 
-//         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-//         remoteEngineBuilder.build(remoteBuilderConfig, directory, "armv7-ios", "a6876bc5s", baos);
+    private Path submitBuild(RemoteEngineBuilder builder, String jobName) throws Exception {
+        Path projectDirectory = Files.createDirectories(tmpDir.resolve(jobName).resolve("upload"));
+        Files.writeString(projectDirectory.resolve("main.cpp"), "int main() { return 0; }");
+        File jobDirectory = Files.createDirectories(tmpDir.resolve(jobName).resolve("job_" + jobName)).toFile();
+        executor.submit(() -> {
+            builder.buildAsync(mockInstanceConfig(), projectDirectory.toFile(), "arm64-ios", "testsdk",
+                jobDirectory, new MetricsWriter(new SimpleMeterRegistry()));
+            return null;
+        });
+        return resultLocation.resolve(jobDirectory.getName());
+    }
 
-//         byte[] bytes = baos.toByteArray();
-//         assertEquals(content, new String(bytes));
-//     }
+    private int receivedBuildRequests() {
+        return builderMock.findAll(postRequestedFor(urlPathMatching("/build_async/.*"))).size();
+    }
 
-//     @Test
-//     public void buildShouldThrowException() throws IOException, ExtenderException {
-//         final File directory = mock(File.class);
-//         final String content = "Internal server error";
+    private boolean waitFor(Supplier<Boolean> condition, long timeoutMillis) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMillis;
+        while (!condition.get()) {
+            if (System.currentTimeMillis() > deadline) {
+                return false;
+            }
+            Thread.sleep(100);
+        }
+        return true;
+    }
 
-//         HttpEntity httpEntity = new ByteArrayEntity(content.getBytes(), ContentType.MULTIPART_FORM_DATA);
+    private void stubSuccessfulJobPipeline(String jobId) {
+        builderMock.stubFor(post(urlPathMatching("/build_async/.*"))
+                .willReturn(aResponse().withStatus(200).withBody(jobId)));
+        builderMock.stubFor(get(urlPathEqualTo("/job_status"))
+                .willReturn(aResponse().withStatus(200)
+                        .withBody(String.valueOf(BuilderConstants.JobStatus.SUCCESS.ordinal()))));
+    }
 
-//         StatusLine statusLine = mock(StatusLine.class);
-//         doReturn(500).when(statusLine).getStatusCode();
+    // Repro for https://github.com/defold/extender/issues/957: builds whose job_result
+    // download stalls must not block other builds to the same builder.
+    @Test
+    @Timeout(60)
+    public void stalledResultDownloadMustNotBlockOtherBuilds() throws Exception {
+        stubSuccessfulJobPipeline("stalled-job");
+        builderMock.stubFor(get(urlPathEqualTo("/job_result"))
+                .willReturn(aResponse().withStatus(200).withFixedDelay(30_000).withBody(new byte[] {0x42})));
 
-//         BasicHttpResponse response = mock(BasicHttpResponse.class);
-//         doReturn(httpEntity).when(response).getEntity();
-//         doReturn(statusLine).when(response).getStatusLine();
+        RemoteEngineBuilder builder = createBuilder(1);
 
-//         doReturn(response)
-//                 .when(remoteEngineBuilder)
-//                 .sendRequest(anyString(), anyString(), anyString(), any(HttpEntity.class));
+        // Occupy the connection pool with builds stuck downloading their result
+        Path stalledResult1 = submitBuild(builder, "stalled1");
+        Path stalledResult2 = submitBuild(builder, "stalled2");
+        assertTrue(waitFor(() -> receivedBuildRequests() == 2, 5_000));
+        // Both builds are polling towards the stalled /job_result; give them time to get stuck there
+        Thread.sleep(3 * BUILD_SLEEP_TIMEOUT + 1_000);
 
-//         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-//         assertThrows(RemoteBuildException.class, () -> {
-//             remoteEngineBuilder.build(remoteBuilderConfig, directory, "armv7-ios", "a6876bc5s", baos);
-//         });
-        
-//     }
-// }
+        submitBuild(builder, "probe");
+        boolean probeDispatched = waitFor(() -> receivedBuildRequests() == 3, 5_000);
+        assertTrue(probeDispatched,
+            "Frozen router: the probe build's POST /build_async never reached the remote builder "
+            + "while other builds were stuck downloading /job_result (defold/extender#957)");
+
+        // The stalled builds must fail gracefully instead of hanging forever
+        assertTrue(waitFor(() -> stalledResult1.resolve(BuilderConstants.BUILD_ERROR_FILENAME).toFile().exists()
+                && stalledResult2.resolve(BuilderConstants.BUILD_ERROR_FILENAME).toFile().exists(), 15_000),
+            "Stalled builds did not get marked with an error result");
+    }
+
+    // A result download interrupted mid-body is retried while the result is still on the builder
+    @Test
+    @Timeout(60)
+    public void interruptedResultDownloadIsRetried() throws Exception {
+        stubSuccessfulJobPipeline("flaky-job");
+        final byte[] resultZip = new byte[] {0x50, 0x4b, 0x03, 0x04, 0x42};
+        builderMock.stubFor(get(urlPathEqualTo("/job_result")).inScenario("flaky download")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK))
+                .willSetStateTo("recovered"));
+        builderMock.stubFor(get(urlPathEqualTo("/job_result")).inScenario("flaky download")
+                .whenScenarioStateIs("recovered")
+                .willReturn(aResponse().withStatus(200).withBody(resultZip)));
+
+        Path resultDir = submitBuild(createBuilder(3), "flaky");
+
+        Path buildResult = resultDir.resolve(BuilderConstants.BUILD_RESULT_FILENAME);
+        assertTrue(waitFor(() -> buildResult.toFile().exists(), 15_000),
+            "Build result was not downloaded although the builder had it ready for a retry");
+        assertArrayEquals(resultZip, Files.readAllBytes(buildResult));
+        assertEquals(2, builderMock.findAll(getRequestedFor(urlPathEqualTo("/job_result"))).size());
+    }
+
+    @Test
+    @Timeout(60)
+    public void rejectedBuildIsMarkedAsError() throws Exception {
+        builderMock.stubFor(post(urlPathMatching("/build_async/.*"))
+                .willReturn(aResponse().withStatus(500).withBody("no space left on device")));
+
+        Path resultDir = submitBuild(createBuilder(1), "rejected");
+
+        Path errorResult = resultDir.resolve(BuilderConstants.BUILD_ERROR_FILENAME);
+        assertTrue(waitFor(() -> errorResult.toFile().exists(), 15_000));
+        assertEquals("no space left on device", Files.readString(errorResult));
+    }
+}


### PR DESCRIPTION
There were several problems:
* connection pool size - under the hood http client uses connection pool which has predefined size. In case if no available connection object exists - execution just stuck
* http client didn't use closable connection which led to connection pool exhausting
* connection didn't have configured timeouts. By default they are set to -1 which means that connection and socket timeouts depends on system settings

Changes:
* Use ClosableHttpCleint
* Configure connection and socket timeouts
* Add build result download retries
* Automatically close writing stream if connection is aborted
* Add connection pool size config option

Additional config parameters:
```yml
extender:
    remote-builder:
        connect-timeout: 30000 <----- how long connection will try establish between frontend instance and remote builder
        connection-request-timeout: 30000 <---------- how long code will wait for free connection object from connection pool (in ms)
        # per-read inactivity limit; a download making progress is never cut off
        socket-timeout: 120000 <------------ how long socket will wait for data (in ms)
        max-connections: 35 <------ the size of connection pool which used by frontend instance to communicate with remote builders
        result-download-retries: 3 <---- how many times try to fetch build result from remote builder in ms
        result-download-retry-delay: 5000 <------ delay between download result retry in ms
```

Fixes #957 