### PR TITLE
Replace ProGuard with R8 for Android shrinking

### DIFF
--- a/.wrangler/cache/pages.json
+++ b/.wrangler/cache/pages.json
@@ -1,0 +1,4 @@
+{
+  "account_id": "61e031a1dbed397d0705aeb96885d900",
+  "project_name": "project-bar"
+}

--- a/.wrangler/cache/pages.json
+++ b/.wrangler/cache/pages.json
@@ -1,4 +1,0 @@
-{
-  "account_id": "61e031a1dbed397d0705aeb96885d900",
-  "project_name": "project-bar"
-}

--- a/README_DEBUGGING.md
+++ b/README_DEBUGGING.md
@@ -21,7 +21,7 @@ This downloads the latest sdk to the folder `defoldsdk/<sha1>/defoldsdk`; sets t
 # Environment variables
 
 * **DM_DEBUG_COMMANDS** - Prints the command line and result  for each command in a build
-* **DM_DEBUG_DISABLE_PROGUARD** - Disables building with ProGuard (Android only)
+* **DM_DEBUG_DISABLE_R8** - Disables shrinking with R8 and uses D8 directly (Android only)
 * **DM_DEBUG_JOB_FOLDER** - The uploaded job (and build) will always end up in this folder
 * **DM_DEBUG_KEEP_JOB_FOLDER** - Always keep the job folders
 * **DM_DEBUG_JOB_UPLOAD** - Output the file names in the received payload

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -43,6 +43,17 @@ configurations.all {
 
 repositories {
     mavenCentral()
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = 'GoogleR8'
+                url = uri('https://dl.google.com/dl/android/maven2/')
+            }
+        }
+        filter {
+            includeModule('com.android.tools', 'r8')
+        }
+    }
 }
 
 dependencies {
@@ -102,6 +113,7 @@ dependencies {
     testImplementation('org.springframework.security:spring-security-test')
 
     testImplementation('org.smali:dexlib2:2.5.2')
+    testImplementation('com.android.tools:r8:8.13.19')
     testImplementation project(':client')
     testImplementation('org.wiremock:wiremock-standalone:3.13.2')
 }

--- a/server/docker/Dockerfile.android.ndk25-env
+++ b/server/docker/Dockerfile.android.ndk25-env
@@ -13,7 +13,6 @@ ARG ANDROID_NDK25_BIN_PATH=${ANDROID_NDK25_PATH}/toolchains/llvm/prebuilt/linux-
 ARG ANDROID_SDK_HOME=${ANDROID_ROOT}/.android
 ARG ANDROID_SDK_BUILD_TOOLS_PATH_34=${ANDROID_HOME}/build-tools/${ANDROID_BUILD_TOOLS_VERSION_34}
 ARG ANDROID_SDK_BUILD_TOOLS_PATH_35=${ANDROID_HOME}/build-tools/${ANDROID_BUILD_TOOLS_VERSION_35}
-ARG R8_VERSION=8.13.19
 
 FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.1.0 AS build
 
@@ -36,7 +35,7 @@ ARG ANDROID_SDK_BUILD_TOOLS_PATH_35
 ARG ANDROID_SDK_FILENAME_34=android-sdk-linux-android-${ANDROID_SDK_VERSION_34}-${ANDROID_BUILD_TOOLS_VERSION_34}.tar.gz
 ARG ANDROID_SDK_FILENAME_35=android-sdk-linux-android-${ANDROID_SDK_VERSION_35}-${ANDROID_BUILD_TOOLS_VERSION_35}.tar.gz
 ARG ANDROID_NDK25_FILENAME=android-ndk-r${ANDROID_NDK25_VERSION}-linux.tar.gz
-ARG R8_VERSION
+ARG R8_VERSION=8.7.0-dev
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN --mount=type=secret,id=DM_PACKAGES_URL,required=true \
@@ -91,7 +90,6 @@ ARG ANDROID_NDK25_BIN_PATH
 ARG ANDROID_SDK_HOME
 ARG ANDROID_SDK_BUILD_TOOLS_PATH_34
 ARG ANDROID_SDK_BUILD_TOOLS_PATH_35
-ARG R8_VERSION
 
 ENV ANDROID_ROOT=${ANDROID_ROOT} \
 # ANDROID_HOME has been replaced with ANDROID_SDK_ROOT
@@ -133,8 +131,7 @@ ENV ANDROID_ROOT=${ANDROID_ROOT} \
     ANDROID_NDK_PATH=${ANDROID_NDK25_PATH} \
     ANDROID_NDK_BIN_PATH=${ANDROID_NDK25_BIN_PATH} \
     ANDROID_NDK_SYSROOT=${ANDROID_NDK25_PATH}/toolchains/llvm/prebuilt/linux-x86_64/sysroot \
-    ANDROID_R8=${ANDROID_SDK_BUILD_TOOLS_PATH_35}/lib/d8.jar \
-    ANDROID_R8_VERSION=${R8_VERSION} \
+    ANDROID_PROGUARD=/usr/share/java/proguard.jar \
 # We specify it in build_input.yml by setting it the first in PATH for new SDK
 # But at least one SDK should be specified by default in Dockerfile
     PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${ANDROID_SDK_BUILD_TOOLS_PATH_34}:${ANDROID_NDK25_BIN_PATH}
@@ -142,9 +139,16 @@ ENV ANDROID_ROOT=${ANDROID_ROOT} \
 COPY --from=build ${ANDROID_ROOT} ${ANDROID_ROOT}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+# android proguard was version 4.7, this is at least 5.2.1 which seems to work with OpenJDK 11
+RUN \
+  apt-get update && \
+  apt-get install -y --no-install-recommends proguard && \
+  apt-get autoremove -y && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* && \
 # Since dotnet cannot really cross compile, we need to create a "ar" shim for "llvm-ar"
 # As long as it's in the path, it will be picked up
-RUN echo '#!/usr/bin/env bash' > /usr/bin/ar && \
+  echo '#!/usr/bin/env bash' > /usr/bin/ar && \
   LLVM_AR=$(find /opt/platformsdk/android -iname "llvm-ar" | tail -1) && \
   echo "${LLVM_AR} \$*" >> /usr/bin/ar && \
   chmod +x /usr/bin/ar

--- a/server/docker/Dockerfile.android.ndk25-env
+++ b/server/docker/Dockerfile.android.ndk25-env
@@ -13,6 +13,7 @@ ARG ANDROID_NDK25_BIN_PATH=${ANDROID_NDK25_PATH}/toolchains/llvm/prebuilt/linux-
 ARG ANDROID_SDK_HOME=${ANDROID_ROOT}/.android
 ARG ANDROID_SDK_BUILD_TOOLS_PATH_34=${ANDROID_HOME}/build-tools/${ANDROID_BUILD_TOOLS_VERSION_34}
 ARG ANDROID_SDK_BUILD_TOOLS_PATH_35=${ANDROID_HOME}/build-tools/${ANDROID_BUILD_TOOLS_VERSION_35}
+ARG R8_VERSION=8.13.19
 
 FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.1.0 AS build
 
@@ -35,7 +36,7 @@ ARG ANDROID_SDK_BUILD_TOOLS_PATH_35
 ARG ANDROID_SDK_FILENAME_34=android-sdk-linux-android-${ANDROID_SDK_VERSION_34}-${ANDROID_BUILD_TOOLS_VERSION_34}.tar.gz
 ARG ANDROID_SDK_FILENAME_35=android-sdk-linux-android-${ANDROID_SDK_VERSION_35}-${ANDROID_BUILD_TOOLS_VERSION_35}.tar.gz
 ARG ANDROID_NDK25_FILENAME=android-ndk-r${ANDROID_NDK25_VERSION}-linux.tar.gz
-ARG R8_VERSION=8.7.0-dev
+ARG R8_VERSION
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN --mount=type=secret,id=DM_PACKAGES_URL,required=true \
@@ -90,6 +91,7 @@ ARG ANDROID_NDK25_BIN_PATH
 ARG ANDROID_SDK_HOME
 ARG ANDROID_SDK_BUILD_TOOLS_PATH_34
 ARG ANDROID_SDK_BUILD_TOOLS_PATH_35
+ARG R8_VERSION
 
 ENV ANDROID_ROOT=${ANDROID_ROOT} \
 # ANDROID_HOME has been replaced with ANDROID_SDK_ROOT
@@ -131,7 +133,8 @@ ENV ANDROID_ROOT=${ANDROID_ROOT} \
     ANDROID_NDK_PATH=${ANDROID_NDK25_PATH} \
     ANDROID_NDK_BIN_PATH=${ANDROID_NDK25_BIN_PATH} \
     ANDROID_NDK_SYSROOT=${ANDROID_NDK25_PATH}/toolchains/llvm/prebuilt/linux-x86_64/sysroot \
-    ANDROID_PROGUARD=/usr/share/java/proguard.jar \
+    ANDROID_R8=${ANDROID_SDK_BUILD_TOOLS_PATH_35}/lib/d8.jar \
+    ANDROID_R8_VERSION=${R8_VERSION} \
 # We specify it in build_input.yml by setting it the first in PATH for new SDK
 # But at least one SDK should be specified by default in Dockerfile
     PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${ANDROID_SDK_BUILD_TOOLS_PATH_34}:${ANDROID_NDK25_BIN_PATH}
@@ -139,16 +142,9 @@ ENV ANDROID_ROOT=${ANDROID_ROOT} \
 COPY --from=build ${ANDROID_ROOT} ${ANDROID_ROOT}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-# android proguard was version 4.7, this is at least 5.2.1 which seems to work with OpenJDK 11
-RUN \
-  apt-get update && \
-  apt-get install -y --no-install-recommends proguard && \
-  apt-get autoremove -y && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* && \
 # Since dotnet cannot really cross compile, we need to create a "ar" shim for "llvm-ar"
 # As long as it's in the path, it will be picked up
-  echo '#!/usr/bin/env bash' > /usr/bin/ar && \
+RUN echo '#!/usr/bin/env bash' > /usr/bin/ar && \
   LLVM_AR=$(find /opt/platformsdk/android -iname "llvm-ar" | tail -1) && \
   echo "${LLVM_AR} \$*" >> /usr/bin/ar && \
   chmod +x /usr/bin/ar

--- a/server/docker/Dockerfile.android.ndk25_sdk36-env
+++ b/server/docker/Dockerfile.android.ndk25_sdk36-env
@@ -13,6 +13,7 @@ ARG ANDROID_NDK_PATH=${ANDROID_ROOT}/android-ndk-r${ANDROID_NDK_VERSION}
 ARG ANDROID_SDK_HOME=${ANDROID_ROOT}/.android
 ARG ANDROID_NDK_BIN_PATH=${ANDROID_NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin
 ARG ANDROID_SDK_BUILD_TOOLS_PATH=${ANDROID_HOME}/build-tools/${ANDROID_BUILD_TOOLS_VERSION}
+ARG R8_VERSION=8.13.19
 
 FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.1.0 AS build
 
@@ -29,7 +30,7 @@ ARG ANDROID_NDK_VERSION
 ARG ANDROID_NDK_API_VERSION
 ARG ANDROID_64_NDK_API_VERSION
 ARG ANDROID_NDK_FILENAME=android-ndk-r${ANDROID_NDK_VERSION}-linux.tar.gz
-ARG R8_VERSION=8.13.19
+ARG R8_VERSION
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN --mount=type=secret,id=DM_PACKAGES_URL,required=true \
@@ -77,6 +78,7 @@ ARG ANDROID_SDK_BUILD_TOOLS_PATH
 ARG ANDROID_NDK_VERSION
 ARG ANDROID_NDK_API_VERSION
 ARG ANDROID_64_NDK_API_VERSION
+ARG R8_VERSION
 
 ENV ANDROID_ROOT=${ANDROID_ROOT} \
 # ANDROID_HOME has been replaced with ANDROID_SDK_ROOT
@@ -101,21 +103,15 @@ ENV ANDROID_ROOT=${ANDROID_ROOT} \
     ANDROID_NDK_SYSROOT=${ANDROID_NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/sysroot \
 # We specify it in build_input.yml by setting it the first in PATH
     PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${ANDROID_SDK_BUILD_TOOLS_PATH}:${ANDROID_NDK_BIN_PATH} \
-    ANDROID_PROGUARD=/usr/share/java/proguard.jar
+    ANDROID_R8=${ANDROID_SDK_BUILD_TOOLS_PATH}/lib/d8.jar \
+    ANDROID_R8_VERSION=${R8_VERSION}
 
 COPY --from=build ${ANDROID_ROOT} ${ANDROID_ROOT}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-# android proguard was version 4.7, this is at least 5.2.1 which seems to work with OpenJDK 11
-RUN \
-  apt-get update && \
-  apt-get install -y --no-install-recommends proguard && \
-  apt-get autoremove -y && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* && \
 # Since dotnet cannot really cross compile, we need to create a "ar" shim for "llvm-ar"
 # As long as it's in the path, it will be picked up
-  echo '#!/usr/bin/env bash' > /usr/bin/ar && \
+RUN echo '#!/usr/bin/env bash' > /usr/bin/ar && \
   LLVM_AR=$(find /opt/platformsdk/android -iname "llvm-ar" | tail -1) && \
   echo "${LLVM_AR} \$*" >> /usr/bin/ar && \
   chmod +x /usr/bin/ar

--- a/server/docker/common-services.yml
+++ b/server/docker/common-services.yml
@@ -28,7 +28,7 @@ services:
     environment:
       - DYNAMO_HOME${DYNAMO_HOME:+=/dynamo_home}
       - DM_DEBUG_COMMANDS
-      - DM_DEBUG_DISABLE_PROGUARD
+      - DM_DEBUG_DISABLE_R8
       - DM_DEBUG_JOB_FOLDER
       - DM_DEBUG_KEEP_JOB_FOLDER
       - DM_DEBUG_JOB_UPLOAD

--- a/server/src/main/java/com/defold/extender/AsyncBuilder.java
+++ b/server/src/main/java/com/defold/extender/AsyncBuilder.java
@@ -39,6 +39,7 @@ public class AsyncBuilder {
     private GradleService gradleService;
     private CocoaPodsService cocoaPodsService;
     private BuildProgressService buildProgressService;
+    private R8Configuration r8Configuration;
     private File jobResultLocation;
     private long resultLifetime;
     private boolean keepJobDirectory = false;
@@ -47,12 +48,14 @@ public class AsyncBuilder {
                         GradleService gradleService,
                         Optional<CocoaPodsService> cocoaPodsService,
                         BuildProgressService buildProgressService,
+                        R8Configuration r8Configuration,
                         @Value("${extender.job-result.location}") String jobResultLocation,
                         @Value("${extender.job-result.lifetime:1200000}") long jobResultLifetime) {
         this.defoldSdkService = defoldSdkService;
         this.gradleService = gradleService;
         cocoaPodsService.ifPresent(val -> { this.cocoaPodsService = val; });
         this.buildProgressService = buildProgressService;
+        this.r8Configuration = r8Configuration;
         this.jobResultLocation = new File(jobResultLocation);
         this.keepJobDirectory = System.getenv("DM_DEBUG_KEEP_JOB_FOLDER") != null || System.getenv("DM_DEBUG_JOB_FOLDER") != null;
         this.resultLifetime = jobResultLifetime;
@@ -114,6 +117,7 @@ public class AsyncBuilder {
                             .setBuildDirectory(buildDirectory)
                             .setMetricsWriter(metricsWriter)
                             .setProgressReporter(progressReporter)
+                            .setR8Configuration(r8Configuration)
                             .build();
 
                 // Resolve Gradle dependencies and .aar files shipped inside the extensions

--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -69,6 +69,7 @@ class Extender {
     private final TemplateExecutor templateExecutor = new TemplateExecutor();
     private final ProcessExecutor processExecutor = new ProcessExecutor();
     private final ProgressReporter progressReporter;
+    private final R8Configuration r8Configuration;
     private MetricsWriter metricsWriter;
     // context flags
     private Boolean needsCSLibraries = false;
@@ -125,6 +126,7 @@ class Extender {
         Map<String, String> env = new HashMap<String, String>();
         MetricsWriter metricsWriter;
         ProgressReporter progressReporter = ProgressReporter.NOOP;
+        R8Configuration r8Configuration = new R8Configuration();
 
         public Builder() { }
 
@@ -168,6 +170,11 @@ class Extender {
             return this;
         }
 
+        public Builder setR8Configuration(R8Configuration r8Configuration) {
+            this.r8Configuration = r8Configuration;
+            return this;
+        }
+
         public Extender build() throws IOException, ExtenderException {
             return new Extender(this);
         }
@@ -176,6 +183,7 @@ class Extender {
     private Extender(Builder builder) throws IOException, ExtenderException {
         this.metricsWriter = builder.metricsWriter;
         this.progressReporter = builder.progressReporter != null ? builder.progressReporter : ProgressReporter.NOOP;
+        this.r8Configuration = builder.r8Configuration;
         this.androidPackages = new ArrayList<>();
         this.androidPackageResourceNames = new HashMap<>();
         this.outputFiles = new ArrayList<>();
@@ -293,25 +301,12 @@ class Extender {
             for (String k : keys) {
                 // Older SDKs declare PROGUARD in build.yml. The old command is never
                 // used, so do not require the removed ANDROID_PROGUARD environment.
+                // TODO: Remove this compatibility workaround after 2027-02-26.
                 if (k.equals("PROGUARD")) {
                     continue;
                 }
-                boolean r8Environment = k.equals("R8") || k.equals("R8_VERSION");
-                if (r8Environment && !R8Builder.isRequested(builder.uploadDirectory)) {
-                    continue;
-                }
                 String v = this.platformConfig.env.get(k);
-                try {
-                    v = r8Environment
-                            ? templateExecutor.executeOnceWithoutLogging(v, envContext)
-                            : templateExecutor.execute(v, envContext);
-                } catch (RuntimeException e) {
-                    if (r8Environment) {
-                        LOGGER.warn("Deferring unresolved {} until the requested R8 build", k);
-                        continue;
-                    }
-                    throw e;
-                }
+                v = templateExecutor.execute(v, envContext);
                 processExecutor.putEnv(k, v);
             }
 
@@ -429,22 +424,6 @@ class Extender {
         context.put("host_platform", buildState.hostPlatform);
 
         resolveVariables(context);
-        return context;
-    }
-
-    Map<String, Object> createR8BuilderContext(Map<String, Object> src) throws ExtenderException {
-        // These two values were deliberately resolved exactly once in the constructor.
-        // Keep literal Mustache text in their resolved values out of createContext's recursive pass.
-        Map<String, Object> contextWithoutR8Environment = new HashMap<>(src);
-        Map<String, Object> resolvedR8Environment = new HashMap<>();
-        for (String key : List.of("env.R8", "env.R8_VERSION")) {
-            if (contextWithoutR8Environment.containsKey(key)) {
-                resolvedR8Environment.put(key, contextWithoutR8Environment.remove(key));
-            }
-        }
-
-        Map<String, Object> context = createContext(contextWithoutR8Environment);
-        context.putAll(resolvedR8Environment);
         return context;
     }
 
@@ -2590,8 +2569,9 @@ class Extender {
                 buildState.buildDir,
                 platformConfig,
                 androidPackages,
-                createR8BuilderContext(mergedAppContext),
+                createContext(mergedAppContext),
                 buildState.getMinAndroidSdkVersion(),
+                r8Configuration,
                 templateExecutor,
                 (command, commandContext) -> executeCommandLine(command));
         R8Builder.BuildOutput r8Output = r8Builder.build(

--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -2618,6 +2618,7 @@ class Extender {
         if (r8Output != null) {
             outputFiles.addAll(Arrays.asList(r8Output.dexFiles));
             outputFiles.add(r8Output.mappingFile);
+            outputFiles.addAll(Arrays.asList(r8Output.metaInformationFiles));
         } else {
             File[] classesDex = buildClassesDex(allJars, mainDexList);
             if (classesDex.length > 0) {
@@ -2629,7 +2630,9 @@ class Extender {
         outputFiles.addAll(copyAndroidAssetFolders(platform));
         outputFiles.addAll(copyAndroidJniFolders(platform));
 
-        outputFiles.addAll(copyMetaInformationFiles(allJars));
+        if (r8Output == null) {
+            outputFiles.addAll(copyMetaInformationFiles(allJars));
+        }
 
         return outputFiles;
     }

--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -78,8 +78,8 @@ class Extender {
 
     private List<File> extDirs;
     private List<File> manifests;       // The list of ext.manifests found in the upload
-    // Unpacked Android dependencies: a .jar file, or a directory named "*.aar" holding an exploded
-    // .aar. They come from Gradle/Maven, or from .aar files shipped inside an extension.
+    // Android dependencies: a standalone .jar, or an exploded .aar directory in either the local
+    // archive layout or AGP's EXPLODED_AAR layout.
     private List<File> androidPackages;
     private List<File> outputFiles;
     private ResolvedPods resolvedPods;
@@ -514,9 +514,9 @@ class Extender {
         // Where we previously stored the dependencies directly inside the extensions
         // we now use gradle to resolve the dependencies
         for (File f : androidPackages) {
-            if (f.getName().endsWith(".jar"))
+            if (f.isFile() && f.getName().endsWith(".jar"))
                 allLibJars.add(f.getAbsolutePath());
-            else if(f.getName().endsWith(".aar")) {
+            else if (f.isDirectory()) {
                 allLibJars.addAll(R8Builder.getAndroidPackageJars(f));
             }
         }
@@ -1706,6 +1706,13 @@ class Extender {
         return dir;
     }
 
+    static String getCompiledResourceDirectoryName(int index, File resourceDirectory) {
+        File packageDirectory = resourceDirectory.getParentFile();
+        String packageName = packageDirectory == null ? "resources" : packageDirectory.getName();
+        String safePackageName = packageName.replaceAll("[^A-Za-z0-9._-]", "_");
+        return String.format("%04d-%s", index, safePackageName);
+    }
+
     /**
     * Compile android resources into "flat" files
     * https://developer.android.com/studio/build/building-cmdline#compile_and_link_your_apps_resources
@@ -1717,13 +1724,15 @@ class Extender {
         outputDirectory.mkdirs();
         try {
             Map<String, Object> context = createContext(mergedAppContext);
+            int resourceDirectoryIndex = 0;
             for (String resDir : resourceDirectories) {
-                // /tmp/.gradle/unpacked/android.arch.lifecycle-livedata-1.1.1.aar/res
                 File resourceDirectory = new File(resDir);
-                // android.arch.lifecycle-livedata-1.1.1.aar
-                String packageName = resourceDirectory.getParentFile().getName();
+                String packageName = getCompiledResourceDirectoryName(
+                        resourceDirectoryIndex++,
+                        resourceDirectory);
 
-                // we compile the package resources to one output directory per package
+                // Keep one output directory per input. Different Maven groups may publish AARs
+                // with the same filename, while AGP's exploded directory names omit the group.
                 File packageDirectoryOut = createDir(outputDirectory, packageName);
                 context.put("outputDirectory", packageDirectoryOut.getAbsolutePath());
 
@@ -2441,9 +2450,13 @@ class Extender {
         List<String> packagesList = new ArrayList<>();
 
         try {
+            int resourceDirectoryIndex = 0;
             for (String androidResourceFolder : androidResourceFolders) {
                 File packageResourceDir = new File(androidResourceFolder);
-                File targetDir = new File(packagesDir, packageResourceDir.getParentFile().getName() + "/res");
+                String packageName = getCompiledResourceDirectoryName(
+                        resourceDirectoryIndex++,
+                        packageResourceDir);
+                File targetDir = new File(packagesDir, packageName + "/res");
                 FileUtils.copyDirectory(packageResourceDir, targetDir);
 
                 String relativePath = ExtenderUtil.getRelativePath(packagesDir, targetDir);
@@ -2491,7 +2504,7 @@ class Extender {
         Set<String> extraPackages = new HashSet<String>();
         try {
             for (File f : androidPackages) {
-                if(f.getName().endsWith(".aar")) {
+                if (f.isDirectory()) {
                     File res = new File(f, "res");
                     File androidManifest = new File(f, "AndroidManifest.xml");
                     if (res.exists() && androidManifest.exists()) {
@@ -2732,15 +2745,15 @@ class Extender {
 
     // Unpack the .aar files shipped inside the extensions into the same exploded layout that the
     // Gradle service produces, so that their classes.jar, libs/, res/, assets/, jni/ and
-    // AndroidManifest.xml are consumed just like those of a Maven resolved .aar.
+    // AndroidManifest.xml are consumed just like AGP's exploded Maven dependencies.
     void resolveLocalAars() throws ExtenderException {
         File aarsDir = new File(buildState.buildDir, "local_aars");
 
         for (File extDir : this.extDirs) {
             for (String path : getExtensionLibAars(extDir)) {
                 File aar = new File(path);
-                // The name must be unique among all packages and must end with ".aar", since that is
-                // what the consumers key off, and it also names the resource package of the .aar.
+                // The name must be unique among all local packages. Keeping the .aar suffix also
+                // makes retained debug jobs easy to inspect; consumers identify packages by layout.
                 File unpacked = SandboxedPath.resolve(aarsDir, extDir.getName() + "-" + aar.getName());
                 if (unpacked.exists()) {
                     // the same .aar was found in both lib/android and lib/<arch>-android

--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -1713,6 +1713,34 @@ class Extender {
         return String.format("%04d-%s", index, safePackageName);
     }
 
+    static List<String> getReturnedResourcePackageNames(List<String> resourceDirectories) {
+        List<String> baseNames = resourceDirectories.stream()
+                .map(File::new)
+                .map(File::getParentFile)
+                .map(directory -> directory == null ? "resources" : directory.getName())
+                .collect(Collectors.toList());
+        Set<String> reservedNames = new HashSet<>(baseNames);
+        Set<String> assignedNames = new HashSet<>();
+        List<String> result = new ArrayList<>();
+
+        for (int index = 0; index < baseNames.size(); index++) {
+            String baseName = baseNames.get(index);
+            if (assignedNames.add(baseName)) {
+                // Preserve the existing externally visible package name whenever possible.
+                result.add(baseName);
+                continue;
+            }
+
+            String candidate = String.format("%s-%04d", baseName, index);
+            int retry = 1;
+            while (reservedNames.contains(candidate) || !assignedNames.add(candidate)) {
+                candidate = String.format("%s-%04d-%d", baseName, index, retry++);
+            }
+            result.add(candidate);
+        }
+        return result;
+    }
+
     /**
     * Compile android resources into "flat" files
     * https://developer.android.com/studio/build/building-cmdline#compile_and_link_your_apps_resources
@@ -2450,12 +2478,11 @@ class Extender {
         List<String> packagesList = new ArrayList<>();
 
         try {
-            int resourceDirectoryIndex = 0;
-            for (String androidResourceFolder : androidResourceFolders) {
+            List<String> packageNames = getReturnedResourcePackageNames(androidResourceFolders);
+            for (int index = 0; index < androidResourceFolders.size(); index++) {
+                String androidResourceFolder = androidResourceFolders.get(index);
                 File packageResourceDir = new File(androidResourceFolder);
-                String packageName = getCompiledResourceDirectoryName(
-                        resourceDirectoryIndex++,
-                        packageResourceDir);
+                String packageName = packageNames.get(index);
                 File targetDir = new File(packagesDir, packageName + "/res");
                 FileUtils.copyDirectory(packageResourceDir, targetDir);
 

--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.HashMap;
@@ -110,22 +111,6 @@ class Extender {
         "ps4", "x86_64-ps4",
         "ps5", "x86_64-ps5",
     };
-
-    // This class specifies the set of files that are used when running proguard on
-    // the project jars that were found during the build process. This class is only
-    // relevant on Android.
-    //
-    // * proGuardFiles - Array of .pro files that contain settings and rules that specify
-    //                   what ProGuard should do with the input jars.
-    // * libraryJars - Array of .jar files should be passed to ProGuard as '-libraryjar' entries.
-    //                 Everything from a libraryjar will be kept by ProGuard, i.e no optimization or
-    //                 obfuscation will be performed.
-    private static class ProGuardContext {
-        public List<String> proGuardFiles = new ArrayList<>();
-        public List<String> libraryJars   = new ArrayList<>();
-    }
-
-    private static final boolean DM_DEBUG_DISABLE_PROGUARD = System.getenv("DM_DEBUG_DISABLE_PROGUARD") != null;
 
     static public class Builder {
         String platform;
@@ -301,8 +286,27 @@ class Extender {
 
             Set<String> keys = this.platformConfig.env.keySet();
             for (String k : keys) {
+                // Older SDKs declare PROGUARD in build.yml. The old command is never
+                // used, so do not require the removed ANDROID_PROGUARD environment.
+                if (k.equals("PROGUARD")) {
+                    continue;
+                }
+                boolean r8Environment = k.equals("R8") || k.equals("R8_VERSION");
+                if (r8Environment && !R8Builder.isRequested(builder.uploadDirectory)) {
+                    continue;
+                }
                 String v = this.platformConfig.env.get(k);
-                v = templateExecutor.execute(v, envContext);
+                try {
+                    v = r8Environment
+                            ? templateExecutor.executeOnceWithoutLogging(v, envContext)
+                            : templateExecutor.execute(v, envContext);
+                } catch (RuntimeException e) {
+                    if (r8Environment) {
+                        LOGGER.warn("Deferring unresolved {} until the requested R8 build", k);
+                        continue;
+                    }
+                    throw e;
+                }
                 processExecutor.putEnv(k, v);
             }
 
@@ -355,6 +359,10 @@ class Extender {
 
     private String executeCommand(String template, Map<String, Object> context) throws ExtenderException {
         String command = templateExecutor.execute(template, context);
+        return executeCommandLine(command);
+    }
+
+    private String executeCommandLine(String command) throws ExtenderException {
         try {
             if (processExecutor.execute(command) != 0) {
                 throw new ExtenderException(processExecutor.getOutput());
@@ -419,6 +427,22 @@ class Extender {
         return context;
     }
 
+    Map<String, Object> createR8BuilderContext(Map<String, Object> src) throws ExtenderException {
+        // These two values were deliberately resolved exactly once in the constructor.
+        // Keep literal Mustache text in their resolved values out of createContext's recursive pass.
+        Map<String, Object> contextWithoutR8Environment = new HashMap<>(src);
+        Map<String, Object> resolvedR8Environment = new HashMap<>();
+        for (String key : List.of("env.R8", "env.R8_VERSION")) {
+            if (contextWithoutR8Environment.containsKey(key)) {
+                resolvedR8Environment.put(key, contextWithoutR8Environment.remove(key));
+            }
+        }
+
+        Map<String, Object> context = createContext(contextWithoutR8Environment);
+        context.putAll(resolvedR8Environment);
+        return context;
+    }
+
     private List<String> getFrameworks(File dir) {
         List<String> frameworks = new ArrayList<>();
         final String[] platformParts = buildState.fullPlatform.split("-");
@@ -470,6 +494,17 @@ class Extender {
         return aars;
     }
 
+    List<String> getExtensionLocalAarJars(File extDir) throws ExtenderException {
+        Set<String> jars = new TreeSet<>();
+        File localAarsDir = new File(buildState.buildDir, "local_aars");
+        for (String path : getExtensionLibAars(extDir)) {
+            File aar = new File(path);
+            File unpacked = SandboxedPath.resolve(localAarsDir, extDir.getName() + "-" + aar.getName());
+            jars.addAll(R8Builder.getAndroidPackageJars(unpacked));
+        }
+        return new ArrayList<>(jars);
+    }
+
     private List<String> getAllExtensionsLibJars() {
         List<String> allLibJars = new ArrayList<>();
         for (File extDir : this.extDirs) {
@@ -482,20 +517,7 @@ class Extender {
             if (f.getName().endsWith(".jar"))
                 allLibJars.add(f.getAbsolutePath());
             else if(f.getName().endsWith(".aar")) {
-                File classesJar = new File(f, "classes.jar");
-                if (classesJar.exists()) {
-                    allLibJars.add(classesJar.getAbsolutePath());
-                }
-
-                // There can be an optional libs/ folder with jar files.
-                // Make sure to copy these!
-                // https://developer.android.com/studio/projects/android-library.html#aar-contents
-                File libs = new File(f, "libs");
-                if (libs.exists() && libs.isDirectory()) {
-                    for(File lib : libs.listFiles()) {
-                        allLibJars.add(lib.getAbsolutePath());
-                    }
-                }
+                allLibJars.addAll(R8Builder.getAndroidPackageJars(f));
             }
         }
 
@@ -1722,6 +1744,10 @@ class Extender {
         return outputDirectory;
     }
 
+    static boolean shouldGenerateAaptMainDexRules(File uploadDir, int minAndroidSdkVersion) {
+        return R8Builder.isRequested(uploadDir) && minAndroidSdkVersion < 21;
+    }
+
     private Map<String, File> linkAndroidResources(File compiledResourcesDir, Map<String, Object> mergedAppContext) throws ExtenderException {
         LOGGER.info("Linking Android resources");
 
@@ -1767,9 +1793,23 @@ class Extender {
             File outApkFile = new File(buildState.buildDir, "compiledresources.apk");
             context.put("outApkFile", outApkFile.getAbsolutePath());
 
+            File aaptKeepRules = new File(buildState.buildDir, "aapt-generated.keep");
+            context.put("aaptKeepRules", aaptKeepRules.getAbsolutePath());
+            File aaptMainDexRules = new File(buildState.buildDir, "aapt-main-dex-generated.keep");
+            context.put("aaptMainDexRules", aaptMainDexRules.getAbsolutePath());
+            boolean useR8 = R8Builder.isRequested(buildState.uploadDir);
+            context.put("useR8", useR8);
+            context.put(
+                    "useR8MainDexRules",
+                    shouldGenerateAaptMainDexRules(
+                            buildState.uploadDir,
+                            buildState.getMinAndroidSdkVersion()));
+
             files.put("resourceIdsFile", resourceIdsFile);
             files.put("outApkFile", outApkFile);
             files.put("outJavaDirectory", outputJavaDirectory);
+            files.put("aaptKeepRules", aaptKeepRules);
+            files.put("aaptMainDexRules", aaptMainDexRules);
 
             executeCommand(platformConfig.aapt2linkCmd, context);
         } catch (IOException e) {
@@ -1866,10 +1906,8 @@ class Extender {
         return null;
     }
 
-    // returns:
-    //   a pair of the .jar file and a list of all of the proguard files that were found
-    //   in the manifests/android folder. If proGuard isn't supported (i.e old build.yml), a null pointer will be returned.
-    private Map.Entry<File, ProGuardContext> buildJavaExtension(File manifest, Map<String, Object> manifestContext, File rJar) throws ExtenderException {
+    // Returns the compiled extension jar together with its R8 rules/protection context.
+    private Map.Entry<File, R8Builder.ExtensionContext> buildJavaExtension(File manifest, Map<String, Object> manifestContext, File rJar) throws ExtenderException {
         try {
             // Collect all Java source files
             File extDir = manifest.getParentFile();
@@ -1880,38 +1918,21 @@ class Extender {
                 javaSrcFiles = ExtenderUtil.filterFiles(javaSrcFiles, platformConfig.javaSourceRe);
             }
 
-            File manifestDir = new File(extDir, "manifests/android/");
-            Collection<File> proGuardSrcFiles = new ArrayList<>();
-            if (manifestDir.isDirectory()) {
-                proGuardSrcFiles = FileUtils.listFiles(manifestDir, null, true);
-                proGuardSrcFiles = ExtenderUtil.filterFiles(proGuardSrcFiles, platformConfig.proGuardSourceRe);
-            }
-            // We want to collect ProGuards files even if we don't have java or jar files for the build
-            // because it's possible that this extention depends on some base extension
-            if (javaSrcFiles.size() == 0 && proGuardSrcFiles.size() == 0) {
+            List<String> extensionLibJars = getExtensionLibJars(extDir);
+            extensionLibJars.addAll(getExtensionLocalAarJars(extDir));
+            R8Builder.ExtensionContext r8Context = R8Builder.createExtensionContext(
+                    extDir,
+                    extensionLibJars,
+                    platformConfig.r8RuleSourceRe);
+
+            // Rules can apply to a base extension with no Java sources, and a jar-only
+            // extension still needs a protection context when it has no rules.
+            if (javaSrcFiles.size() == 0 && r8Context.ruleFiles.isEmpty() && extensionLibJars.size() == 0) {
                 LOGGER.info("No Java sources. Skipping");
                 return null;
             }
 
             LOGGER.info("Building Java sources with extension source {}", buildState.uploadDir);
-
-            ProGuardContext proGuardContext = new ProGuardContext();
-
-            // * If we found proguard files, we add all of them to the proguard context
-            //   for this extension. It is implied that if there are .pro files present,
-            //   then the extension developer is responsible to make sure the correct classes and symbols are kept.
-            // * However, if no proguard files were found, we need to add all potential jar files
-            //   from the extension lib folder into the context so that we can set them as -libraryjar when
-            //   running proguard.
-            if (proGuardSrcFiles.size() > 0) {
-                for (File pFile : proGuardSrcFiles) {
-                    proGuardContext.proGuardFiles.add(pFile.getAbsolutePath());
-                }
-            } else {
-                // Get extension supplied Jar libraries
-                List<String> extJars = getExtensionLibJars(extDir);
-                proGuardContext.libraryJars = new ArrayList<>(extJars);
-            }
 
             // Create temp working directory, which will include;
             // * classes/    - Output directory of javac compilation
@@ -1923,11 +1944,9 @@ class Extender {
             tmpDir.mkdir();
 
             if (javaSrcFiles.size() == 0) {
-                // If we collect proguard files without building `jar`
-                // we have to use special name to avoid "File doesn't exist"
-                // error. We check it later with `(.*)/proguard_files_without_jar` pattern.
-                File proguardFakeJar = new File(tmpDir, "proguard_files_without_jar");
-                return new AbstractMap.SimpleEntry<File, ProGuardContext>(proguardFakeJar, proGuardContext);
+                // Preserve the context even when this extension has no compiled jar.
+                File r8FakeJar = new File(tmpDir, R8Builder.RULES_WITHOUT_JAR);
+                return new AbstractMap.SimpleEntry<File, R8Builder.ExtensionContext>(r8FakeJar, r8Context);
             }
 
             File classesDir = new File(tmpDir, "classes");
@@ -1970,20 +1989,15 @@ class Extender {
             context.put("classesDir", classesDir.getAbsolutePath());
             executeCommand(platformConfig.jarCmd, context);
 
-            return new AbstractMap.SimpleEntry<File, ProGuardContext>(outputJar, proGuardContext);
+            return new AbstractMap.SimpleEntry<File, R8Builder.ExtensionContext>(outputJar, r8Context);
 
         } catch (IOException e) {
             throw new ExtenderException(e, "Building java extension");
         }
     }
 
-    // returns:
-    //   a file path to the built jar as well as a (potential) list
-    //   of proguard files that should be applied to the final application jar.
-    //   If the collection contains zero entries, then the jar should be treated as a library jar,
-    //   which means that it should not be obfuscated or optimized.
-    private Map<String,ProGuardContext> buildJava(File rJar) throws ExtenderException {
-        Map<String,ProGuardContext> builtJars = new HashMap<>();
+    private Map<String, R8Builder.ExtensionContext> buildJava(File rJar) throws ExtenderException {
+        Map<String, R8Builder.ExtensionContext> builtJars = new HashMap<>();
 
         if (rJar != null) {
             builtJars.put(rJar.getAbsolutePath(), null);
@@ -1994,7 +2008,7 @@ class Extender {
             Map<String, Object> extensionContext = manifestConfigs.get(extensionSymbol);
             File extensionManifest = manifestFiles.get(extensionSymbol);
 
-            Map.Entry<File, ProGuardContext> javaExtensionsEntry = buildJavaExtension(extensionManifest, extensionContext, rJar);
+            Map.Entry<File, R8Builder.ExtensionContext> javaExtensionsEntry = buildJavaExtension(extensionManifest, extensionContext, rJar);
             if (javaExtensionsEntry != null) {
                 builtJars.put(javaExtensionsEntry.getKey().getAbsolutePath(), javaExtensionsEntry.getValue());
             }
@@ -2002,140 +2016,20 @@ class Extender {
         return builtJars;
     }
 
-    // arguments:
-    //   extensionJarMap - a mapping from a jar file to a list of its corresponding proGuard files
     // returns:
     //   all jar files from each extension, as well as the engine defined jar files
-    private List<String> getAllJars(Map<String,ProGuardContext> extensionJarMap) throws ExtenderException {
+    private List<String> getAllJars(Map<String, R8Builder.ExtensionContext> extensionJarMap) throws ExtenderException {
         List<String> includeJars = ExtenderUtil.getStringList(mergedAppContext, "includeJars");
         List<String> excludeJars = ExtenderUtil.getStringList(mergedAppContext, "excludeJars");
 
         List<String> extensionJars = getAllExtensionsLibJars();
 
-        for (Map.Entry<String,ProGuardContext> extensionJar : extensionJarMap.entrySet()) {
-            extensionJars.add(extensionJar.getKey());
-        }
+        extensionJars.addAll(R8Builder.getCompiledJars(extensionJarMap));
 
         Map<String, Object> context = createContext(mergedAppContext);
         List<String> allJars = ExtenderUtil.pruneItems( (List<String>)context.get("engineJars"), includeJars, excludeJars);
         allJars.addAll( ExtenderUtil.pruneItems( extensionJars, includeJars, excludeJars) );
         return allJars;
-    }
-
-    // arguments:
-    //   jars            - the list of all available jar files gathered from the build
-    //   extensionJarMap - a mapping from a jar file to a list of its corresponding proGuard contexts
-    private Map<String, ProGuardContext> getProGuardMapping(List<String> jars, Map<String,ProGuardContext> extensionJarMap) {
-        Map<String,ProGuardContext> jarToProGuardContextMap = new HashMap<>();
-
-        for (String jar : jars) {
-            jarToProGuardContextMap.put(jar, null);
-        }
-
-        for (Map.Entry<String,ProGuardContext> extensionJarEntry : extensionJarMap.entrySet()) {
-            String jar          = extensionJarEntry.getKey();
-            ProGuardContext ctx = extensionJarEntry.getValue();
-
-            // rJars from the buildRJar function will exist in the extensionJarMap,
-            // but associated with a null context.
-            if (ctx == null) {
-                continue;
-            }
-
-            jarToProGuardContextMap.put(jar,ctx);
-
-            // If we couldn't find any proguard files for this extension,
-            // we need to make sure that there is a context available
-            // for all the .jar files we found in the extension
-            if (ctx.proGuardFiles.size() == 0) {
-                for (String libraryJar : ctx.libraryJars) {
-                    ProGuardContext libraryCtx = jarToProGuardContextMap.get(libraryJar);
-
-                    if (libraryCtx == null) {
-                        libraryCtx = new ProGuardContext();
-                        libraryCtx.proGuardFiles.addAll(ctx.proGuardFiles);
-                        jarToProGuardContextMap.put(libraryJar,libraryCtx);
-                    }
-                }
-            }
-        }
-
-        return jarToProGuardContextMap;
-    }
-
-    // arguments:
-    //   allJars         - the list of all available jar files gathered from the build
-    //   extensionJarMap - a mapping from a jar file to a list of its corresponding proGuard contexts
-    // returns:
-    //   a pair of the built & optimized proGuard jar and its corresponding mappings.txt file.
-    //   the mappings file can be uploaded to google play and then used for symbolication
-    private Map.Entry<File,File> buildProGuard(List<String> allJars, Map<String,ProGuardContext> extensionJarMap) throws ExtenderException {
-        // To support older versions of build.yml where proGuardCmd is not defined:
-        String proGuardCmd = platformConfig.proGuardCmd;
-        if (proGuardCmd == null || proGuardCmd.isEmpty() || DM_DEBUG_DISABLE_PROGUARD) {
-            if (DM_DEBUG_DISABLE_PROGUARD) {
-                LOGGER.info("ProGuard support disabled by environment flag DM_DEBUG_DISABLE_PROGUARD");
-            } else {
-                LOGGER.info("No SDK support. Skipping ProGuard step.");
-            }
-            return null;
-        }
-
-        File appPro = new File(buildState.uploadDir, "/_app/app.pro");
-        if (!appPro.exists()) {
-            LOGGER.info("No .pro file present. Skipping ProGuard step.");
-            return null;
-        }
-
-        LOGGER.info("Building using ProGuard {}", buildState.uploadDir);
-
-        String appProPath = appPro.getAbsolutePath();
-        Map<String,ProGuardContext> allJarsMap = getProGuardMapping(allJars, extensionJarMap);
-
-        List<String> allPro = new ArrayList<>();
-        allPro.add(appProPath);
-
-        File targetFile  = new File(buildState.buildDir, "dmengine.jar");
-        File mappingFile = new File(buildState.buildDir, "mapping.txt");
-
-        List<String> jarList          = new ArrayList<>();
-        List<String> jarLibrariesList = new ArrayList<>();
-
-        for (Map.Entry<String,ProGuardContext> jarMapEntry : allJarsMap.entrySet())
-        {
-            String jar = jarMapEntry.getKey();
-            ProGuardContext jarProGuardContext = jarMapEntry.getValue();
-
-            // jarProGuardContext is null for all the jars that are affected by the
-            // 'global' appPro file. We could make a context for them, but it's not necessary
-            if (jarProGuardContext == null || jarProGuardContext.proGuardFiles.size() > 0) {
-                jarList.add(jar);
-
-                if (jarProGuardContext != null) {
-                    for (String proGuardFile : jarProGuardContext.proGuardFiles) {
-                        allPro.add(proGuardFile);
-                    }
-                }
-            } else {
-                jarLibrariesList.add(jar);
-            }
-        }
-        //exclude fake `jar` paths for extensions without java code
-        List<String> excludeJars = new ArrayList<>();
-        excludeJars.add("(.*)/proguard_files_without_jar");
-        jarLibrariesList = ExtenderUtil.excludeItems(jarLibrariesList, excludeJars);
-        jarList = ExtenderUtil.excludeItems(jarList, excludeJars);
-
-        Map<String, Object> context = createContext(mergedAppContext);
-        context.put("jars", jarList);
-        context.put("libraryjars", jarLibrariesList);
-        context.put("src", allPro);
-        context.put("tgt", targetFile.getAbsolutePath());
-        context.put("mapping", mappingFile.getAbsolutePath());
-
-        executeCommand(proGuardCmd, context);
-
-        return new AbstractMap.SimpleEntry<File, File>(targetFile, mappingFile);
     }
 
     public void validateManifestPlatforms(ManifestConfiguration manifestConfig) throws ExtenderException {
@@ -2192,7 +2086,7 @@ class Extender {
         try {
             mainList.createNewFile();
             for (String classFile : mainClassNames) {
-                // create main dex list in form of Proguards rules. Additional info https://github.com/defold/extender/issues/393
+                // Create the main dex list in R8 keep-rule form. Additional info: https://github.com/defold/extender/issues/393
                 classFile = classFile.replace("/", ".").replace(".class", "");
                 FileUtils.writeStringToFile(mainList, String.format("-keep class %s { *; }\n", classFile), Charset.defaultCharset(), true);
             }
@@ -2331,11 +2225,6 @@ class Extender {
         mergedAppContext.put("dynamo_home", ExtenderUtil.getRelativePath(buildState.jobDir, buildState.sdk));
         mergedAppContext.put("platform", buildState.fullPlatform);
         mergedAppContext.put("host_platform", buildState.getHostPlatform());
-
-        //exclude fake `jar` path for extensions without java code
-        List<String> excludeJars = ExtenderUtil.getStringList(mergedAppContext, "excludeJars");
-        excludeJars.add("(.*)/proguard_files_without_jar");
-        mergedAppContext.put("excludeJars", excludeJars);
 
         mergedAppContext = ExtenderUtil.mergeContexts(mergedAppContext, debugContext);
     }
@@ -2631,6 +2520,8 @@ class Extender {
         final List<String> androidResourceFolders = getAndroidResourceFolders(platform);
 
         File rJavaDir = null;
+        File aaptKeepRules = null;
+        File aaptMainDexRules = null;
         // 1.2.174
         if (platformConfig.aapt2compileCmd != null) {
             // compile and link all of the resource files
@@ -2642,6 +2533,8 @@ class Extender {
             outputFiles.add(files.get("outApkFile"));
             outputFiles.add(files.get("resourceIdsFile"));
             rJavaDir = files.get("outJavaDirectory");
+            aaptKeepRules = files.get("aaptKeepRules");
+            aaptMainDexRules = files.get("aaptMainDexRules");
         }
         else {
             rJavaDir = generateRJava(androidResourceFolders, mergedAppContext);
@@ -2650,37 +2543,32 @@ class Extender {
         // take the generated R.java files and compile them to jar files
         File rJar = buildRJar(rJavaDir);
 
-        Map<String, ProGuardContext> extensionJarMap = buildJava(rJar);
-        List<String> allJars                         = getAllJars(extensionJarMap);
-        Map.Entry<File,File> proGuardFiles           = buildProGuard(allJars, extensionJarMap);
-
+        Map<String, R8Builder.ExtensionContext> extensionJarMap = buildJava(rJar);
+        List<String> allJars = getAllJars(extensionJarMap);
         File mainDexList = buildMainDexList(allJars);
-
-        // If we have proGuard support, we need to reset the allJars list so that
-        // we don't get duplicate symbols.
-        if (proGuardFiles != null) {
-            allJars.clear();
-            allJars.add(proGuardFiles.getKey().getAbsolutePath()); // built jar
-            outputFiles.add(proGuardFiles.getValue()); // mappings file
-
-            // Add the jars that were not run through ProGuard
-            for (Map.Entry<String,ProGuardContext> extensionJarEntry : extensionJarMap.entrySet()) {
-                String extensionJar = extensionJarEntry.getKey();
-                ProGuardContext proGuardContext = extensionJarEntry.getValue();
-
-                if (proGuardContext != null && proGuardContext.proGuardFiles.size() == 0) {
-                    allJars.add(extensionJar);
-
-                    for (String extensionLibraryJar : proGuardContext.libraryJars) {
-                        allJars.add(extensionLibraryJar);
-                    }
-                }
+        R8Builder r8Builder = new R8Builder(
+                buildState.uploadDir,
+                buildState.buildDir,
+                platformConfig,
+                androidPackages,
+                createR8BuilderContext(mergedAppContext),
+                buildState.getMinAndroidSdkVersion(),
+                templateExecutor,
+                (command, commandContext) -> executeCommandLine(command));
+        R8Builder.BuildOutput r8Output = r8Builder.build(
+                allJars,
+                extensionJarMap,
+                mainDexList,
+                aaptKeepRules,
+                aaptMainDexRules);
+        if (r8Output != null) {
+            outputFiles.addAll(Arrays.asList(r8Output.dexFiles));
+            outputFiles.add(r8Output.mappingFile);
+        } else {
+            File[] classesDex = buildClassesDex(allJars, mainDexList);
+            if (classesDex.length > 0) {
+                outputFiles.addAll(Arrays.asList(classesDex));
             }
-        }
-
-        File[] classesDex = buildClassesDex(allJars, mainDexList);
-        if (classesDex.length > 0) {
-            outputFiles.addAll(Arrays.asList(classesDex));
         }
 
         outputFiles.addAll(copyAndroidResourceFolders(androidResourceFolders));

--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -43,6 +43,7 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import com.defold.extender.services.GradleArtifact;
 import com.defold.extender.services.GradleService;
 import com.defold.extender.services.cocoapods.CocoaPodsService;
 import com.defold.extender.services.cocoapods.PodBuildSpec;
@@ -81,6 +82,9 @@ class Extender {
     // Android dependencies: a standalone .jar, or an exploded .aar directory in either the local
     // archive layout or AGP's EXPLODED_AAR layout.
     private List<File> androidPackages;
+    // Maven AARs keep their legacy externally visible package names even though their content is
+    // consumed directly from AGP's transform cache.
+    private Map<File, String> androidPackageResourceNames;
     private List<File> outputFiles;
     private ResolvedPods resolvedPods;
     private int nameCounter = 0;
@@ -173,6 +177,7 @@ class Extender {
         this.metricsWriter = builder.metricsWriter;
         this.progressReporter = builder.progressReporter != null ? builder.progressReporter : ProgressReporter.NOOP;
         this.androidPackages = new ArrayList<>();
+        this.androidPackageResourceNames = new HashMap<>();
         this.outputFiles = new ArrayList<>();
 
         // Read config from SDK
@@ -1713,12 +1718,19 @@ class Extender {
         return String.format("%04d-%s", index, safePackageName);
     }
 
-    static List<String> getReturnedResourcePackageNames(List<String> resourceDirectories) {
-        List<String> baseNames = resourceDirectories.stream()
-                .map(File::new)
-                .map(File::getParentFile)
-                .map(directory -> directory == null ? "resources" : directory.getName())
-                .collect(Collectors.toList());
+    static List<String> getReturnedResourcePackageNames(
+            List<String> resourceDirectories,
+            Map<File, String> preferredPackageNames) throws IOException {
+        List<String> baseNames = new ArrayList<>();
+        for (String resourceDirectory : resourceDirectories) {
+            File packageDirectory = new File(resourceDirectory).getParentFile();
+            String preferredName = packageDirectory == null
+                    ? null
+                    : preferredPackageNames.get(packageDirectory.getCanonicalFile());
+            baseNames.add(preferredName != null
+                    ? preferredName
+                    : packageDirectory == null ? "resources" : packageDirectory.getName());
+        }
         Set<String> reservedNames = new HashSet<>(baseNames);
         Set<String> assignedNames = new HashSet<>();
         List<String> result = new ArrayList<>();
@@ -2478,7 +2490,9 @@ class Extender {
         List<String> packagesList = new ArrayList<>();
 
         try {
-            List<String> packageNames = getReturnedResourcePackageNames(androidResourceFolders);
+            List<String> packageNames = getReturnedResourcePackageNames(
+                    androidResourceFolders,
+                    androidPackageResourceNames);
             for (int index = 0; index < androidResourceFolders.size(); index++) {
                 String androidResourceFolder = androidResourceFolders.get(index);
                 File packageResourceDir = new File(androidResourceFolder);
@@ -2763,7 +2777,17 @@ class Extender {
 
     void resolve(GradleService gradleService) throws ExtenderException {
         try {
-            androidPackages.addAll(gradleService.resolveDependencies(this.buildState, this.platformConfig.context, outputFiles));
+            for (GradleArtifact artifact : gradleService.resolveDependencies(
+                    this.buildState,
+                    this.platformConfig.context,
+                    outputFiles)) {
+                androidPackages.add(artifact.getFile());
+                if (artifact.getResourcePackageName() != null) {
+                    androidPackageResourceNames.put(
+                            artifact.getFile().getCanonicalFile(),
+                            artifact.getResourcePackageName());
+                }
+            }
         }
         catch (IOException e) {
             throw new ExtenderException(e, "Failed to resolve Gradle dependencies. " + e.getMessage());

--- a/server/src/main/java/com/defold/extender/Extender.java
+++ b/server/src/main/java/com/defold/extender/Extender.java
@@ -1793,10 +1793,6 @@ class Extender {
         return outputDirectory;
     }
 
-    static boolean shouldGenerateAaptMainDexRules(File uploadDir, int minAndroidSdkVersion) {
-        return R8Builder.isRequested(uploadDir) && minAndroidSdkVersion < 21;
-    }
-
     private Map<String, File> linkAndroidResources(File compiledResourcesDir, Map<String, Object> mergedAppContext) throws ExtenderException {
         LOGGER.info("Linking Android resources");
 
@@ -1844,21 +1840,13 @@ class Extender {
 
             File aaptKeepRules = new File(buildState.buildDir, "aapt-generated.keep");
             context.put("aaptKeepRules", aaptKeepRules.getAbsolutePath());
-            File aaptMainDexRules = new File(buildState.buildDir, "aapt-main-dex-generated.keep");
-            context.put("aaptMainDexRules", aaptMainDexRules.getAbsolutePath());
             boolean useR8 = R8Builder.isRequested(buildState.uploadDir);
             context.put("useR8", useR8);
-            context.put(
-                    "useR8MainDexRules",
-                    shouldGenerateAaptMainDexRules(
-                            buildState.uploadDir,
-                            buildState.getMinAndroidSdkVersion()));
 
             files.put("resourceIdsFile", resourceIdsFile);
             files.put("outApkFile", outApkFile);
             files.put("outJavaDirectory", outputJavaDirectory);
             files.put("aaptKeepRules", aaptKeepRules);
-            files.put("aaptMainDexRules", aaptMainDexRules);
 
             executeCommand(platformConfig.aapt2linkCmd, context);
         } catch (IOException e) {
@@ -2575,7 +2563,6 @@ class Extender {
 
         File rJavaDir = null;
         File aaptKeepRules = null;
-        File aaptMainDexRules = null;
         // 1.2.174
         if (platformConfig.aapt2compileCmd != null) {
             // compile and link all of the resource files
@@ -2588,7 +2575,6 @@ class Extender {
             outputFiles.add(files.get("resourceIdsFile"));
             rJavaDir = files.get("outJavaDirectory");
             aaptKeepRules = files.get("aaptKeepRules");
-            aaptMainDexRules = files.get("aaptMainDexRules");
         }
         else {
             rJavaDir = generateRJava(androidResourceFolders, mergedAppContext);
@@ -2599,7 +2585,6 @@ class Extender {
 
         Map<String, R8Builder.ExtensionContext> extensionJarMap = buildJava(rJar);
         List<String> allJars = getAllJars(extensionJarMap);
-        File mainDexList = buildMainDexList(allJars);
         R8Builder r8Builder = new R8Builder(
                 buildState.uploadDir,
                 buildState.buildDir,
@@ -2612,14 +2597,13 @@ class Extender {
         R8Builder.BuildOutput r8Output = r8Builder.build(
                 allJars,
                 extensionJarMap,
-                mainDexList,
-                aaptKeepRules,
-                aaptMainDexRules);
+                aaptKeepRules);
         if (r8Output != null) {
             outputFiles.addAll(Arrays.asList(r8Output.dexFiles));
             outputFiles.add(r8Output.mappingFile);
             outputFiles.addAll(Arrays.asList(r8Output.metaInformationFiles));
         } else {
+            File mainDexList = buildMainDexList(allJars);
             File[] classesDex = buildClassesDex(allJars, mainDexList);
             if (classesDex.length > 0) {
                 outputFiles.addAll(Arrays.asList(classesDex));

--- a/server/src/main/java/com/defold/extender/ExtenderUtil.java
+++ b/server/src/main/java/com/defold/extender/ExtenderUtil.java
@@ -929,6 +929,7 @@ public class ExtenderUtil
             && !entryName.endsWith(".MF")
             && !entryName.endsWith(".kotlin_module")
             && !entryName.endsWith(".class")
+            && !entryName.endsWith(".pro")
             && !R8Builder.isEmbeddedRuleEntryName(entryName)
             && !entryName.endsWith("pom.xml")
             && !entryName.endsWith("pom.properties");

--- a/server/src/main/java/com/defold/extender/ExtenderUtil.java
+++ b/server/src/main/java/com/defold/extender/ExtenderUtil.java
@@ -929,7 +929,7 @@ public class ExtenderUtil
             && !entryName.endsWith(".MF")
             && !entryName.endsWith(".kotlin_module")
             && !entryName.endsWith(".class")
-            && !entryName.endsWith(".pro")
+            && !R8Builder.isEmbeddedRuleEntryName(entryName)
             && !entryName.endsWith("pom.xml")
             && !entryName.endsWith("pom.properties");
     }

--- a/server/src/main/java/com/defold/extender/PlatformConfig.java
+++ b/server/src/main/java/com/defold/extender/PlatformConfig.java
@@ -29,8 +29,12 @@ public class PlatformConfig {
     public String manifestName;
     public String manifestMergeCmd;
     public String bitcodeStripCmd;  // deprecated
-    public String proGuardSourceRe;
-    public String proGuardCmd;
+    public String r8RuleSourceRe;
+    public String r8Cmd;
+    public String r8Version;
+    // Legacy SDK deserialization only. Extender deliberately never reads these fields.
+    @Deprecated public String proGuardCmd;
+    @Deprecated public String proGuardSourceRe;
     public String windresCmd;
     public String symbolCmd;
     public String symbolsPattern;

--- a/server/src/main/java/com/defold/extender/R8Builder.java
+++ b/server/src/main/java/com/defold/extender/R8Builder.java
@@ -125,18 +125,29 @@ final class R8Builder {
 
     static List<String> getAndroidPackageJars(File androidPackage) {
         Set<String> jars = new TreeSet<>();
-        File classesJar = new File(androidPackage, "classes.jar");
+        File classesJar = getAndroidPackageClassesJar(androidPackage);
         if (classesJar.isFile()) {
             jars.add(classesJar.getAbsolutePath());
         }
-        File libsDir = new File(androidPackage, "libs");
-        File[] libraryJars = libsDir.listFiles(file -> file.isFile() && file.getName().endsWith(".jar"));
-        if (libraryJars != null) {
-            for (File libraryJar : libraryJars) {
-                jars.add(libraryJar.getAbsolutePath());
+        for (File libsDir : List.of(
+                new File(androidPackage, "libs"),
+                new File(androidPackage, "jars/libs"))) {
+            File[] libraryJars = libsDir.listFiles(file -> file.isFile() && file.getName().endsWith(".jar"));
+            if (libraryJars != null) {
+                for (File libraryJar : libraryJars) {
+                    jars.add(libraryJar.getAbsolutePath());
+                }
             }
         }
         return new ArrayList<>(jars);
+    }
+
+    static File getAndroidPackageClassesJar(File androidPackage) {
+        File unpackedClassesJar = new File(androidPackage, "classes.jar");
+        if (unpackedClassesJar.isFile()) {
+            return unpackedClassesJar;
+        }
+        return new File(androidPackage, "jars/classes.jar");
     }
 
     private static final class R8SemanticVersion {
@@ -420,12 +431,12 @@ final class R8Builder {
         List<File> sortedPackages = new ArrayList<>(androidPackages);
         sortedPackages.sort((left, right) -> left.getAbsolutePath().compareTo(right.getAbsolutePath()));
         for (File androidPackage : sortedPackages) {
-            if (!androidPackage.isDirectory() || !androidPackage.getName().endsWith(".aar")) {
+            if (!androidPackage.isDirectory()) {
                 continue;
             }
 
             File legacyRules = new File(androidPackage, "proguard.txt");
-            File classesJar = new File(androidPackage, "classes.jar");
+            File classesJar = getAndroidPackageClassesJar(androidPackage);
             try {
                 boolean hasTargetedRules = classesJar.isFile()
                         && jarHasTargetedRules.getOrDefault(classesJar.getCanonicalPath(), false);

--- a/server/src/main/java/com/defold/extender/R8Builder.java
+++ b/server/src/main/java/com/defold/extender/R8Builder.java
@@ -1,0 +1,974 @@
+package com.defold.extender;
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+/** Builds Android dex files with R8 and owns all R8 rule discovery and assembly. */
+final class R8Builder {
+    private static final Logger LOGGER = LoggerFactory.getLogger(R8Builder.class);
+
+    static final String RULES_WITHOUT_JAR = "r8_rules_without_jar";
+
+    private static final boolean DM_DEBUG_DISABLE_R8 = System.getenv("DM_DEBUG_DISABLE_R8") != null;
+    private static final String APP_RULES_PATH = "_app/app.keep";
+    private static final String JAR_LEGACY_RULE_PREFIX = "META-INF/proguard/";
+    private static final String JAR_R8_RULE_PREFIX = "META-INF/com.android.tools/r8";
+    private static final String GENERATED_EXTENSION_KEEP_ATTRIBUTES =
+            "-keepattributes *Annotation*,Signature,InnerClasses,EnclosingMethod,MethodParameters,Exceptions";
+    static final int MAX_GENERATED_EXTENSION_CLASSES = 32 * 1024;
+    static final int MAX_CLASSFILE_HEADER_BYTES = 4 * 1024 * 1024;
+    static final long MAX_TOTAL_CLASSFILE_HEADER_BYTES = 64L * 1024L * 1024L;
+    static final class ExtensionContext {
+        final List<String> ruleFiles = new ArrayList<>();
+        final List<String> protectedJars = new ArrayList<>();
+    }
+
+    static final class BuildOutput {
+        final File[] dexFiles;
+        final File mappingFile;
+
+        BuildOutput(File[] dexFiles, File mappingFile) {
+            this.dexFiles = dexFiles;
+            this.mappingFile = mappingFile;
+        }
+    }
+
+    @FunctionalInterface
+    interface CommandExecutor {
+        void execute(String commandTemplate, Map<String, Object> context) throws ExtenderException;
+    }
+
+    private final File uploadDir;
+    private final File buildDir;
+    private final PlatformConfig platformConfig;
+    private final List<File> androidPackages;
+    private final Map<String, Object> commandContext;
+    private final int minAndroidSdkVersion;
+    private final TemplateExecutor templateExecutor;
+    private final CommandExecutor commandExecutor;
+
+    R8Builder(
+            File uploadDir,
+            File buildDir,
+            PlatformConfig platformConfig,
+            List<File> androidPackages,
+            Map<String, Object> commandContext,
+            int minAndroidSdkVersion,
+            TemplateExecutor templateExecutor,
+            CommandExecutor commandExecutor) {
+        this.uploadDir = uploadDir;
+        this.buildDir = buildDir;
+        this.platformConfig = platformConfig;
+        this.androidPackages = androidPackages;
+        this.commandContext = commandContext;
+        this.minAndroidSdkVersion = minAndroidSdkVersion;
+        this.templateExecutor = templateExecutor;
+        this.commandExecutor = commandExecutor;
+    }
+
+    static ExtensionContext createExtensionContext(
+            File extensionDir,
+            List<String> extensionLibJars,
+            String ruleSourceRegex) {
+        ExtensionContext context = new ExtensionContext();
+        File manifestDir = new File(extensionDir, "manifests/android");
+        if (manifestDir.isDirectory() && ruleSourceRegex != null && !ruleSourceRegex.isBlank()) {
+            Collection<File> candidates = FileUtils.listFiles(manifestDir, null, true);
+            List<File> ruleFiles = ExtenderUtil.filterFiles(candidates, ruleSourceRegex);
+            ruleFiles.sort((left, right) -> left.getAbsolutePath().compareTo(right.getAbsolutePath()));
+            for (File ruleFile : ruleFiles) {
+                context.ruleFiles.add(ruleFile.getAbsolutePath());
+            }
+        }
+
+        if (context.ruleFiles.isEmpty()) {
+            context.protectedJars.addAll(extensionLibJars);
+        }
+        return context;
+    }
+
+    static boolean isRulesOnlyPlaceholder(String path) {
+        return path.endsWith(RULES_WITHOUT_JAR);
+    }
+
+    static List<String> getCompiledJars(Map<String, ExtensionContext> extensionJarMap) {
+        return extensionJarMap.keySet().stream()
+                .filter(path -> !isRulesOnlyPlaceholder(path))
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
+    static List<String> getAndroidPackageJars(File androidPackage) {
+        Set<String> jars = new TreeSet<>();
+        File classesJar = new File(androidPackage, "classes.jar");
+        if (classesJar.isFile()) {
+            jars.add(classesJar.getAbsolutePath());
+        }
+        File libsDir = new File(androidPackage, "libs");
+        File[] libraryJars = libsDir.listFiles(file -> file.isFile() && file.getName().endsWith(".jar"));
+        if (libraryJars != null) {
+            for (File libraryJar : libraryJars) {
+                jars.add(libraryJar.getAbsolutePath());
+            }
+        }
+        return new ArrayList<>(jars);
+    }
+
+    private static final class R8SemanticVersion {
+        private final int major;
+        private final int minor;
+        private final int patch;
+        private final String prerelease;
+
+        private R8SemanticVersion(int major, int minor, int patch, String prerelease) {
+            this.major = major;
+            this.minor = minor;
+            this.patch = patch;
+            this.prerelease = prerelease;
+        }
+
+        static R8SemanticVersion parse(String value) {
+            int firstDot = value.indexOf('.');
+            if (firstDot <= 0) {
+                throw new IllegalArgumentException("Invalid R8 semantic version " + value);
+            }
+            int secondDot = value.indexOf('.', firstDot + 1);
+            if (secondDot <= firstDot + 1) {
+                throw new IllegalArgumentException("Invalid R8 semantic version " + value);
+            }
+            int prereleaseStart = value.indexOf('-', secondDot + 1);
+            int patchEnd = prereleaseStart < 0 ? value.length() : prereleaseStart;
+            if (patchEnd <= secondDot + 1) {
+                throw new IllegalArgumentException("Invalid R8 semantic version " + value);
+            }
+            try {
+                return new R8SemanticVersion(
+                        Integer.parseInt(value.substring(0, firstDot)),
+                        Integer.parseInt(value.substring(firstDot + 1, secondDot)),
+                        Integer.parseInt(value.substring(secondDot + 1, patchEnd)),
+                        prereleaseStart < 0 ? null : value.substring(prereleaseStart + 1));
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid R8 semantic version " + value, e);
+            }
+        }
+
+        int compareNumbers(R8SemanticVersion other) {
+            int comparison = Integer.compare(major, other.major);
+            if (comparison == 0) {
+                comparison = Integer.compare(minor, other.minor);
+            }
+            if (comparison == 0) {
+                comparison = Integer.compare(patch, other.patch);
+            }
+            return comparison;
+        }
+
+        boolean isNewer(R8SemanticVersion other) {
+            return compareNumbers(other) > 0;
+        }
+
+        boolean isNewerOrEqual(R8SemanticVersion other) {
+            return isNewer(other) || (compareNumbers(other) == 0
+                    && (prerelease == null ? other.prerelease == null : prerelease.equals(other.prerelease)));
+        }
+    }
+
+    static int compareVersions(String left, String right) {
+        return R8SemanticVersion.parse(left).compareNumbers(R8SemanticVersion.parse(right));
+    }
+
+    static boolean isEmbeddedRuleEntryName(String entryName) {
+        if (entryName.startsWith(JAR_LEGACY_RULE_PREFIX)) {
+            return true;
+        }
+        if (!entryName.startsWith(JAR_R8_RULE_PREFIX)) {
+            return false;
+        }
+        String suffix = entryName.substring(JAR_R8_RULE_PREFIX.length());
+        return suffix.startsWith("/")
+                || suffix.startsWith("-from-")
+                || suffix.startsWith("-upto-");
+    }
+
+    private static int indexOfEither(String value, char first, char second) {
+        int firstIndex = value.indexOf(first);
+        int secondIndex = value.indexOf(second);
+        if (firstIndex < 0) {
+            return secondIndex;
+        }
+        if (secondIndex < 0) {
+            return firstIndex;
+        }
+        return Math.min(firstIndex, secondIndex);
+    }
+
+    private static boolean isApplicableR8RuleEntry(String entryName, String r8Version) {
+        if (!entryName.startsWith(JAR_R8_RULE_PREFIX)) {
+            return false;
+        }
+        String suffix = entryName.substring(JAR_R8_RULE_PREFIX.length());
+        if (suffix.startsWith("/")) {
+            return true;
+        }
+        if (!suffix.startsWith("-from-") && !suffix.startsWith("-upto-")) {
+            return false;
+        }
+
+        try {
+            R8SemanticVersion from = new R8SemanticVersion(0, 0, 0, null);
+            R8SemanticVersion upTo = null;
+            if (suffix.startsWith("-from-")) {
+                suffix = suffix.substring("-from-".length());
+                int versionEnd = indexOfEither(suffix, '-', '/');
+                if (versionEnd < 0) {
+                    return false;
+                }
+                from = R8SemanticVersion.parse(suffix.substring(0, versionEnd));
+                suffix = suffix.substring(versionEnd);
+            }
+            if (suffix.startsWith("-upto-")) {
+                suffix = suffix.substring("-upto-".length());
+                int versionEnd = suffix.indexOf('/');
+                if (versionEnd < 0) {
+                    return false;
+                }
+                upTo = R8SemanticVersion.parse(suffix.substring(0, versionEnd));
+            }
+            R8SemanticVersion compilerVersion = R8SemanticVersion.parse(r8Version);
+            return compilerVersion.isNewerOrEqual(from)
+                    && (upTo == null || upTo.isNewer(compilerVersion));
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    static boolean isApplicableRuleDirectory(String directory, String r8Version) {
+        if (!directory.startsWith("r8")) {
+            return false;
+        }
+        return isApplicableR8RuleEntry(
+                JAR_R8_RULE_PREFIX + directory.substring("r8".length()) + "/rules.keep",
+                r8Version);
+    }
+
+    static List<String> selectEmbeddedRuleEntries(File jar, String r8Version)
+            throws IOException, ExtenderException {
+        List<String> targetedRules = new ArrayList<>();
+        List<String> legacyRules = new ArrayList<>();
+        Set<String> candidateNames = new LinkedHashSet<>();
+        int candidateCount = 0;
+
+        try (ZipFile zipFile = new ZipFile(jar)) {
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                if (entry.isDirectory()) {
+                    continue;
+                }
+
+                String entryName = entry.getName();
+                if (!isEmbeddedRuleEntryName(entryName)) {
+                    continue;
+                }
+                if (!candidateNames.add(entryName)) {
+                    throw new ExtenderException("Duplicate embedded R8 rule entry " + entryName + " in " + jar);
+                }
+                if (++candidateCount > R8RulePolicy.MAX_RULE_FILES) {
+                    throw new ExtenderException(String.format(
+                            "Too many embedded R8 rule files in %s (maximum %d)",
+                            jar,
+                            R8RulePolicy.MAX_RULE_FILES));
+                }
+                if (entryName.startsWith(JAR_LEGACY_RULE_PREFIX)) {
+                    legacyRules.add(entryName);
+                    continue;
+                }
+                if (isApplicableR8RuleEntry(entryName, r8Version)) {
+                    targetedRules.add(entryName);
+                }
+            }
+        }
+
+        Collections.sort(targetedRules);
+        Collections.sort(legacyRules);
+        return targetedRules.isEmpty() ? legacyRules : targetedRules;
+    }
+
+    static boolean isRequested(File uploadDir) {
+        return new File(uploadDir, APP_RULES_PATH).isFile();
+    }
+
+    static void validateConfiguration(String r8Cmd, String r8Version) throws ExtenderException {
+        if (r8Cmd == null || r8Cmd.isBlank() || r8Version == null || r8Version.isBlank()) {
+            throw new ExtenderException("R8 shrinking was requested, but this Defold SDK does not provide r8Cmd and r8Version");
+        }
+        try {
+            compareVersions(r8Version, r8Version);
+        } catch (IllegalArgumentException e) {
+            throw new ExtenderException("Invalid r8Version in this Defold SDK: " + r8Version);
+        }
+    }
+
+    private void validateResolvedR8Environment(Map<String, Object> context) throws ExtenderException {
+        for (String name : List.of("R8", "R8_VERSION")) {
+            if (!platformConfig.env.containsKey(name)) {
+                continue;
+            }
+            Object value = context.get("env." + name);
+            if (!(value instanceof String) || ((String) value).isBlank()) {
+                validateConfiguration(null, null);
+            }
+        }
+    }
+
+    private static boolean containsTargetedRules(List<String> entries) {
+        return entries.stream().anyMatch(entry -> entry.startsWith(JAR_R8_RULE_PREFIX));
+    }
+
+    static List<String> collectConsumerRules(
+            List<String> allJars,
+            List<File> androidPackages,
+            String r8Version,
+            File rulesRoot) throws ExtenderException {
+        File emptyRuleBase = R8RulePolicy.createEmptyBaseDirectory(
+                rulesRoot.getAbsoluteFile().getParentFile());
+        return collectConsumerRules(
+                allJars,
+                androidPackages,
+                r8Version,
+                rulesRoot,
+                new R8RulePolicy.Budget(),
+                emptyRuleBase);
+    }
+
+    private static List<String> collectConsumerRules(
+            List<String> allJars,
+            List<File> androidPackages,
+            String r8Version,
+            File rulesRoot,
+            R8RulePolicy.Budget ruleBudget,
+            File emptyRuleBase) throws ExtenderException {
+        try {
+            Files.createDirectories(rulesRoot.toPath());
+        } catch (IOException e) {
+            throw new ExtenderException(e, "Failed to create R8 consumer rules directory " + rulesRoot);
+        }
+
+        List<String> sortedJars = new ArrayList<>(new LinkedHashSet<>(allJars));
+        Collections.sort(sortedJars);
+        Map<String, Boolean> jarHasTargetedRules = new HashMap<>();
+        List<String> consumerRules = new ArrayList<>();
+        int artifactIndex = 0;
+
+        for (String jarPath : sortedJars) {
+            File jar = new File(jarPath);
+            if (!jar.isFile() || !jar.getName().endsWith(".jar")) {
+                continue;
+            }
+
+            try (ZipFile zipFile = new ZipFile(jar)) {
+                List<String> selectedEntries = selectEmbeddedRuleEntries(jar, r8Version);
+                jarHasTargetedRules.put(jar.getCanonicalPath(), containsTargetedRules(selectedEntries));
+                if (selectedEntries.isEmpty()) {
+                    continue;
+                }
+
+                File artifactRulesDir = new File(rulesRoot, String.format("jar-%04d", artifactIndex++));
+                for (int ruleIndex = 0; ruleIndex < selectedEntries.size(); ++ruleIndex) {
+                    String entryName = selectedEntries.get(ruleIndex);
+                    ZipEntry entry = zipFile.getEntry(entryName);
+                    if (entry == null) {
+                        throw new ExtenderException("Missing embedded R8 rule entry " + entryName + " in " + jar);
+                    }
+                    byte[] contents = R8RulePolicy.readAndValidate(zipFile, entry, ruleBudget);
+                    File extractedRule = new File(
+                            artifactRulesDir,
+                            String.format("rule-%04d.keep", ruleIndex));
+                    R8RulePolicy.writeSanitized(extractedRule, contents, emptyRuleBase);
+                    consumerRules.add(extractedRule.getAbsolutePath());
+                }
+            } catch (IOException e) {
+                throw new ExtenderException(e, "Failed to read R8 consumer rules from " + jarPath);
+            }
+        }
+
+        List<File> sortedPackages = new ArrayList<>(androidPackages);
+        sortedPackages.sort((left, right) -> left.getAbsolutePath().compareTo(right.getAbsolutePath()));
+        for (File androidPackage : sortedPackages) {
+            if (!androidPackage.isDirectory() || !androidPackage.getName().endsWith(".aar")) {
+                continue;
+            }
+
+            File legacyRules = new File(androidPackage, "proguard.txt");
+            File classesJar = new File(androidPackage, "classes.jar");
+            try {
+                boolean hasTargetedRules = classesJar.isFile()
+                        && jarHasTargetedRules.getOrDefault(classesJar.getCanonicalPath(), false);
+                if (legacyRules.isFile() && !hasTargetedRules) {
+                    File extractedRules = new File(rulesRoot, String.format("aar-%04d.keep", artifactIndex++));
+                    byte[] contents = R8RulePolicy.readAndValidate(legacyRules, ruleBudget);
+                    R8RulePolicy.writeSanitized(extractedRules, contents, emptyRuleBase);
+                    consumerRules.add(extractedRules.getAbsolutePath());
+                }
+            } catch (IOException e) {
+                throw new ExtenderException(e, "Failed to collect R8 consumer rules from " + androidPackage);
+            }
+        }
+
+        return consumerRules;
+    }
+
+    private static boolean hasEmbeddedRuleEntries(File jar) throws IOException {
+        try (org.apache.commons.compress.archivers.zip.ZipFile zipFile =
+                     org.apache.commons.compress.archivers.zip.ZipFile.builder().setFile(jar).get()) {
+            Enumeration<ZipArchiveEntry> entries = zipFile.getEntriesInPhysicalOrder();
+            while (entries.hasMoreElements()) {
+                ZipArchiveEntry entry = entries.nextElement();
+                if (!entry.isDirectory() && isEmbeddedRuleEntryName(entry.getName())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    static File stripEmbeddedRuleEntries(File jar, File strippedJar) throws ExtenderException {
+        try {
+            if (!hasEmbeddedRuleEntries(jar)) {
+                return jar;
+            }
+            if (strippedJar.toPath().getParent() != null) {
+                Files.createDirectories(strippedJar.toPath().getParent());
+            }
+            try (org.apache.commons.compress.archivers.zip.ZipFile zipFile =
+                         org.apache.commons.compress.archivers.zip.ZipFile.builder().setFile(jar).get();
+                 ZipArchiveOutputStream output = new ZipArchiveOutputStream(strippedJar)) {
+                Enumeration<ZipArchiveEntry> entries = zipFile.getEntriesInPhysicalOrder();
+                while (entries.hasMoreElements()) {
+                    ZipArchiveEntry entry = entries.nextElement();
+                    if (!entry.isDirectory() && isEmbeddedRuleEntryName(entry.getName())) {
+                        continue;
+                    }
+                    try (InputStream rawInput = zipFile.getRawInputStream(entry)) {
+                        if (rawInput == null) {
+                            throw new IOException("Missing raw ZIP data for " + entry.getName());
+                        }
+                        output.addRawArchiveEntry(new ZipArchiveEntry(entry), rawInput);
+                    }
+                }
+            }
+            return strippedJar;
+        } catch (IOException e) {
+            throw new ExtenderException(e, "Failed to remove embedded R8 rules from " + jar);
+        }
+    }
+
+    private static List<String> prepareProgramJars(List<String> allJars, File strippedJarsDir)
+            throws ExtenderException {
+        List<String> originalProgramJars = allJars.stream()
+                .filter(jar -> new File(jar).isFile())
+                .distinct()
+                .sorted()
+                .collect(Collectors.toList());
+        List<String> programJars = new ArrayList<>(originalProgramJars.size());
+        for (int index = 0; index < originalProgramJars.size(); ++index) {
+            File originalJar = new File(originalProgramJars.get(index));
+            File strippedJar = new File(strippedJarsDir, String.format("program-%04d.jar", index));
+            programJars.add(stripEmbeddedRuleEntries(originalJar, strippedJar).getPath());
+        }
+        return programJars;
+    }
+
+    private List<String> getProtectedJars(Map<String, ExtensionContext> extensionJarMap) {
+        Set<String> protectedJars = new TreeSet<>();
+        for (Map.Entry<String, ExtensionContext> extensionEntry : extensionJarMap.entrySet()) {
+            ExtensionContext context = extensionEntry.getValue();
+            if (context == null || !context.ruleFiles.isEmpty()) {
+                continue;
+            }
+
+            String extensionJar = extensionEntry.getKey();
+            if (!isRulesOnlyPlaceholder(extensionJar)) {
+                protectedJars.add(extensionJar);
+            }
+            protectedJars.addAll(context.protectedJars);
+        }
+        return new ArrayList<>(protectedJars);
+    }
+
+    private static final class ClassFileReadBudget {
+        private long totalBytes;
+    }
+
+    private static final class BoundedClassFileInputStream extends FilterInputStream {
+        private final ClassFileReadBudget budget;
+        private int classBytes;
+
+        BoundedClassFileInputStream(InputStream input, ClassFileReadBudget budget) {
+            super(input);
+            this.budget = budget;
+        }
+
+        private int allowedBytes(int requested) throws IOException {
+            if (requested == 0) {
+                return 0;
+            }
+            int classRemaining = MAX_CLASSFILE_HEADER_BYTES - classBytes;
+            if (classRemaining <= 0) {
+                throw new IOException(String.format(
+                        "Class file header exceeds the %d-byte read limit",
+                        MAX_CLASSFILE_HEADER_BYTES));
+            }
+            long totalRemaining = MAX_TOTAL_CLASSFILE_HEADER_BYTES - budget.totalBytes;
+            if (totalRemaining <= 0) {
+                throw new IOException(String.format(
+                        "Class file headers exceed the %d-byte aggregate read limit",
+                        MAX_TOTAL_CLASSFILE_HEADER_BYTES));
+            }
+            return (int) Math.min(requested, Math.min(classRemaining, totalRemaining));
+        }
+
+        private void account(int count) {
+            if (count > 0) {
+                classBytes += count;
+                budget.totalBytes += count;
+            }
+        }
+
+        @Override
+        public int read() throws IOException {
+            allowedBytes(1);
+            int value = super.read();
+            if (value >= 0) {
+                account(1);
+            }
+            return value;
+        }
+
+        @Override
+        public int read(byte[] bytes, int offset, int length) throws IOException {
+            int allowed = allowedBytes(length);
+            if (allowed == 0) {
+                return 0;
+            }
+            int count = super.read(bytes, offset, allowed);
+            account(count);
+            return count;
+        }
+    }
+
+    private static String readClassInternalName(
+            ZipFile zipFile,
+            ZipEntry entry,
+            ClassFileReadBudget budget) throws IOException {
+        try (DataInputStream input = new DataInputStream(new BoundedClassFileInputStream(
+                zipFile.getInputStream(entry),
+                budget))) {
+            if (input.readInt() != 0xCAFEBABE) {
+                throw new IOException("Invalid class file magic");
+            }
+            input.readUnsignedShort(); // minor_version
+            input.readUnsignedShort(); // major_version
+
+            int constantPoolCount = input.readUnsignedShort();
+            if (constantPoolCount <= 1) {
+                throw new IOException("Invalid class file constant pool count");
+            }
+            byte[] tags = new byte[constantPoolCount];
+            String[] utf8Values = new String[constantPoolCount];
+            int[] classNameIndexes = new int[constantPoolCount];
+            for (int index = 1; index < constantPoolCount; ++index) {
+                int tag = input.readUnsignedByte();
+                tags[index] = (byte) tag;
+                switch (tag) {
+                    case 1:
+                        utf8Values[index] = input.readUTF();
+                        break;
+                    case 3:
+                    case 4:
+                        input.readInt();
+                        break;
+                    case 5:
+                    case 6:
+                        input.readLong();
+                        if (++index >= constantPoolCount) {
+                            throw new IOException("Long or double overruns the class file constant pool");
+                        }
+                        break;
+                    case 7:
+                        classNameIndexes[index] = input.readUnsignedShort();
+                        break;
+                    case 8:
+                    case 16:
+                    case 19:
+                    case 20:
+                        input.readUnsignedShort();
+                        break;
+                    case 9:
+                    case 10:
+                    case 11:
+                    case 12:
+                    case 17:
+                    case 18:
+                        input.readInt();
+                        break;
+                    case 15:
+                        input.readUnsignedByte();
+                        input.readUnsignedShort();
+                        break;
+                    default:
+                        throw new IOException("Unknown class file constant pool tag " + tag);
+                }
+            }
+
+            input.readUnsignedShort(); // access_flags
+            int thisClass = input.readUnsignedShort();
+            input.readUnsignedShort(); // super_class
+            if (thisClass <= 0 || thisClass >= constantPoolCount || tags[thisClass] != 7) {
+                throw new IOException("Invalid this_class constant pool index");
+            }
+            int nameIndex = classNameIndexes[thisClass];
+            if (nameIndex <= 0 || nameIndex >= constantPoolCount || tags[nameIndex] != 1) {
+                throw new IOException("Invalid class name constant pool index");
+            }
+            return utf8Values[nameIndex];
+        }
+    }
+
+    private static boolean isR8LiteralSimpleNameCodePoint(int codePoint) {
+        boolean isDexSimpleNameCodePoint = (codePoint >= 'A' && codePoint <= 'Z')
+                || (codePoint >= 'a' && codePoint <= 'z')
+                || (codePoint >= '0' && codePoint <= '9')
+                || codePoint == '$'
+                || codePoint == '-'
+                || codePoint == '_'
+                || (codePoint >= 0x00A1 && codePoint <= 0x1FFF)
+                || (codePoint >= 0x2010 && codePoint <= 0x2027)
+                || (codePoint >= 0x2030 && codePoint <= 0xD7FF)
+                || (codePoint >= 0xE000 && codePoint <= 0xFEFE)
+                || (codePoint >= 0xFF00 && codePoint <= 0xFFEF)
+                || (codePoint >= 0x10000 && codePoint <= 0x10FFFF);
+        boolean isUnicodeSpace = codePoint == ' '
+                || codePoint == 0x00A0
+                || codePoint == 0x1680
+                || (codePoint >= 0x2000 && codePoint <= 0x200A)
+                || codePoint == 0x202F
+                || codePoint == 0x205F
+                || codePoint == 0x3000;
+        return isDexSimpleNameCodePoint && !isUnicodeSpace;
+    }
+
+    private static String toR8ClassPattern(String internalName) throws IOException {
+        if (internalName == null || internalName.isEmpty()) {
+            throw new IOException("Class file has an empty internal name");
+        }
+
+        StringBuilder pattern = new StringBuilder(internalName.length());
+        boolean segmentIsEmpty = true;
+        for (int offset = 0; offset < internalName.length();) {
+            int codePoint = internalName.codePointAt(offset);
+            offset += Character.charCount(codePoint);
+            if (codePoint == '/') {
+                if (segmentIsEmpty || offset == internalName.length()) {
+                    throw new IOException("Class file has an empty internal-name segment");
+                }
+                pattern.append('.');
+                segmentIsEmpty = true;
+            } else {
+                if (codePoint == '.' || codePoint == ';' || codePoint == '[') {
+                    throw new IOException(String.format(
+                            "Class file internal name contains forbidden character U+%04X",
+                            codePoint));
+                }
+                pattern.appendCodePoint(isR8LiteralSimpleNameCodePoint(codePoint) ? codePoint : '?');
+                segmentIsEmpty = false;
+            }
+        }
+        return pattern.toString();
+    }
+
+    static File writeProtectedJarKeepRules(List<String> jarPaths, File outputFile)
+            throws IOException, ExtenderException {
+        Set<String> classNames = new TreeSet<>();
+        int classEntryCount = 0;
+        ClassFileReadBudget classFileReadBudget = new ClassFileReadBudget();
+        long generatedBytes = jarPaths.isEmpty()
+                ? 0
+                : GENERATED_EXTENSION_KEEP_ATTRIBUTES.getBytes(StandardCharsets.UTF_8).length + 1L;
+        for (String jarPath : jarPaths) {
+            File jar = new File(jarPath);
+            if (!jar.isFile()) {
+                continue;
+            }
+
+            try (ZipFile zipFile = new ZipFile(jar)) {
+                Enumeration<? extends ZipEntry> entries = zipFile.entries();
+                while (entries.hasMoreElements()) {
+                    ZipEntry entry = entries.nextElement();
+                    String entryName = entry.getName();
+                    if (entry.isDirectory()
+                            || !entryName.endsWith(".class")
+                            || entryName.startsWith("META-INF/")) {
+                        continue;
+                    }
+                    if (++classEntryCount > MAX_GENERATED_EXTENSION_CLASSES) {
+                        throw new ExtenderException(String.format(
+                                "Too many classes need generated R8 keep rules (maximum %d)",
+                                MAX_GENERATED_EXTENSION_CLASSES));
+                    }
+
+                    String internalName;
+                    try {
+                        internalName = readClassInternalName(zipFile, entry, classFileReadBudget);
+                    } catch (IOException e) {
+                        throw new ExtenderException(e, String.format(
+                                "Failed to read class file %s from %s: %s",
+                                entryName,
+                                jar,
+                                e.getMessage()));
+                    }
+                    if (internalName.equals("module-info")) {
+                        continue;
+                    }
+
+                    String className;
+                    try {
+                        className = toR8ClassPattern(internalName);
+                    } catch (IOException e) {
+                        throw new ExtenderException(e, String.format(
+                                "Invalid class name in %s from %s: %s",
+                                entryName,
+                                jar,
+                                e.getMessage()));
+                    }
+                    if (classNames.add(className)) {
+                        String rule = String.format("-keep class %s { *; }\n", className);
+                        generatedBytes += rule.getBytes(StandardCharsets.UTF_8).length;
+                        if (generatedBytes > R8RulePolicy.MAX_RULE_FILE_BYTES) {
+                            throw new ExtenderException(String.format(
+                                    "Generated R8 keep rules are too large (maximum %d bytes)",
+                                    R8RulePolicy.MAX_RULE_FILE_BYTES));
+                        }
+                    }
+                }
+            }
+        }
+
+        StringBuilder rules = new StringBuilder((int) generatedBytes);
+        if (!jarPaths.isEmpty()) {
+            rules.append(GENERATED_EXTENSION_KEEP_ATTRIBUTES).append('\n');
+        }
+        for (String className : classNames) {
+            rules.append("-keep class ").append(className).append(" { *; }\n");
+        }
+        Files.writeString(outputFile.toPath(), rules, StandardCharsets.UTF_8);
+        return outputFile;
+    }
+
+    static String escapeDoubleQuotedCommandValue(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    static Map<String, Object> createR8CommandContext(Map<String, Object> context) {
+        Map<String, Object> escaped = new HashMap<>(context);
+        for (String key : List.of(
+                "env.R8",
+                "env.LIBRARYJAR",
+                "classes_dex_dir",
+                "mainDexList",
+                "mapping")) {
+            Object value = escaped.get(key);
+            if (value instanceof String) {
+                escaped.put(key, escapeDoubleQuotedCommandValue((String) value));
+            }
+        }
+        for (String key : List.of("jars", "rules", "mainDexRules")) {
+            Object value = escaped.get(key);
+            if (value instanceof List<?>) {
+                List<String> escapedValues = ((List<?>) value).stream()
+                        .map(Object::toString)
+                        .map(R8Builder::escapeDoubleQuotedCommandValue)
+                        .collect(Collectors.toList());
+                escaped.put(key, escapedValues);
+            }
+        }
+        return escaped;
+    }
+
+    BuildOutput build(
+            List<String> allJars,
+            Map<String, ExtensionContext> extensionJarMap,
+            File mainDexList,
+            File aaptGeneratedRules,
+            File aaptMainDexRules) throws ExtenderException {
+        File appRules = new File(uploadDir, APP_RULES_PATH);
+        if (!isRequested(uploadDir)) {
+            LOGGER.info("No app.keep file present. Skipping R8 step.");
+            return null;
+        }
+        if (DM_DEBUG_DISABLE_R8) {
+            LOGGER.info("R8 support disabled by environment flag DM_DEBUG_DISABLE_R8");
+            return null;
+        }
+
+        Map<String, Object> context = new HashMap<>(commandContext);
+        if (platformConfig.r8Cmd == null || platformConfig.r8Cmd.isBlank()
+                || platformConfig.r8Version == null || platformConfig.r8Version.isBlank()) {
+            validateConfiguration(platformConfig.r8Cmd, platformConfig.r8Version);
+        }
+        validateResolvedR8Environment(context);
+        String r8Version;
+        try {
+            r8Version = templateExecutor.executeOnceWithoutLogging(platformConfig.r8Version, context);
+        } catch (RuntimeException e) {
+            throw new ExtenderException(e, "R8 shrinking was requested, but its configuration could not be resolved");
+        }
+        validateConfiguration(platformConfig.r8Cmd, r8Version);
+        if (aaptGeneratedRules == null || !aaptGeneratedRules.isFile()) {
+            throw new ExtenderException(
+                    "R8 shrinking was requested, but aapt2 did not generate aapt-generated.keep");
+        }
+        if (minAndroidSdkVersion < 21) {
+            if (mainDexList == null || !mainDexList.isFile()) {
+                throw new ExtenderException(
+                        "R8 shrinking was requested below API 21, but the engine main-dex rules are missing");
+            }
+            if (aaptMainDexRules == null || !aaptMainDexRules.isFile()) {
+                throw new ExtenderException(
+                        "R8 shrinking was requested below API 21, but aapt2 did not generate aapt-main-dex-generated.keep");
+            }
+        }
+
+        LOGGER.info("Building classes.dex using R8 {}", r8Version);
+
+        Set<String> ruleFiles = new LinkedHashSet<>();
+        R8RulePolicy.Budget ruleBudget = new R8RulePolicy.Budget();
+        File emptyRuleBase = R8RulePolicy.createEmptyBaseDirectory(buildDir);
+        File sanitizedRulesDir = new File(buildDir, "r8-sanitized-rules");
+        File sanitizedAppRules = new File(sanitizedRulesDir, "app.keep");
+        R8RulePolicy.writeSanitized(
+                sanitizedAppRules,
+                R8RulePolicy.readAndValidate(appRules, ruleBudget),
+                emptyRuleBase);
+        ruleFiles.add(sanitizedAppRules.getAbsolutePath());
+        File sanitizedAaptRules = new File(sanitizedRulesDir, "aapt-generated.keep");
+        R8RulePolicy.writeSanitized(
+                sanitizedAaptRules,
+                R8RulePolicy.readAndValidate(aaptGeneratedRules, ruleBudget),
+                emptyRuleBase);
+        ruleFiles.add(sanitizedAaptRules.getAbsolutePath());
+
+        List<String> mainDexRules = new ArrayList<>();
+        if (minAndroidSdkVersion < 21) {
+            File sanitizedAaptMainDexRules = new File(
+                    sanitizedRulesDir,
+                    "aapt-main-dex-generated.keep");
+            R8RulePolicy.writeSanitized(
+                    sanitizedAaptMainDexRules,
+                    R8RulePolicy.readAndValidate(aaptMainDexRules, ruleBudget),
+                    emptyRuleBase);
+            mainDexRules.add(mainDexList.getAbsolutePath());
+            mainDexRules.add(sanitizedAaptMainDexRules.getAbsolutePath());
+        }
+
+        Set<String> seenUntrustedRules = new LinkedHashSet<>();
+        int sanitizedExtensionRuleIndex = 0;
+        List<String> extensionJars = new ArrayList<>(extensionJarMap.keySet());
+        Collections.sort(extensionJars);
+        for (String extensionJar : extensionJars) {
+            ExtensionContext extensionContext = extensionJarMap.get(extensionJar);
+            if (extensionContext != null) {
+                List<String> extensionRules = new ArrayList<>(extensionContext.ruleFiles);
+                Collections.sort(extensionRules);
+                for (String extensionRule : extensionRules) {
+                    if (seenUntrustedRules.add(extensionRule)) {
+                        File sanitizedExtensionRule = new File(
+                                sanitizedRulesDir,
+                                String.format("extension-%04d.keep", sanitizedExtensionRuleIndex++));
+                        R8RulePolicy.writeSanitized(
+                                sanitizedExtensionRule,
+                                R8RulePolicy.readAndValidate(new File(extensionRule), ruleBudget),
+                                emptyRuleBase);
+                        ruleFiles.add(sanitizedExtensionRule.getAbsolutePath());
+                    }
+                }
+            }
+        }
+
+        File consumerRulesDir = new File(buildDir, "r8-consumer-rules");
+        ruleFiles.addAll(collectConsumerRules(
+                allJars,
+                androidPackages,
+                r8Version,
+                consumerRulesDir,
+                ruleBudget,
+                emptyRuleBase));
+
+        List<String> protectedJars = getProtectedJars(extensionJarMap);
+        if (!protectedJars.isEmpty()) {
+            File generatedRules = new File(buildDir, "generated-extension-rules.keep");
+            try {
+                writeProtectedJarKeepRules(protectedJars, generatedRules);
+            } catch (IOException e) {
+                throw new ExtenderException(e, "Failed to generate R8 rules for unconfigured extension jars");
+            }
+            R8RulePolicy.account(generatedRules, ruleBudget);
+            ruleFiles.add(generatedRules.getAbsolutePath());
+        }
+
+        List<String> programJars = prepareProgramJars(
+                allJars,
+                new File(buildDir, "r8-program-jars"));
+        File mappingFile = new File(buildDir, "mapping.txt");
+
+        context.put("classes_dex_dir", buildDir.getAbsolutePath());
+        context.put("jars", programJars);
+        context.put("rules", new ArrayList<>(ruleFiles));
+        context.put("mainDexRules", mainDexRules);
+        context.put("useMainDexRules", !mainDexRules.isEmpty());
+        context.put("mapping", mappingFile.getAbsolutePath());
+        context.put("minAndroidSdkVersion", minAndroidSdkVersion);
+        R8RulePolicy.requireEmptyBaseDirectory(emptyRuleBase);
+        String r8Command;
+        try {
+            r8Command = templateExecutor.executeOnceWithoutLogging(
+                    platformConfig.r8Cmd,
+                    createR8CommandContext(context));
+        } catch (RuntimeException e) {
+            throw new ExtenderException(e, "R8 shrinking was requested, but its configuration could not be resolved");
+        }
+        commandExecutor.execute(r8Command, context);
+
+        File[] dexFiles = ExtenderUtil.listFilesMatching(buildDir, "^classes(|[0-9]+)\\.dex$");
+        Arrays.sort(dexFiles, (left, right) -> left.getName().compareTo(right.getName()));
+        if (dexFiles.length == 0 || !mappingFile.isFile()) {
+            throw new ExtenderException("R8 completed without producing classes.dex and mapping.txt");
+        }
+        return new BuildOutput(dexFiles, mappingFile);
+    }
+}

--- a/server/src/main/java/com/defold/extender/R8Builder.java
+++ b/server/src/main/java/com/defold/extender/R8Builder.java
@@ -41,9 +41,6 @@ final class R8Builder {
     private static final String JAR_R8_RULE_PREFIX = "META-INF/com.android.tools/r8";
     private static final String GENERATED_EXTENSION_KEEP_ATTRIBUTES =
             "-keepattributes *Annotation*,Signature,InnerClasses,EnclosingMethod,MethodParameters,Exceptions";
-    static final int MAX_GENERATED_EXTENSION_CLASSES = 32 * 1024;
-    static final int MAX_CLASSFILE_HEADER_BYTES = 4 * 1024 * 1024;
-    static final long MAX_TOTAL_CLASSFILE_HEADER_BYTES = 64L * 1024L * 1024L;
     static final class ExtensionContext {
         final List<String> ruleFiles = new ArrayList<>();
         final List<String> protectedJars = new ArrayList<>();
@@ -72,6 +69,7 @@ final class R8Builder {
     private final List<File> androidPackages;
     private final Map<String, Object> commandContext;
     private final int minAndroidSdkVersion;
+    private final R8Configuration r8Configuration;
     private final TemplateExecutor templateExecutor;
     private final CommandExecutor commandExecutor;
 
@@ -82,6 +80,7 @@ final class R8Builder {
             List<File> androidPackages,
             Map<String, Object> commandContext,
             int minAndroidSdkVersion,
+            R8Configuration r8Configuration,
             TemplateExecutor templateExecutor,
             CommandExecutor commandExecutor) {
         this.uploadDir = uploadDir;
@@ -90,6 +89,7 @@ final class R8Builder {
         this.androidPackages = androidPackages;
         this.commandContext = commandContext;
         this.minAndroidSdkVersion = minAndroidSdkVersion;
+        this.r8Configuration = r8Configuration;
         this.templateExecutor = templateExecutor;
         this.commandExecutor = commandExecutor;
     }
@@ -292,6 +292,13 @@ final class R8Builder {
 
     static List<String> selectEmbeddedRuleEntries(File jar, String r8Version)
             throws IOException, ExtenderException {
+        return selectEmbeddedRuleEntries(jar, r8Version, new R8Configuration());
+    }
+
+    static List<String> selectEmbeddedRuleEntries(
+            File jar,
+            String r8Version,
+            R8Configuration r8Configuration) throws IOException, ExtenderException {
         List<String> targetedRules = new ArrayList<>();
         List<String> legacyRules = new ArrayList<>();
         Set<String> candidateNames = new LinkedHashSet<>();
@@ -312,11 +319,11 @@ final class R8Builder {
                 if (!candidateNames.add(entryName)) {
                     throw new ExtenderException("Duplicate embedded R8 rule entry " + entryName + " in " + jar);
                 }
-                if (++candidateCount > R8RulePolicy.MAX_RULE_FILES) {
+                if (++candidateCount > r8Configuration.getMaxRuleFiles()) {
                     throw new ExtenderException(String.format(
                             "Too many embedded R8 rule files in %s (maximum %d)",
                             jar,
-                            R8RulePolicy.MAX_RULE_FILES));
+                            r8Configuration.getMaxRuleFiles()));
                 }
                 if (entryName.startsWith(JAR_LEGACY_RULE_PREFIX)) {
                     legacyRules.add(entryName);
@@ -369,6 +376,20 @@ final class R8Builder {
             List<File> androidPackages,
             String r8Version,
             File rulesRoot) throws ExtenderException {
+        return collectConsumerRules(
+                allJars,
+                androidPackages,
+                r8Version,
+                rulesRoot,
+                new R8Configuration());
+    }
+
+    static List<String> collectConsumerRules(
+            List<String> allJars,
+            List<File> androidPackages,
+            String r8Version,
+            File rulesRoot,
+            R8Configuration r8Configuration) throws ExtenderException {
         File emptyRuleBase = R8RulePolicy.createEmptyBaseDirectory(
                 rulesRoot.getAbsoluteFile().getParentFile());
         return collectConsumerRules(
@@ -376,7 +397,8 @@ final class R8Builder {
                 androidPackages,
                 r8Version,
                 rulesRoot,
-                new R8RulePolicy.Budget(),
+                r8Configuration,
+                new R8RulePolicy.Budget(r8Configuration),
                 emptyRuleBase);
     }
 
@@ -385,6 +407,7 @@ final class R8Builder {
             List<File> androidPackages,
             String r8Version,
             File rulesRoot,
+            R8Configuration r8Configuration,
             R8RulePolicy.Budget ruleBudget,
             File emptyRuleBase) throws ExtenderException {
         try {
@@ -406,7 +429,10 @@ final class R8Builder {
             }
 
             try (ZipFile zipFile = new ZipFile(jar)) {
-                List<String> selectedEntries = selectEmbeddedRuleEntries(jar, r8Version);
+                List<String> selectedEntries = selectEmbeddedRuleEntries(
+                        jar,
+                        r8Version,
+                        r8Configuration);
                 jarHasTargetedRules.put(jar.getCanonicalPath(), containsTargetedRules(selectedEntries));
                 if (selectedEntries.isEmpty()) {
                     continue;
@@ -541,28 +567,35 @@ final class R8Builder {
 
     private static final class BoundedClassFileInputStream extends FilterInputStream {
         private final ClassFileReadBudget budget;
+        private final int maxClassfileHeaderBytes;
+        private final long maxTotalClassfileHeaderBytes;
         private int classBytes;
 
-        BoundedClassFileInputStream(InputStream input, ClassFileReadBudget budget) {
+        BoundedClassFileInputStream(
+                InputStream input,
+                ClassFileReadBudget budget,
+                R8Configuration r8Configuration) {
             super(input);
             this.budget = budget;
+            this.maxClassfileHeaderBytes = r8Configuration.getMaxClassfileHeaderBytes();
+            this.maxTotalClassfileHeaderBytes = r8Configuration.getMaxTotalClassfileHeaderBytes();
         }
 
         private int allowedBytes(int requested) throws IOException {
             if (requested == 0) {
                 return 0;
             }
-            int classRemaining = MAX_CLASSFILE_HEADER_BYTES - classBytes;
+            int classRemaining = maxClassfileHeaderBytes - classBytes;
             if (classRemaining <= 0) {
                 throw new IOException(String.format(
                         "Class file header exceeds the %d-byte read limit",
-                        MAX_CLASSFILE_HEADER_BYTES));
+                        maxClassfileHeaderBytes));
             }
-            long totalRemaining = MAX_TOTAL_CLASSFILE_HEADER_BYTES - budget.totalBytes;
+            long totalRemaining = maxTotalClassfileHeaderBytes - budget.totalBytes;
             if (totalRemaining <= 0) {
                 throw new IOException(String.format(
                         "Class file headers exceed the %d-byte aggregate read limit",
-                        MAX_TOTAL_CLASSFILE_HEADER_BYTES));
+                        maxTotalClassfileHeaderBytes));
             }
             return (int) Math.min(requested, Math.min(classRemaining, totalRemaining));
         }
@@ -599,10 +632,12 @@ final class R8Builder {
     private static String readClassInternalName(
             ZipFile zipFile,
             ZipEntry entry,
-            ClassFileReadBudget budget) throws IOException {
+            ClassFileReadBudget budget,
+            R8Configuration r8Configuration) throws IOException {
         try (DataInputStream input = new DataInputStream(new BoundedClassFileInputStream(
                 zipFile.getInputStream(entry),
-                budget))) {
+                budget,
+                r8Configuration))) {
             if (input.readInt() != 0xCAFEBABE) {
                 throw new IOException("Invalid class file magic");
             }
@@ -728,6 +763,13 @@ final class R8Builder {
 
     static File writeProtectedJarKeepRules(List<String> jarPaths, File outputFile)
             throws IOException, ExtenderException {
+        return writeProtectedJarKeepRules(jarPaths, outputFile, new R8Configuration());
+    }
+
+    static File writeProtectedJarKeepRules(
+            List<String> jarPaths,
+            File outputFile,
+            R8Configuration r8Configuration) throws IOException, ExtenderException {
         Set<String> classNames = new TreeSet<>();
         int classEntryCount = 0;
         ClassFileReadBudget classFileReadBudget = new ClassFileReadBudget();
@@ -750,15 +792,19 @@ final class R8Builder {
                             || entryName.startsWith("META-INF/")) {
                         continue;
                     }
-                    if (++classEntryCount > MAX_GENERATED_EXTENSION_CLASSES) {
+                    if (++classEntryCount > r8Configuration.getMaxGeneratedExtensionClasses()) {
                         throw new ExtenderException(String.format(
                                 "Too many classes need generated R8 keep rules (maximum %d)",
-                                MAX_GENERATED_EXTENSION_CLASSES));
+                                r8Configuration.getMaxGeneratedExtensionClasses()));
                     }
 
                     String internalName;
                     try {
-                        internalName = readClassInternalName(zipFile, entry, classFileReadBudget);
+                        internalName = readClassInternalName(
+                                zipFile,
+                                entry,
+                                classFileReadBudget,
+                                r8Configuration);
                     } catch (IOException e) {
                         throw new ExtenderException(e, String.format(
                                 "Failed to read class file %s from %s: %s",
@@ -783,10 +829,10 @@ final class R8Builder {
                     if (classNames.add(className)) {
                         String rule = String.format("-keep class %s { *; }\n", className);
                         generatedBytes += rule.getBytes(StandardCharsets.UTF_8).length;
-                        if (generatedBytes > R8RulePolicy.MAX_RULE_FILE_BYTES) {
+                        if (generatedBytes > r8Configuration.getMaxRuleFileBytes()) {
                             throw new ExtenderException(String.format(
                                     "Generated R8 keep rules are too large (maximum %d bytes)",
-                                    R8RulePolicy.MAX_RULE_FILE_BYTES));
+                                    r8Configuration.getMaxRuleFileBytes()));
                         }
                     }
                 }
@@ -931,7 +977,7 @@ final class R8Builder {
         LOGGER.info("Building classes.dex using R8 {}", r8Version);
 
         Set<String> ruleFiles = new LinkedHashSet<>();
-        R8RulePolicy.Budget ruleBudget = new R8RulePolicy.Budget();
+        R8RulePolicy.Budget ruleBudget = new R8RulePolicy.Budget(r8Configuration);
         File emptyRuleBase = R8RulePolicy.createEmptyBaseDirectory(buildDir);
         File sanitizedRulesDir = new File(buildDir, "r8-sanitized-rules");
         File sanitizedAppRules = new File(sanitizedRulesDir, "app.keep");
@@ -977,6 +1023,7 @@ final class R8Builder {
                 androidPackages,
                 r8Version,
                 consumerRulesDir,
+                r8Configuration,
                 ruleBudget,
                 emptyRuleBase));
 
@@ -984,7 +1031,7 @@ final class R8Builder {
         if (!protectedJars.isEmpty()) {
             File generatedRules = new File(buildDir, "generated-extension-rules.keep");
             try {
-                writeProtectedJarKeepRules(protectedJars, generatedRules);
+                writeProtectedJarKeepRules(protectedJars, generatedRules, r8Configuration);
             } catch (IOException e) {
                 throw new ExtenderException(e, "Failed to generate R8 rules for unconfigured extension jars");
             }

--- a/server/src/main/java/com/defold/extender/R8Builder.java
+++ b/server/src/main/java/com/defold/extender/R8Builder.java
@@ -814,14 +814,13 @@ final class R8Builder {
                 "env.R8",
                 "env.LIBRARYJAR",
                 "classes_dex_dir",
-                "mainDexList",
                 "mapping")) {
             Object value = escaped.get(key);
             if (value instanceof String) {
                 escaped.put(key, escapeDoubleQuotedCommandValue((String) value));
             }
         }
-        for (String key : List.of("jars", "rules", "mainDexRules")) {
+        for (String key : List.of("jars", "rules")) {
             Object value = escaped.get(key);
             if (value instanceof List<?>) {
                 List<String> escapedValues = ((List<?>) value).stream()
@@ -901,9 +900,7 @@ final class R8Builder {
     BuildOutput build(
             List<String> allJars,
             Map<String, ExtensionContext> extensionJarMap,
-            File mainDexList,
-            File aaptGeneratedRules,
-            File aaptMainDexRules) throws ExtenderException {
+            File aaptGeneratedRules) throws ExtenderException {
         File appRules = new File(uploadDir, APP_RULES_PATH);
         if (!isRequested(uploadDir)) {
             LOGGER.info("No app.keep file present. Skipping R8 step.");
@@ -931,17 +928,6 @@ final class R8Builder {
             throw new ExtenderException(
                     "R8 shrinking was requested, but aapt2 did not generate aapt-generated.keep");
         }
-        if (minAndroidSdkVersion < 21) {
-            if (mainDexList == null || !mainDexList.isFile()) {
-                throw new ExtenderException(
-                        "R8 shrinking was requested below API 21, but the engine main-dex rules are missing");
-            }
-            if (aaptMainDexRules == null || !aaptMainDexRules.isFile()) {
-                throw new ExtenderException(
-                        "R8 shrinking was requested below API 21, but aapt2 did not generate aapt-main-dex-generated.keep");
-            }
-        }
-
         LOGGER.info("Building classes.dex using R8 {}", r8Version);
 
         Set<String> ruleFiles = new LinkedHashSet<>();
@@ -960,19 +946,6 @@ final class R8Builder {
                 R8RulePolicy.readAndValidate(aaptGeneratedRules, ruleBudget),
                 emptyRuleBase);
         ruleFiles.add(sanitizedAaptRules.getAbsolutePath());
-
-        List<String> mainDexRules = new ArrayList<>();
-        if (minAndroidSdkVersion < 21) {
-            File sanitizedAaptMainDexRules = new File(
-                    sanitizedRulesDir,
-                    "aapt-main-dex-generated.keep");
-            R8RulePolicy.writeSanitized(
-                    sanitizedAaptMainDexRules,
-                    R8RulePolicy.readAndValidate(aaptMainDexRules, ruleBudget),
-                    emptyRuleBase);
-            mainDexRules.add(mainDexList.getAbsolutePath());
-            mainDexRules.add(sanitizedAaptMainDexRules.getAbsolutePath());
-        }
 
         Set<String> seenUntrustedRules = new LinkedHashSet<>();
         int sanitizedExtensionRuleIndex = 0;
@@ -1028,8 +1001,6 @@ final class R8Builder {
         context.put("classes_dex_dir", r8OutputDir.getAbsolutePath());
         context.put("jars", programJars);
         context.put("rules", new ArrayList<>(ruleFiles));
-        context.put("mainDexRules", mainDexRules);
-        context.put("useMainDexRules", !mainDexRules.isEmpty());
         context.put("mapping", mappingFile.getAbsolutePath());
         context.put("minAndroidSdkVersion", minAndroidSdkVersion);
         R8RulePolicy.requireEmptyBaseDirectory(emptyRuleBase);

--- a/server/src/main/java/com/defold/extender/R8Builder.java
+++ b/server/src/main/java/com/defold/extender/R8Builder.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -51,10 +52,12 @@ final class R8Builder {
     static final class BuildOutput {
         final File[] dexFiles;
         final File mappingFile;
+        final File[] metaInformationFiles;
 
-        BuildOutput(File[] dexFiles, File mappingFile) {
+        BuildOutput(File[] dexFiles, File mappingFile, File[] metaInformationFiles) {
             this.dexFiles = dexFiles;
             this.mappingFile = mappingFile;
+            this.metaInformationFiles = metaInformationFiles;
         }
     }
 
@@ -831,6 +834,70 @@ final class R8Builder {
         return escaped;
     }
 
+    private File createR8OutputDirectory() throws ExtenderException {
+        File r8OutputDir = new File(buildDir, "r8-output");
+        try {
+            FileUtils.deleteDirectory(r8OutputDir);
+            Files.createDirectories(r8OutputDir.toPath());
+        } catch (IOException e) {
+            throw new ExtenderException(e, "Failed to create R8 output directory " + r8OutputDir);
+        }
+        return r8OutputDir;
+    }
+
+    private File moveR8OutputFile(File r8OutputDir, File source) throws ExtenderException, IOException {
+        String relativePath = r8OutputDir.toPath()
+                .relativize(source.toPath())
+                .toString()
+                .replace(File.separatorChar, '/');
+        File target = SandboxedPath.resolve(buildDir, relativePath);
+        Files.createDirectories(target.getParentFile().toPath());
+        Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        return target;
+    }
+
+    private File[] collectR8DexFiles(File r8OutputDir) throws ExtenderException {
+        File[] generatedDexFiles = ExtenderUtil.listFilesMatching(
+                r8OutputDir,
+                "^classes(|[0-9]+)\\.dex$");
+        Arrays.sort(generatedDexFiles, (left, right) -> left.getName().compareTo(right.getName()));
+
+        File[] dexFiles = new File[generatedDexFiles.length];
+        try {
+            for (int index = 0; index < generatedDexFiles.length; ++index) {
+                dexFiles[index] = moveR8OutputFile(r8OutputDir, generatedDexFiles[index]);
+            }
+        } catch (IOException e) {
+            throw new ExtenderException(e, "Failed to collect R8 dex output");
+        }
+        return dexFiles;
+    }
+
+    private File[] collectR8MetaInformationFiles(File r8OutputDir) throws ExtenderException {
+        File metaInfDir = new File(r8OutputDir, "META-INF");
+        if (!metaInfDir.isDirectory()) {
+            return new File[0];
+        }
+
+        List<File> generatedFiles = new ArrayList<>(FileUtils.listFiles(metaInfDir, null, true));
+        generatedFiles.sort((left, right) -> left.getAbsolutePath().compareTo(right.getAbsolutePath()));
+        List<File> metaInformationFiles = new ArrayList<>();
+        try {
+            for (File generatedFile : generatedFiles) {
+                String entryName = r8OutputDir.toPath()
+                        .relativize(generatedFile.toPath())
+                        .toString()
+                        .replace(File.separatorChar, '/');
+                if (ExtenderUtil.isMetaInfEntryValuable(new ZipEntry(entryName))) {
+                    metaInformationFiles.add(moveR8OutputFile(r8OutputDir, generatedFile));
+                }
+            }
+        } catch (IOException e) {
+            throw new ExtenderException(e, "Failed to collect R8 META-INF output");
+        }
+        return metaInformationFiles.toArray(File[]::new);
+    }
+
     BuildOutput build(
             List<String> allJars,
             Map<String, ExtensionContext> extensionJarMap,
@@ -955,9 +1022,10 @@ final class R8Builder {
         List<String> programJars = prepareProgramJars(
                 allJars,
                 new File(buildDir, "r8-program-jars"));
+        File r8OutputDir = createR8OutputDirectory();
         File mappingFile = new File(buildDir, "mapping.txt");
 
-        context.put("classes_dex_dir", buildDir.getAbsolutePath());
+        context.put("classes_dex_dir", r8OutputDir.getAbsolutePath());
         context.put("jars", programJars);
         context.put("rules", new ArrayList<>(ruleFiles));
         context.put("mainDexRules", mainDexRules);
@@ -975,11 +1043,11 @@ final class R8Builder {
         }
         commandExecutor.execute(r8Command, context);
 
-        File[] dexFiles = ExtenderUtil.listFilesMatching(buildDir, "^classes(|[0-9]+)\\.dex$");
-        Arrays.sort(dexFiles, (left, right) -> left.getName().compareTo(right.getName()));
+        File[] dexFiles = collectR8DexFiles(r8OutputDir);
         if (dexFiles.length == 0 || !mappingFile.isFile()) {
             throw new ExtenderException("R8 completed without producing classes.dex and mapping.txt");
         }
-        return new BuildOutput(dexFiles, mappingFile);
+        File[] metaInformationFiles = collectR8MetaInformationFiles(r8OutputDir);
+        return new BuildOutput(dexFiles, mappingFile, metaInformationFiles);
     }
 }

--- a/server/src/main/java/com/defold/extender/R8Configuration.java
+++ b/server/src/main/java/com/defold/extender/R8Configuration.java
@@ -1,0 +1,84 @@
+package com.defold.extender;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/** Server-side resource limits for R8 rule processing and generated keep rules. */
+@Component
+@ConfigurationProperties(prefix = "extender.r8")
+public class R8Configuration {
+    private int maxGeneratedExtensionClasses = 32 * 1024;
+    private int maxClassfileHeaderBytes = 4 * 1024 * 1024;
+    private long maxTotalClassfileHeaderBytes = 64L * 1024L * 1024L;
+    private int maxRuleFiles = 1024;
+    private long maxRuleFileBytes = 1024L * 1024L;
+    private long maxTotalRuleBytes = 16L * 1024L * 1024L;
+
+    public int getMaxGeneratedExtensionClasses() {
+        return maxGeneratedExtensionClasses;
+    }
+
+    public void setMaxGeneratedExtensionClasses(int maxGeneratedExtensionClasses) {
+        this.maxGeneratedExtensionClasses = requirePositive(
+                maxGeneratedExtensionClasses,
+                "max-generated-extension-classes");
+    }
+
+    public int getMaxClassfileHeaderBytes() {
+        return maxClassfileHeaderBytes;
+    }
+
+    public void setMaxClassfileHeaderBytes(int maxClassfileHeaderBytes) {
+        this.maxClassfileHeaderBytes = requirePositive(
+                maxClassfileHeaderBytes,
+                "max-classfile-header-bytes");
+    }
+
+    public long getMaxTotalClassfileHeaderBytes() {
+        return maxTotalClassfileHeaderBytes;
+    }
+
+    public void setMaxTotalClassfileHeaderBytes(long maxTotalClassfileHeaderBytes) {
+        this.maxTotalClassfileHeaderBytes = requirePositive(
+                maxTotalClassfileHeaderBytes,
+                "max-total-classfile-header-bytes");
+    }
+
+    public int getMaxRuleFiles() {
+        return maxRuleFiles;
+    }
+
+    public void setMaxRuleFiles(int maxRuleFiles) {
+        this.maxRuleFiles = requirePositive(maxRuleFiles, "max-rule-files");
+    }
+
+    public long getMaxRuleFileBytes() {
+        return maxRuleFileBytes;
+    }
+
+    public void setMaxRuleFileBytes(long maxRuleFileBytes) {
+        this.maxRuleFileBytes = requirePositive(maxRuleFileBytes, "max-rule-file-bytes");
+    }
+
+    public long getMaxTotalRuleBytes() {
+        return maxTotalRuleBytes;
+    }
+
+    public void setMaxTotalRuleBytes(long maxTotalRuleBytes) {
+        this.maxTotalRuleBytes = requirePositive(maxTotalRuleBytes, "max-total-rule-bytes");
+    }
+
+    private static int requirePositive(int value, String property) {
+        if (value <= 0) {
+            throw new IllegalArgumentException("extender.r8." + property + " must be positive");
+        }
+        return value;
+    }
+
+    private static long requirePositive(long value, String property) {
+        if (value <= 0) {
+            throw new IllegalArgumentException("extender.r8." + property + " must be positive");
+        }
+        return value;
+    }
+}

--- a/server/src/main/java/com/defold/extender/R8RulePolicy.java
+++ b/server/src/main/java/com/defold/extender/R8RulePolicy.java
@@ -12,16 +12,13 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 /** Applies the server-side policy for untrusted R8/ProGuard-compatible rule files. */
 final class R8RulePolicy {
-    static final int MAX_RULE_FILES = 1024;
-    static final long MAX_RULE_FILE_BYTES = 1024L * 1024L;
-    static final long MAX_TOTAL_RULE_BYTES = 16L * 1024L * 1024L;
-
     // Match exact lowercase prefixes anywhere in the raw text. R8 only accepts these lowercase
     // spellings. Deliberate false positives in comments, strings, or malformed tokens keep this
     // check independent of R8's evolving grammar.
@@ -41,45 +38,59 @@ final class R8RulePolicy {
             "laststageoutput");
 
     static final class Budget {
+        private final R8Configuration configuration;
         private int fileCount;
         private long totalBytes;
 
+        Budget() {
+            this(new R8Configuration());
+        }
+
+        Budget(R8Configuration configuration) {
+            this.configuration = Objects.requireNonNull(configuration);
+        }
+
         private void beginFile(String source, long declaredSize) throws ExtenderException {
             ++fileCount;
-            if (fileCount > MAX_RULE_FILES) {
+            if (fileCount > configuration.getMaxRuleFiles()) {
                 throw new ExtenderException(String.format(
                         "Too many R8 rule files (maximum %d), while reading %s",
-                        MAX_RULE_FILES,
+                        configuration.getMaxRuleFiles(),
                         source));
             }
-            if (declaredSize > MAX_RULE_FILE_BYTES) {
+            if (declaredSize > configuration.getMaxRuleFileBytes()) {
                 throw new ExtenderException(String.format(
                         "R8 rule file is too large (maximum %d bytes): %s",
-                        MAX_RULE_FILE_BYTES,
+                        configuration.getMaxRuleFileBytes(),
                         source));
             }
-            if (declaredSize >= 0 && totalBytes + declaredSize > MAX_TOTAL_RULE_BYTES) {
+            if (declaredSize >= 0
+                    && totalBytes + declaredSize > configuration.getMaxTotalRuleBytes()) {
                 throw new ExtenderException(String.format(
                         "R8 rule files are too large in total (maximum %d bytes), while reading %s",
-                        MAX_TOTAL_RULE_BYTES,
+                        configuration.getMaxTotalRuleBytes(),
                         source));
             }
         }
 
         private void addBytes(String source, long fileBytes, int bytesRead) throws ExtenderException {
-            if (fileBytes > MAX_RULE_FILE_BYTES) {
+            if (fileBytes > configuration.getMaxRuleFileBytes()) {
                 throw new ExtenderException(String.format(
                         "R8 rule file is too large (maximum %d bytes): %s",
-                        MAX_RULE_FILE_BYTES,
+                        configuration.getMaxRuleFileBytes(),
                         source));
             }
             totalBytes += bytesRead;
-            if (totalBytes > MAX_TOTAL_RULE_BYTES) {
+            if (totalBytes > configuration.getMaxTotalRuleBytes()) {
                 throw new ExtenderException(String.format(
                         "R8 rule files are too large in total (maximum %d bytes), while reading %s",
-                        MAX_TOTAL_RULE_BYTES,
+                        configuration.getMaxTotalRuleBytes(),
                         source));
             }
+        }
+
+        private long getMaxRuleFileBytes() {
+            return configuration.getMaxRuleFileBytes();
         }
     }
 
@@ -173,7 +184,9 @@ final class R8RulePolicy {
             Budget budget) throws IOException, ExtenderException {
         budget.beginFile(source, declaredSize);
         ByteArrayOutputStream output = new ByteArrayOutputStream(
-                (int) Math.min(Math.max(declaredSize, 0), MAX_RULE_FILE_BYTES));
+                (int) Math.min(
+                        Math.min(Math.max(declaredSize, 0), budget.getMaxRuleFileBytes()),
+                        Integer.MAX_VALUE));
         byte[] buffer = new byte[8192];
         long fileBytes = 0;
         int read;

--- a/server/src/main/java/com/defold/extender/R8RulePolicy.java
+++ b/server/src/main/java/com/defold/extender/R8RulePolicy.java
@@ -1,0 +1,270 @@
+package com.defold.extender;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+/** Applies the server-side policy for untrusted R8/ProGuard-compatible rule files. */
+final class R8RulePolicy {
+    static final int MAX_RULE_FILES = 1024;
+    static final long MAX_RULE_FILE_BYTES = 1024L * 1024L;
+    static final long MAX_TOTAL_RULE_BYTES = 16L * 1024L * 1024L;
+
+    // Match exact lowercase prefixes anywhere in the raw text. R8 only accepts these lowercase
+    // spellings. Deliberate false positives in comments, strings, or malformed tokens keep this
+    // check independent of R8's evolving grammar.
+    private static final List<String> BLOCKED_OPTION_PREFIXES = List.of(
+            "include",
+            "basedirectory",
+            "injars",
+            "outjars",
+            "libraryjars",
+            "applymapping",
+            "obfuscationdictionary",
+            "classobfuscationdictionary",
+            "packageobfuscationdictionary",
+            "print",
+            "dump",
+            "protomapping",
+            "laststageoutput");
+
+    static final class Budget {
+        private int fileCount;
+        private long totalBytes;
+
+        private void beginFile(String source, long declaredSize) throws ExtenderException {
+            ++fileCount;
+            if (fileCount > MAX_RULE_FILES) {
+                throw new ExtenderException(String.format(
+                        "Too many R8 rule files (maximum %d), while reading %s",
+                        MAX_RULE_FILES,
+                        source));
+            }
+            if (declaredSize > MAX_RULE_FILE_BYTES) {
+                throw new ExtenderException(String.format(
+                        "R8 rule file is too large (maximum %d bytes): %s",
+                        MAX_RULE_FILE_BYTES,
+                        source));
+            }
+            if (declaredSize >= 0 && totalBytes + declaredSize > MAX_TOTAL_RULE_BYTES) {
+                throw new ExtenderException(String.format(
+                        "R8 rule files are too large in total (maximum %d bytes), while reading %s",
+                        MAX_TOTAL_RULE_BYTES,
+                        source));
+            }
+        }
+
+        private void addBytes(String source, long fileBytes, int bytesRead) throws ExtenderException {
+            if (fileBytes > MAX_RULE_FILE_BYTES) {
+                throw new ExtenderException(String.format(
+                        "R8 rule file is too large (maximum %d bytes): %s",
+                        MAX_RULE_FILE_BYTES,
+                        source));
+            }
+            totalBytes += bytesRead;
+            if (totalBytes > MAX_TOTAL_RULE_BYTES) {
+                throw new ExtenderException(String.format(
+                        "R8 rule files are too large in total (maximum %d bytes), while reading %s",
+                        MAX_TOTAL_RULE_BYTES,
+                        source));
+            }
+        }
+    }
+
+    private R8RulePolicy() {}
+
+    static File createEmptyBaseDirectory(File parent) throws ExtenderException {
+        try {
+            Files.createDirectories(parent.toPath());
+            return Files.createTempDirectory(parent.toPath(), "r8-rule-base-").toFile();
+        } catch (IOException e) {
+            throw new ExtenderException(e, "Failed to create the R8 rule sandbox directory");
+        }
+    }
+
+    static void requireEmptyBaseDirectory(File emptyBase) throws ExtenderException {
+        Path basePath = emptyBase.toPath();
+        if (!Files.isDirectory(basePath)) {
+            throw new ExtenderException("R8 rule sandbox is not a directory: " + emptyBase);
+        }
+        try (Stream<Path> entries = Files.list(basePath)) {
+            if (entries.findAny().isPresent()) {
+                throw new ExtenderException("R8 rule sandbox is not empty: " + emptyBase);
+            }
+        } catch (IOException e) {
+            throw new ExtenderException(e, "Failed to inspect the R8 rule sandbox " + emptyBase);
+        }
+    }
+
+    static byte[] readAndValidate(ZipFile zipFile, ZipEntry entry, Budget budget)
+            throws ExtenderException {
+        String source = zipFile.getName() + "!/" + entry.getName();
+        try (InputStream input = zipFile.getInputStream(entry)) {
+            return normalizeAndValidate(
+                    readBounded(input, entry.getSize(), source, budget),
+                    source);
+        } catch (IOException e) {
+            throw new ExtenderException(e, "Failed to read R8 consumer rules from " + source);
+        }
+    }
+
+    static byte[] readAndValidate(File ruleFile, Budget budget) throws ExtenderException {
+        String source = ruleFile.getAbsolutePath();
+        try (InputStream input = new FileInputStream(ruleFile)) {
+            return normalizeAndValidate(
+                    readBounded(input, ruleFile.length(), source, budget),
+                    source);
+        } catch (IOException e) {
+            throw new ExtenderException(e, "Failed to read R8 rule file " + source);
+        }
+    }
+
+    static void account(File trustedRuleFile, Budget budget) throws ExtenderException {
+        String source = trustedRuleFile.getAbsolutePath();
+        try (InputStream input = new FileInputStream(trustedRuleFile)) {
+            readBounded(input, trustedRuleFile.length(), source, budget);
+        } catch (IOException e) {
+            throw new ExtenderException(e, "Failed to read R8 rule file " + source);
+        }
+    }
+
+    static void writeSanitized(File target, byte[] contents, File emptyBase)
+            throws ExtenderException {
+        requireEmptyBaseDirectory(emptyBase);
+        try {
+            String base = emptyBase.getCanonicalPath();
+            char quote;
+            if (!base.contains("\"") && base.indexOf('\n') < 0 && base.indexOf('\r') < 0) {
+                quote = '"';
+            } else if (!base.contains("'") && base.indexOf('\n') < 0 && base.indexOf('\r') < 0) {
+                quote = '\'';
+            } else {
+                throw new ExtenderException("R8 rule sandbox path cannot be quoted safely: " + emptyBase);
+            }
+
+            byte[] prefix = String.format("-basedirectory %c%s%c\n", quote, base, quote)
+                    .getBytes(StandardCharsets.UTF_8);
+            ByteArrayOutputStream output = new ByteArrayOutputStream(prefix.length + contents.length);
+            output.write(prefix);
+            output.write(contents);
+            Files.createDirectories(target.getParentFile().toPath());
+            Files.write(target.toPath(), output.toByteArray());
+        } catch (IOException e) {
+            throw new ExtenderException(e, "Failed to write sanitized R8 rules to " + target);
+        }
+    }
+
+    private static byte[] readBounded(
+            InputStream input,
+            long declaredSize,
+            String source,
+            Budget budget) throws IOException, ExtenderException {
+        budget.beginFile(source, declaredSize);
+        ByteArrayOutputStream output = new ByteArrayOutputStream(
+                (int) Math.min(Math.max(declaredSize, 0), MAX_RULE_FILE_BYTES));
+        byte[] buffer = new byte[8192];
+        long fileBytes = 0;
+        int read;
+        while ((read = input.read(buffer)) != -1) {
+            fileBytes += read;
+            budget.addBytes(source, fileBytes, read);
+            output.write(buffer, 0, read);
+        }
+        return output.toByteArray();
+    }
+
+    private static byte[] normalizeAndValidate(byte[] contents, String source)
+            throws ExtenderException {
+        final String decoded;
+        try {
+            decoded = StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(contents))
+                    .toString();
+        } catch (CharacterCodingException e) {
+            throw new ExtenderException(e, "R8 rule file is not valid UTF-8: " + source);
+        }
+        String rules = decoded.startsWith("\uFEFF") ? decoded.substring(1) : decoded;
+        validateRules(rules, source);
+        return rules.getBytes(StandardCharsets.UTF_8);
+    }
+
+    static void validateRules(String rules, String source) throws ExtenderException {
+        int line = 1;
+        for (int index = 0; index < rules.length(); ++index) {
+            char current = rules.charAt(index);
+            if (current == '\n') {
+                ++line;
+                continue;
+            }
+            if (current == '-') {
+                for (String blockedPrefix : BLOCKED_OPTION_PREFIXES) {
+                    if (rules.startsWith(blockedPrefix, index + 1)) {
+                        throw blockedDirective(source, line, "-" + blockedPrefix);
+                    }
+                }
+            } else if (current == '@' && hasPathLikeOperand(rules, index + 1)) {
+                throw blockedDirective(source, line, "path-like @file include");
+            }
+        }
+    }
+
+    private static boolean hasPathLikeOperand(String rules, int start) {
+        int index = start;
+        while (index < rules.length()) {
+            while (index < rules.length() && Character.isWhitespace(rules.charAt(index))) {
+                ++index;
+            }
+            if (index >= rules.length() || rules.charAt(index) != '#') {
+                break;
+            }
+            while (index < rules.length()
+                    && rules.charAt(index) != '\n'
+                    && rules.charAt(index) != '\r') {
+                ++index;
+            }
+        }
+        if (index >= rules.length()) {
+            return false;
+        }
+
+        char first = rules.charAt(index);
+        if (first == '/' || first == '\\' || first == '.' || first == '~'
+                || first == '\'' || first == '"' || first == '<') {
+            return true;
+        }
+
+        for (; index < rules.length() && !Character.isWhitespace(rules.charAt(index)); ++index) {
+            char current = rules.charAt(index);
+            if (current == '/' || current == '\\' || current == ':'
+                    || current == '<' || current == '>') {
+                return true;
+            }
+            if (current == '.' && index + 1 < rules.length() && rules.charAt(index + 1) == '.') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static ExtenderException blockedDirective(String source, int line, String directive) {
+        return new ExtenderException(String.format(
+                "R8 rule file %s:%d uses forbidden filesystem directive %s",
+                source,
+                line,
+                directive));
+    }
+}

--- a/server/src/main/java/com/defold/extender/TemplateExecutor.java
+++ b/server/src/main/java/com/defold/extender/TemplateExecutor.java
@@ -13,14 +13,22 @@ import java.util.Map;
 public class TemplateExecutor {
     private static final Logger LOGGER = LoggerFactory.getLogger(TemplateExecutor.class);
 
+    String executeOnceWithoutLogging(String template, Map<String, Object> context) {
+        return Mustache.compiler().compile(template).execute(context);
+    }
+
+    String executeWithoutLogging(String template, Map<String, Object> context) {
+        String result = executeOnceWithoutLogging(template, context);
+        while (!result.equals(template)) {
+            template = result;
+            result = executeOnceWithoutLogging(template, context);
+        }
+        return result;
+    }
+
     public String execute(String template, Map<String, Object> context) {
         try {
-        	String result = Mustache.compiler().compile(template).execute(context);
-            while (!result.equals(template)) {
-                template = result;
-                result = Mustache.compiler().compile(template).execute(context);
-            }
-            return result;
+            return executeWithoutLogging(template, context);
         } catch (Exception e) {
             LOGGER.error(Markers.COMPILATION_ERROR, String.format("Failed to substitute string '%s'", (String)template));
             ExtenderUtil.debugPrint(context, 0);

--- a/server/src/main/java/com/defold/extender/services/GradleArtifact.java
+++ b/server/src/main/java/com/defold/extender/services/GradleArtifact.java
@@ -1,0 +1,49 @@
+package com.defold.extender.services;
+
+import java.io.File;
+
+public final class GradleArtifact {
+    public enum Kind {
+        EXPLODED_AAR,
+        JAR
+    }
+
+    private final File file;
+    private final String component;
+    private final String originalFileName;
+    private final Kind kind;
+    private final String resourcePackageName;
+
+    GradleArtifact(
+            File file,
+            String component,
+            String originalFileName,
+            Kind kind,
+            String resourcePackageName) {
+        this.file = file;
+        this.component = component;
+        this.originalFileName = originalFileName;
+        this.kind = kind;
+        this.resourcePackageName = resourcePackageName;
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    public String getComponent() {
+        return component;
+    }
+
+    public String getOriginalFileName() {
+        return originalFileName;
+    }
+
+    public Kind getKind() {
+        return kind;
+    }
+
+    public String getResourcePackageName() {
+        return resourcePackageName;
+    }
+}

--- a/server/src/main/java/com/defold/extender/services/GradleService.java
+++ b/server/src/main/java/com/defold/extender/services/GradleService.java
@@ -24,7 +24,7 @@ public class GradleService {
         Gauge.builder("extender.job.gradle.cacheSize", this, GradleService::getCacheSize).baseUnit(BaseUnits.BYTES).register(registry);
     }
 
-    public List<File> resolveDependencies(ExtenderBuildState buildState, Map<String, Object> env, List<File> outputFiles)
+    public List<GradleArtifact> resolveDependencies(ExtenderBuildState buildState, Map<String, Object> env, List<File> outputFiles)
         throws IOException, ExtenderException {
         return gradleService.resolveDependencies(buildState, env, outputFiles);
     }

--- a/server/src/main/java/com/defold/extender/services/GradleServiceInterface.java
+++ b/server/src/main/java/com/defold/extender/services/GradleServiceInterface.java
@@ -10,7 +10,7 @@ import com.defold.extender.ExtenderException;
 
 public interface GradleServiceInterface {
     // Resolve dependencies, download them, extract to
-    public List<File> resolveDependencies(ExtenderBuildState buildState, Map<String, Object> env, List<File> outputFiles) throws IOException, ExtenderException;
+    public List<GradleArtifact> resolveDependencies(ExtenderBuildState buildState, Map<String, Object> env, List<File> outputFiles) throws IOException, ExtenderException;
     
     public long getCacheSize() throws IOException;
 }

--- a/server/src/main/java/com/defold/extender/services/MockGradleService.java
+++ b/server/src/main/java/com/defold/extender/services/MockGradleService.java
@@ -15,7 +15,7 @@ import com.defold.extender.ExtenderException;
 @ConditionalOnProperty(name = "extender.gradle.enabled", havingValue = "false", matchIfMissing = true)
 public class MockGradleService implements GradleServiceInterface {
     @Override
-    public List<File> resolveDependencies(ExtenderBuildState buildState, Map<String, Object> env, List<File> outputFiles)
+    public List<GradleArtifact> resolveDependencies(ExtenderBuildState buildState, Map<String, Object> env, List<File> outputFiles)
             throws IOException, ExtenderException {
         return List.of();
     }

--- a/server/src/main/java/com/defold/extender/services/RealGradleService.java
+++ b/server/src/main/java/com/defold/extender/services/RealGradleService.java
@@ -6,7 +6,6 @@ import com.defold.extender.ExtenderUtil;
 import com.defold.extender.TemplateExecutor;
 import com.defold.extender.Timer;
 import com.defold.extender.ZipUtils;
-import com.defold.extender.log.Markers;
 import com.defold.extender.metrics.MetricsWriter;
 import com.defold.extender.process.ProcessUtils;
 
@@ -26,10 +25,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.FileInputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.HashMap;
@@ -41,6 +43,7 @@ import java.util.regex.Pattern;
 @ConditionalOnProperty(name = "extender.gradle.enabled", havingValue = "true")
 public class RealGradleService implements GradleServiceInterface {
     private static final Logger LOGGER = LoggerFactory.getLogger(RealGradleService.class);
+    private static final String PROCESSED_DEPENDENCY_CACHE_VERSION = "processed-v1";
 
     private static final List<String> GRADLE_BLOCKLIST = List.of(
         "buildscript", "apply plugin:", "apply from:",
@@ -117,7 +120,7 @@ public class RealGradleService implements GradleServiceInterface {
         createLocalPropertiesFile(localPropertiesFile, jobEnvContext);
 
         // download, parse and unpack dependencies
-        List<File> unpackedDependencies = downloadDependencies(workDir);
+        List<File> unpackedDependencies = downloadDependencies(workDir, buildState.isUsedJetifier());
         // add gradle lockfile to outputs
         // configured in template.build.gradle
         outputFiles.add(new File(buildDir, "gradle.lockfile"));
@@ -210,24 +213,6 @@ public class RealGradleService implements GradleServiceInterface {
         Files.write(mainGradleFile.toPath(), contents.getBytes());
     }
 
-    // Helper function to move files/directories
-    private static void Move(Path source, Path target) {
-        try {
-            Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
-        } catch (IOException e) {
-            // If the target path suddenly exists, and the source path still exists,
-            // then we failed with the atomic move, and we assume another job succeeded with the download
-            if (Files.exists(source) && Files.exists(target)) {
-                LOGGER.info("Gradle package {} was downloaded by another job in the meantime", source.toString());
-                try {
-                    FileUtils.deleteDirectory(source.toFile());
-                } catch (IOException e2) {
-                    LOGGER.error(Markers.SERVER_ERROR, "Failed to delete temp directory {}: {}", source.toString(), e2.getMessage());
-                }
-            }
-        }
-    }
-
     private Map<String, String> parseDependencies(String log) {
         // The output comes from template.build.gradle
         Pattern p = Pattern.compile("PATH:\\s*([\\w-.\\/]*)\\sEXTENSION:\\s*([\\w-.\\/]*)\\sTYPE:\\s*([\\w-.\\/]*)\\sMODULE_GROUP:\\s*([\\w-.\\/]*)\\sMODULE_NAME:\\s*([\\w-.\\/]*)\\sMODULE_VERSION:\\s*([\\w-.\\/]*)");
@@ -251,36 +236,144 @@ public class RealGradleService implements GradleServiceInterface {
         return dependencies;
     }
 
-    private File resolveDependencyAAR(File dependency, String name, File jobDir) throws IOException {
-        File unpackedTarget = new File(baseDirectory, name);
+    static String getDependencyCacheNamespace(String gradlePluginVersion, boolean useJetifier) {
+        String safePluginVersion = gradlePluginVersion == null
+                ? "unknown"
+                : gradlePluginVersion.replaceAll("[^A-Za-z0-9_-]", "_");
+        return String.format(
+                "%s-agp-%s-%s",
+                PROCESSED_DEPENDENCY_CACHE_VERSION,
+                safePluginVersion,
+                useJetifier ? "jetified" : "plain");
+    }
+
+    private File getDependencyCacheDirectory(boolean useJetifier) throws IOException {
+        File directory = new File(
+                baseDirectory,
+                getDependencyCacheNamespace(GRADLE_PLUGIN_VERSION, useJetifier));
+        Files.createDirectories(directory.toPath());
+        return directory;
+    }
+
+    static String getDependencyCacheName(File dependency, String extension) throws IOException {
+        String contentHash;
+        try (InputStream input = new FileInputStream(dependency)) {
+            contentHash = ExtenderUtil.calculateSHA256(input);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IOException("SHA-256 is not available", e);
+        }
+        return contentHash + extension;
+    }
+
+    private static void deleteTemporaryPath(Path temporary) throws IOException {
+        if (Files.isDirectory(temporary)) {
+            FileUtils.deleteDirectory(temporary.toFile());
+        } else {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    static void publishCacheEntry(Path temporary, Path target) throws IOException {
+        publishCacheEntry(temporary, target, () -> {});
+    }
+
+    static void publishCacheEntry(
+            Path temporary,
+            Path target,
+            Runnable beforeMove) throws IOException {
+        IOException failure = null;
+        if (!Files.exists(target)) {
+            try {
+                beforeMove.run();
+                try {
+                    Files.move(temporary, target, StandardCopyOption.ATOMIC_MOVE);
+                } catch (AtomicMoveNotSupportedException e) {
+                    Files.move(temporary, target);
+                }
+            } catch (FileAlreadyExistsException e) {
+                if (!Files.exists(target)) {
+                    failure = e;
+                }
+            } catch (IOException e) {
+                // A concurrent writer of the same content-addressed entry may win
+                // with a platform-specific exception (for example, Linux reports
+                // Directory not empty for an atomic directory move).
+                if (!Files.exists(target)) {
+                    failure = e;
+                }
+            }
+        }
+
+        if (Files.exists(temporary)) {
+            try {
+                deleteTemporaryPath(temporary);
+            } catch (IOException e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
+        }
+        if (failure != null) {
+            throw failure;
+        }
+        if (!Files.exists(target)) {
+            throw new IOException("Failed to publish Gradle dependency cache entry: " + target);
+        }
+    }
+
+    private File resolveDependencyAAR(
+            File dependency,
+            File cacheDirectory) throws IOException {
+        File unpackedTarget = new File(
+                cacheDirectory,
+                getDependencyCacheName(dependency, ".aar"));
         if (unpackedTarget.exists()) {
             return unpackedTarget;
         }
 
-        // use job folder as tmp location
-        File unpackedTmp = new File(jobDir, dependency.getName() + ".tmp");
-        try (InputStream fis = new FileInputStream(dependency)) {
-            ZipUtils.unzip(fis, unpackedTmp.toPath());
+        Path unpackedTmp = Files.createTempDirectory(cacheDirectory.toPath(), ".aar-");
+        try {
+            try (InputStream fis = new FileInputStream(dependency)) {
+                ZipUtils.unzip(fis, unpackedTmp);
+            }
+            publishCacheEntry(unpackedTmp, unpackedTarget.toPath());
+        } finally {
+            if (Files.exists(unpackedTmp)) {
+                deleteTemporaryPath(unpackedTmp);
+            }
         }
-        Move(unpackedTmp.toPath(), unpackedTarget.toPath());
         return unpackedTarget;
     }
 
-    private File resolveDependencyJAR(File dependency, String name, File jobDir) throws IOException {
-        File targetFile = new File(baseDirectory, name);
+    private File resolveDependencyJAR(
+            File dependency,
+            File cacheDirectory) throws IOException {
+        File targetFile = new File(
+                cacheDirectory,
+                getDependencyCacheName(dependency, ".jar"));
         if (targetFile.exists()) {
             return targetFile;
         }
 
-        // use job folder as tmp location
-        File tmpFile = new File(jobDir, dependency.getName() + ".tmp");
-        FileUtils.copyFile(dependency, tmpFile);
-        Move(tmpFile.toPath(), targetFile.toPath());
+        Path tmpFile = Files.createTempFile(cacheDirectory.toPath(), ".jar-", ".tmp");
+        try {
+            Files.copy(dependency.toPath(), tmpFile, StandardCopyOption.REPLACE_EXISTING);
+            publishCacheEntry(tmpFile, targetFile.toPath());
+        } finally {
+            if (Files.exists(tmpFile)) {
+                deleteTemporaryPath(tmpFile);
+            }
+        }
         return targetFile;
     }
 
-    private List<File> unpackDependencies(Map<String, String> dependencies, File jobDir) throws IOException {
+    private List<File> unpackDependencies(
+            Map<String, String> dependencies,
+            boolean useJetifier) throws IOException {
         List<File> resolvedDependencies = new ArrayList<>();
+        File cacheDirectory = getDependencyCacheDirectory(useJetifier);
         Timer timer = new Timer();
         timer.start();
         for (String newName : dependencies.keySet()) {
@@ -291,9 +384,9 @@ public class RealGradleService implements GradleServiceInterface {
                 throw new IOException("File does not exist: %s" + dependency);
             }
             if (dependency.endsWith(".aar")) {
-                resolvedDependencies.add(resolveDependencyAAR(file, newName, jobDir));
+                resolvedDependencies.add(resolveDependencyAAR(file, cacheDirectory));
             } else if (dependency.endsWith(".jar")) {
-                resolvedDependencies.add(resolveDependencyJAR(file, newName, jobDir));
+                resolvedDependencies.add(resolveDependencyJAR(file, cacheDirectory));
             } else {
                 resolvedDependencies.add(file);
             }
@@ -303,7 +396,7 @@ public class RealGradleService implements GradleServiceInterface {
         return resolvedDependencies;
     }
 
-    private List<File> downloadDependencies(File cwd) throws IOException, ExtenderException {
+    private List<File> downloadDependencies(File cwd, boolean useJetifier) throws IOException, ExtenderException {
         long methodStart = System.currentTimeMillis();
         LOGGER.info("Resolving dependencies");
 
@@ -322,7 +415,7 @@ public class RealGradleService implements GradleServiceInterface {
 
         Map<String, String> dependencies = parseDependencies(log);
 
-        List<File> unpackedDependencies = unpackDependencies(dependencies, cwd);
+        List<File> unpackedDependencies = unpackDependencies(dependencies, useJetifier);
 
         MetricsWriter.metricsTimer(meterRegistry, "extender.service.gradle.get", System.currentTimeMillis() - methodStart);
         return unpackedDependencies;

--- a/server/src/main/java/com/defold/extender/services/RealGradleService.java
+++ b/server/src/main/java/com/defold/extender/services/RealGradleService.java
@@ -4,12 +4,13 @@ import com.defold.extender.ExtenderBuildState;
 import com.defold.extender.ExtenderException;
 import com.defold.extender.ExtenderUtil;
 import com.defold.extender.TemplateExecutor;
-import com.defold.extender.Timer;
-import com.defold.extender.ZipUtils;
 import com.defold.extender.metrics.MetricsWriter;
 import com.defold.extender.process.ProcessUtils;
 
-import org.apache.commons.io.FileUtils;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,28 +23,24 @@ import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.FileInputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.AtomicMoveNotSupportedException;
-import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 @Service
 @ConditionalOnProperty(name = "extender.gradle.enabled", havingValue = "true")
 public class RealGradleService implements GradleServiceInterface {
     private static final Logger LOGGER = LoggerFactory.getLogger(RealGradleService.class);
-    private static final String PROCESSED_DEPENDENCY_CACHE_VERSION = "processed-v1";
 
     private static final List<String> GRADLE_BLOCKLIST = List.of(
         "buildscript", "apply plugin:", "apply from:",
@@ -57,7 +54,6 @@ public class RealGradleService implements GradleServiceInterface {
 
     private final String gradleHome;
 
-    private final File baseDirectory;
     private final MeterRegistry meterRegistry;
     private final String buildGradleTemplateContents;
     private final String gradlePropertiesTemplateContents;
@@ -71,18 +67,11 @@ public class RealGradleService implements GradleServiceInterface {
             this.gradleHome = GRADLE_USER_HOME;
         } else {
             File f = new File(".gradle");
-            if (!f.exists()) {
-                f.mkdirs();
-            }
             this.gradleHome = f.getAbsolutePath();
         }
+        Files.createDirectories(Paths.get(this.gradleHome));
 
         this.meterRegistry = meterRegistry;
-
-        this.baseDirectory = new File(this.gradleHome, "unpacked");
-        if (!this.baseDirectory.exists()) {
-            Files.createDirectories(this.baseDirectory.toPath());
-        }
 
         this.buildGradleTemplateContents = ExtenderUtil.readContentFromResource(buildGradleTemplate);
         this.gradlePropertiesTemplateContents = ExtenderUtil.readContentFromResource(gradlePropertiesTemplate);
@@ -109,7 +98,24 @@ public class RealGradleService implements GradleServiceInterface {
         List<File> gradleFiles = ExtenderUtil.listFilesMatchingRecursive(workDir, "build\\.gradle");
         // This file might exist when testing and debugging the extender using a debug job folder
         gradleFiles.remove(mainGradleFile);
-        createBuildGradleFile(mainGradleFile, gradleFiles, jobEnvContext);
+        boolean hasDependencies = createBuildGradleFile(mainGradleFile, gradleFiles, jobEnvContext);
+
+        Files.createDirectories(buildDir.toPath());
+        File lockFile = new File(buildDir, "gradle.lockfile");
+        File dependencyTreeFile = new File(buildDir, "gradle.dependencytree");
+        File artifactManifestFile = new File(buildDir, "gradle-artifacts.json");
+        outputFiles.add(lockFile);
+        outputFiles.add(dependencyTreeFile);
+
+        if (!hasDependencies) {
+            Files.deleteIfExists(artifactManifestFile.toPath());
+            Files.writeString(lockFile.toPath(), "", StandardCharsets.UTF_8);
+            Files.writeString(
+                    dependencyTreeFile.toPath(),
+                    "No Gradle dependencies were declared.\n",
+                    StandardCharsets.UTF_8);
+            return List.of();
+        }
 
         // create gradle.properties
         File gradlePropertiesFile = new File(workDir, "gradle.properties");
@@ -119,27 +125,19 @@ public class RealGradleService implements GradleServiceInterface {
         File localPropertiesFile = new File(workDir, "local.properties");
         createLocalPropertiesFile(localPropertiesFile, jobEnvContext);
 
-        // download, parse and unpack dependencies
-        List<File> unpackedDependencies = downloadDependencies(workDir, buildState.isUsedJetifier());
-        // add gradle lockfile to outputs
-        // configured in template.build.gradle
-        outputFiles.add(new File(buildDir, "gradle.lockfile"));
-
-        // write dependency tree and add to outputs
-        File dependencyTreeFile = new File(buildDir, "gradle.dependencytree");
-        writeDependencyTree(dependencyTreeFile, workDir);
-        outputFiles.add(dependencyTreeFile);
-
-        return unpackedDependencies;
+        // Resolve AGP-processed dependencies and reuse their cache paths directly.
+        return resolveGradleArtifacts(workDir, artifactManifestFile, dependencyTreeFile);
     }
 
     @Override
     public long getCacheSize() throws IOException {
-        Path folder = Paths.get(GRADLE_USER_HOME);
-        return Files.walk(folder)
-          .filter(p -> p.toFile().isFile())
-          .mapToLong(p -> p.toFile().length())
-          .sum();
+        Path folder = Paths.get(this.gradleHome);
+        try (Stream<Path> paths = Files.walk(folder)) {
+            return paths
+                    .filter(Files::isRegularFile)
+                    .mapToLong(path -> path.toFile().length())
+                    .sum();
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
@@ -195,7 +193,7 @@ public class RealGradleService implements GradleServiceInterface {
         return lines;
     }
 
-    private void createBuildGradleFile(File mainGradleFile, List<File> gradleFiles, Map<String, Object> jobEnvContext) throws IOException, ExtenderException {
+    private boolean createBuildGradleFile(File mainGradleFile, List<File> gradleFiles, Map<String, Object> jobEnvContext) throws IOException, ExtenderException {
         List<String> userDependencies = new ArrayList<>();
         List<String> userRepositories = new ArrayList<>();
         for (File file : gradleFiles) {
@@ -211,232 +209,90 @@ public class RealGradleService implements GradleServiceInterface {
         envContext.put("gradle-plugin-version", GRADLE_PLUGIN_VERSION);
         String contents = templateExecutor.execute(buildGradleTemplateContents, envContext);
         Files.write(mainGradleFile.toPath(), contents.getBytes());
+        return !userDependencies.isEmpty();
     }
 
-    private Map<String, String> parseDependencies(String log) {
-        // The output comes from template.build.gradle
-        Pattern p = Pattern.compile("PATH:\\s*([\\w-.\\/]*)\\sEXTENSION:\\s*([\\w-.\\/]*)\\sTYPE:\\s*([\\w-.\\/]*)\\sMODULE_GROUP:\\s*([\\w-.\\/]*)\\sMODULE_NAME:\\s*([\\w-.\\/]*)\\sMODULE_VERSION:\\s*([\\w-.\\/]*)");
-
-        Map<String, String> dependencies = new HashMap<>();
-        String[] lines = log.split(System.getProperty("line.separator"));
-        for (String line : lines) {
-            Matcher m = p.matcher(line);
-            if (m.matches()) {
-                String path = m.group(1);
-                String extension = m.group(2);
-                String group = m.group(4);
-                String name = m.group(5);
-                String version = m.group(6);
-
-                // Map the new name to the original file path
-                dependencies.put(String.format("%s-%s-%s.%s", group, name, version, extension), path);
-            }
-        }
-
-        return dependencies;
-    }
-
-    static String getDependencyCacheNamespace(String gradlePluginVersion, boolean useJetifier) {
-        String safePluginVersion = gradlePluginVersion == null
-                ? "unknown"
-                : gradlePluginVersion.replaceAll("[^A-Za-z0-9_-]", "_");
-        return String.format(
-                "%s-agp-%s-%s",
-                PROCESSED_DEPENDENCY_CACHE_VERSION,
-                safePluginVersion,
-                useJetifier ? "jetified" : "plain");
-    }
-
-    private File getDependencyCacheDirectory(boolean useJetifier) throws IOException {
-        File directory = new File(
-                baseDirectory,
-                getDependencyCacheNamespace(GRADLE_PLUGIN_VERSION, useJetifier));
-        Files.createDirectories(directory.toPath());
-        return directory;
-    }
-
-    static String getDependencyCacheName(File dependency, String extension) throws IOException {
-        String contentHash;
-        try (InputStream input = new FileInputStream(dependency)) {
-            contentHash = ExtenderUtil.calculateSHA256(input);
-        } catch (NoSuchAlgorithmException e) {
-            throw new IOException("SHA-256 is not available", e);
-        }
-        return contentHash + extension;
-    }
-
-    private static void deleteTemporaryPath(Path temporary) throws IOException {
-        if (Files.isDirectory(temporary)) {
-            FileUtils.deleteDirectory(temporary.toFile());
-        } else {
-            Files.deleteIfExists(temporary);
-        }
-    }
-
-    static void publishCacheEntry(Path temporary, Path target) throws IOException {
-        publishCacheEntry(temporary, target, () -> {});
-    }
-
-    static void publishCacheEntry(
-            Path temporary,
-            Path target,
-            Runnable beforeMove) throws IOException {
-        IOException failure = null;
-        if (!Files.exists(target)) {
-            try {
-                beforeMove.run();
-                try {
-                    Files.move(temporary, target, StandardCopyOption.ATOMIC_MOVE);
-                } catch (AtomicMoveNotSupportedException e) {
-                    Files.move(temporary, target);
-                }
-            } catch (FileAlreadyExistsException e) {
-                if (!Files.exists(target)) {
-                    failure = e;
-                }
-            } catch (IOException e) {
-                // A concurrent writer of the same content-addressed entry may win
-                // with a platform-specific exception (for example, Linux reports
-                // Directory not empty for an atomic directory move).
-                if (!Files.exists(target)) {
-                    failure = e;
-                }
-            }
-        }
-
-        if (Files.exists(temporary)) {
-            try {
-                deleteTemporaryPath(temporary);
-            } catch (IOException e) {
-                if (failure == null) {
-                    failure = e;
-                } else {
-                    failure.addSuppressed(e);
-                }
-            }
-        }
-        if (failure != null) {
-            throw failure;
-        }
-        if (!Files.exists(target)) {
-            throw new IOException("Failed to publish Gradle dependency cache entry: " + target);
-        }
-    }
-
-    private File resolveDependencyAAR(
-            File dependency,
-            File cacheDirectory) throws IOException {
-        File unpackedTarget = new File(
-                cacheDirectory,
-                getDependencyCacheName(dependency, ".aar"));
-        if (unpackedTarget.exists()) {
-            return unpackedTarget;
-        }
-
-        Path unpackedTmp = Files.createTempDirectory(cacheDirectory.toPath(), ".aar-");
+    static List<File> parseGradleArtifacts(File artifactManifest) throws IOException, ExtenderException {
+        final Object parsed;
         try {
-            try (InputStream fis = new FileInputStream(dependency)) {
-                ZipUtils.unzip(fis, unpackedTmp);
-            }
-            publishCacheEntry(unpackedTmp, unpackedTarget.toPath());
-        } finally {
-            if (Files.exists(unpackedTmp)) {
-                deleteTemporaryPath(unpackedTmp);
-            }
+            parsed = new JSONParser().parse(Files.readString(
+                    artifactManifest.toPath(),
+                    StandardCharsets.UTF_8));
+        } catch (ParseException e) {
+            throw new ExtenderException(e, "Invalid Gradle artifact manifest: " + artifactManifest);
         }
-        return unpackedTarget;
-    }
-
-    private File resolveDependencyJAR(
-            File dependency,
-            File cacheDirectory) throws IOException {
-        File targetFile = new File(
-                cacheDirectory,
-                getDependencyCacheName(dependency, ".jar"));
-        if (targetFile.exists()) {
-            return targetFile;
+        if (!(parsed instanceof JSONArray)) {
+            throw new ExtenderException("Gradle artifact manifest must contain a JSON array: " + artifactManifest);
         }
 
-        Path tmpFile = Files.createTempFile(cacheDirectory.toPath(), ".jar-", ".tmp");
-        try {
-            Files.copy(dependency.toPath(), tmpFile, StandardCopyOption.REPLACE_EXISTING);
-            publishCacheEntry(tmpFile, targetFile.toPath());
-        } finally {
-            if (Files.exists(tmpFile)) {
-                deleteTemporaryPath(tmpFile);
+        List<File> artifacts = new ArrayList<>();
+        Set<String> seenPaths = new LinkedHashSet<>();
+        for (Object value : (JSONArray) parsed) {
+            if (!(value instanceof JSONObject)) {
+                throw new ExtenderException("Invalid entry in Gradle artifact manifest: " + value);
             }
-        }
-        return targetFile;
-    }
-
-    private List<File> unpackDependencies(
-            Map<String, String> dependencies,
-            boolean useJetifier) throws IOException {
-        List<File> resolvedDependencies = new ArrayList<>();
-        File cacheDirectory = getDependencyCacheDirectory(useJetifier);
-        Timer timer = new Timer();
-        timer.start();
-        for (String newName : dependencies.keySet()) {
-            String dependency = dependencies.get(newName);
-
-            File file = new File(dependency);
-            if (!file.exists()) {
-                throw new IOException("File does not exist: %s" + dependency);
+            JSONObject entry = (JSONObject) value;
+            Object kindValue = entry.get("kind");
+            Object pathValue = entry.get("path");
+            if (!(kindValue instanceof String) || !(pathValue instanceof String)) {
+                throw new ExtenderException("Gradle artifact entry must contain string kind and path fields: " + entry);
             }
-            if (dependency.endsWith(".aar")) {
-                resolvedDependencies.add(resolveDependencyAAR(file, cacheDirectory));
-            } else if (dependency.endsWith(".jar")) {
-                resolvedDependencies.add(resolveDependencyJAR(file, cacheDirectory));
+
+            String kind = (String) kindValue;
+            File artifact = new File((String) pathValue).getCanonicalFile();
+            if ("exploded-aar".equals(kind)) {
+                if (!artifact.isDirectory()) {
+                    throw new ExtenderException("Gradle exploded AAR does not exist: " + artifact);
+                }
+            } else if ("jar".equals(kind)) {
+                if (!artifact.isFile() || !artifact.getName().endsWith(".jar")) {
+                    throw new ExtenderException("Gradle JAR does not exist: " + artifact);
+                }
             } else {
-                resolvedDependencies.add(file);
+                throw new ExtenderException("Unsupported Gradle artifact kind '" + kind + "': " + artifact);
+            }
+
+            if (seenPaths.add(artifact.getAbsolutePath())) {
+                artifacts.add(artifact);
             }
         }
-        long duration = timer.start();
-        MetricsWriter.metricsTimer(meterRegistry, "extender.service.gradle.unpack", duration);
-        return resolvedDependencies;
+        return artifacts;
     }
 
-    private List<File> downloadDependencies(File cwd, boolean useJetifier) throws IOException, ExtenderException {
-        long methodStart = System.currentTimeMillis();
-        LOGGER.info("Resolving dependencies");
-
-        // add --info for additional logging
-        String log = ProcessUtils.execCommand(List.of(
+    static List<String> getGradleResolveCommand() {
+        return List.of(
                 "gradle",
                 "downloadDependencies",
+                "dependencies",
+                "--configuration",
+                "releaseCompileClasspath",
                 "--write-locks",
                 "--stacktrace",
                 "--warning-mode",
                 "all",
-                "--no-daemon"
-            ), cwd,
-            Map.of("GRADLE_USER_HOME", this.gradleHome));
-        LOGGER.debug("\n" + log);
-
-        Map<String, String> dependencies = parseDependencies(log);
-
-        List<File> unpackedDependencies = unpackDependencies(dependencies, useJetifier);
-
-        MetricsWriter.metricsTimer(meterRegistry, "extender.service.gradle.get", System.currentTimeMillis() - methodStart);
-        return unpackedDependencies;
+                "--no-daemon");
     }
 
-    private void writeDependencyTree(File out, File cwd) throws IOException, ExtenderException {
+    private List<File> resolveGradleArtifacts(
+            File cwd,
+            File artifactManifest,
+            File dependencyTree) throws IOException, ExtenderException {
         long methodStart = System.currentTimeMillis();
-        LOGGER.info("Writing dependency tree");
+        LOGGER.info("Resolving dependencies");
+        Files.deleteIfExists(artifactManifest.toPath());
 
-        String treelog = ProcessUtils.execCommand(List.of(
-                "gradle",
-                "dependencies",
-                "--configuration",
-                "releaseCompileClasspath",
-                "--no-daemon"
-            ), cwd, Map.of("GRADLE_USER_HOME", this.gradleHome));
-        LOGGER.debug("\n" + treelog);
+        String log = ProcessUtils.execCommand(getGradleResolveCommand(), cwd,
+            Map.of("GRADLE_USER_HOME", this.gradleHome));
+        LOGGER.debug("\n" + log);
+        Files.writeString(dependencyTree.toPath(), log, StandardCharsets.UTF_8);
 
-        Files.write(out.toPath(), treelog.getBytes());
+        if (!artifactManifest.isFile()) {
+            throw new ExtenderException("Gradle did not produce its artifact manifest: " + artifactManifest);
+        }
+        List<File> artifacts = parseGradleArtifacts(artifactManifest);
 
-        MetricsWriter.metricsTimer(meterRegistry, "extender.service.gradle.dependencytree", System.currentTimeMillis() - methodStart);
+        MetricsWriter.metricsTimer(meterRegistry, "extender.service.gradle.get", System.currentTimeMillis() - methodStart);
+        return artifacts;
     }
 
 }

--- a/server/src/main/java/com/defold/extender/services/RealGradleService.java
+++ b/server/src/main/java/com/defold/extender/services/RealGradleService.java
@@ -50,6 +50,8 @@ public class RealGradleService implements GradleServiceInterface {
     );
     private static final String GRADLE_USER_HOME = System.getenv("GRADLE_USER_HOME");
     private static final String GRADLE_PLUGIN_VERSION = System.getenv("GRADLE_PLUGIN_VERSION");
+    private static final String ARTIFACT_KIND_EXPLODED_AAR = "exploded-aar";
+    private static final String ARTIFACT_KIND_JAR = "jar";
 
     private final TemplateExecutor templateExecutor = new TemplateExecutor();
 
@@ -276,13 +278,13 @@ public class RealGradleService implements GradleServiceInterface {
             File artifact = new File((String) pathValue).getCanonicalFile();
             GradleArtifact.Kind artifactKind;
             String resourcePackageName = null;
-            if ("exploded-aar".equals(kind)) {
+            if (ARTIFACT_KIND_EXPLODED_AAR.equals(kind)) {
                 if (!artifact.isDirectory()) {
                     throw new ExtenderException("Gradle exploded AAR does not exist: " + artifact);
                 }
                 artifactKind = GradleArtifact.Kind.EXPLODED_AAR;
                 resourcePackageName = getResourcePackageName(component, originalFileName);
-            } else if ("jar".equals(kind)) {
+            } else if (ARTIFACT_KIND_JAR.equals(kind)) {
                 if (!artifact.isFile() || !artifact.getName().endsWith(".jar")) {
                     throw new ExtenderException("Gradle JAR does not exist: " + artifact);
                 }

--- a/server/src/main/java/com/defold/extender/services/RealGradleService.java
+++ b/server/src/main/java/com/defold/extender/services/RealGradleService.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -88,7 +89,7 @@ public class RealGradleService implements GradleServiceInterface {
     }
 
     @Override
-    public List<File> resolveDependencies(ExtenderBuildState buildState, Map<String, Object> env, List<File> outputFiles) throws IOException, ExtenderException {
+    public List<GradleArtifact> resolveDependencies(ExtenderBuildState buildState, Map<String, Object> env, List<File> outputFiles) throws IOException, ExtenderException {
         // cwd -> jobDir
         File workDir = buildState.getJobDir();
         File buildDir = buildState.getBuildDir();
@@ -212,7 +213,31 @@ public class RealGradleService implements GradleServiceInterface {
         return !userDependencies.isEmpty();
     }
 
-    static List<File> parseGradleArtifacts(File artifactManifest) throws IOException, ExtenderException {
+    private static String getResourcePackageName(String component, String originalFileName) {
+        String[] coordinate = component.split(":", 3);
+        if (coordinate.length == 3
+                && !coordinate[0].isBlank()
+                && !coordinate[1].isBlank()
+                && !coordinate[2].isBlank()) {
+            // Match the package directory names returned by the pre-AGP-cache implementation.
+            return (coordinate[0] + "-" + coordinate[1] + "-" + coordinate[2] + ".aar")
+                    .replaceAll("[^A-Za-z0-9._-]", "_");
+        }
+
+        String fileName = new File(originalFileName).getName();
+        if (fileName.isBlank()) {
+            fileName = "dependency.aar";
+        }
+        if (!fileName.toLowerCase(Locale.ROOT).endsWith(".aar")) {
+            fileName += ".aar";
+        }
+
+        // Gradle uses incomplete coordinates such as :LocalAar: for flatDir dependencies. The
+        // externally visible name is cosmetic, so fall back instead of rejecting a valid build.
+        return fileName.replaceAll("[^A-Za-z0-9._-]", "_");
+    }
+
+    static List<GradleArtifact> parseGradleArtifacts(File artifactManifest) throws IOException, ExtenderException {
         final Object parsed;
         try {
             parsed = new JSONParser().parse(Files.readString(
@@ -225,35 +250,54 @@ public class RealGradleService implements GradleServiceInterface {
             throw new ExtenderException("Gradle artifact manifest must contain a JSON array: " + artifactManifest);
         }
 
-        List<File> artifacts = new ArrayList<>();
+        List<GradleArtifact> artifacts = new ArrayList<>();
         Set<String> seenPaths = new LinkedHashSet<>();
         for (Object value : (JSONArray) parsed) {
             if (!(value instanceof JSONObject)) {
                 throw new ExtenderException("Invalid entry in Gradle artifact manifest: " + value);
             }
             JSONObject entry = (JSONObject) value;
+            Object componentValue = entry.get("component");
+            Object originalFileNameValue = entry.get("originalFileName");
             Object kindValue = entry.get("kind");
             Object pathValue = entry.get("path");
-            if (!(kindValue instanceof String) || !(pathValue instanceof String)) {
-                throw new ExtenderException("Gradle artifact entry must contain string kind and path fields: " + entry);
+            if (!(componentValue instanceof String)
+                    || !(originalFileNameValue instanceof String)
+                    || !(kindValue instanceof String)
+                    || !(pathValue instanceof String)) {
+                throw new ExtenderException(
+                        "Gradle artifact entry must contain string component, originalFileName, kind and path fields: "
+                                + entry);
             }
 
+            String component = (String) componentValue;
+            String originalFileName = (String) originalFileNameValue;
             String kind = (String) kindValue;
             File artifact = new File((String) pathValue).getCanonicalFile();
+            GradleArtifact.Kind artifactKind;
+            String resourcePackageName = null;
             if ("exploded-aar".equals(kind)) {
                 if (!artifact.isDirectory()) {
                     throw new ExtenderException("Gradle exploded AAR does not exist: " + artifact);
                 }
+                artifactKind = GradleArtifact.Kind.EXPLODED_AAR;
+                resourcePackageName = getResourcePackageName(component, originalFileName);
             } else if ("jar".equals(kind)) {
                 if (!artifact.isFile() || !artifact.getName().endsWith(".jar")) {
                     throw new ExtenderException("Gradle JAR does not exist: " + artifact);
                 }
+                artifactKind = GradleArtifact.Kind.JAR;
             } else {
                 throw new ExtenderException("Unsupported Gradle artifact kind '" + kind + "': " + artifact);
             }
 
             if (seenPaths.add(artifact.getAbsolutePath())) {
-                artifacts.add(artifact);
+                artifacts.add(new GradleArtifact(
+                        artifact,
+                        component,
+                        originalFileName,
+                        artifactKind,
+                        resourcePackageName));
             }
         }
         return artifacts;
@@ -273,7 +317,7 @@ public class RealGradleService implements GradleServiceInterface {
                 "--no-daemon");
     }
 
-    private List<File> resolveGradleArtifacts(
+    private List<GradleArtifact> resolveGradleArtifacts(
             File cwd,
             File artifactManifest,
             File dependencyTree) throws IOException, ExtenderException {
@@ -289,7 +333,7 @@ public class RealGradleService implements GradleServiceInterface {
         if (!artifactManifest.isFile()) {
             throw new ExtenderException("Gradle did not produce its artifact manifest: " + artifactManifest);
         }
-        List<File> artifacts = parseGradleArtifacts(artifactManifest);
+        List<GradleArtifact> artifacts = parseGradleArtifacts(artifactManifest);
 
         MetricsWriter.metricsTimer(meterRegistry, "extender.service.gradle.get", System.currentTimeMillis() - methodStart);
         return artifacts;

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -38,6 +38,14 @@ extender:
     gradle:
         enabled: false
         location: /tmp/.gradle
+    # Resource limits for untrusted R8 input; byte limits use expanded sizes.
+    r8:
+        max-generated-extension-classes: 32768
+        max-classfile-header-bytes: 4194304
+        max-total-classfile-header-bytes: 67108864
+        max-rule-files: 1024
+        max-rule-file-bytes: 1048576
+        max-total-rule-bytes: 16777216
     cocoapods:
         enabled: false
         cdn-concurrency: 10 # value for COCOAPODS_CDN_MAX_CONCURRENCY

--- a/server/src/main/resources/template.build.gradle
+++ b/server/src/main/resources/template.build.gradle
@@ -1,3 +1,6 @@
+import com.android.build.gradle.internal.publishing.AndroidArtifacts
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+
 buildscript {
     repositories {
         google()
@@ -53,13 +56,70 @@ dependencyLocking {
 
 task downloadDependencies {
     doLast {
-        project.configurations.releaseRuntimeClasspath.getResolvedConfiguration().getResolvedArtifacts().each {
-            println "PATH: " + it.file + \
+        def runtimeClasspath = project.configurations.releaseRuntimeClasspath
+        def useJetifier = (project.findProperty("android.enableJetifier") ?: "false").toBoolean()
+        if (!useJetifier) {
+            runtimeClasspath.getResolvedConfiguration().getResolvedArtifacts().each {
+                println "PATH: " + it.file + \
+                        " EXTENSION: " + it.extension + \
+                        " TYPE: " + it.type + \
+                        " MODULE_GROUP: " + it.moduleVersion.id.group + \
+                        " MODULE_NAME: " + it.moduleVersion.id.name + \
+                        " MODULE_VERSION: " + it.moduleVersion.id.version
+            }
+            return
+        }
+
+        def processedAars = runtimeClasspath.incoming.artifactView {
+            componentFilter {
+                it instanceof ModuleComponentIdentifier
+            }
+            attributes {
+                attribute(
+                    AndroidArtifacts.ARTIFACT_TYPE,
+                    AndroidArtifacts.ArtifactType.PROCESSED_AAR.type)
+            }
+        }.artifacts.artifacts
+        def getOriginalFileName = { artifact ->
+            def identifier = artifact.id
+            identifier.metaClass.hasProperty(identifier, "originalFileName") != null
+                    ? identifier.originalFileName
+                    : artifact.file.name
+        }
+        def aarArtifactKeys = processedAars.collect {
+            [it.id.componentIdentifier, getOriginalFileName(it)]
+        } as Set
+        def processedJars = runtimeClasspath.incoming.artifactView {
+            componentFilter {
+                it instanceof ModuleComponentIdentifier
+            }
+            attributes {
+                attribute(
+                    AndroidArtifacts.ARTIFACT_TYPE,
+                    AndroidArtifacts.ArtifactType.PROCESSED_JAR.type)
+            }
+        }.artifacts.artifacts.findAll {
+            def artifactKey = [it.id.componentIdentifier, getOriginalFileName(it)]
+            !aarArtifactKeys.contains(artifactKey)
+        }
+
+        def processedArtifacts = []
+        processedAars.each { processedArtifacts << [artifact: it, extension: "aar"] }
+        processedJars.each { processedArtifacts << [artifact: it, extension: "jar"] }
+        processedArtifacts.sort { left, right ->
+            def componentComparison = left.artifact.id.componentIdentifier.toString() <=>
+                    right.artifact.id.componentIdentifier.toString()
+            componentComparison != 0 ? componentComparison :
+                    left.artifact.file.name <=> right.artifact.file.name
+        }.each {
+            def artifact = it.artifact
+            def component = artifact.id.componentIdentifier
+            println "PATH: " + artifact.file + \
                     " EXTENSION: " + it.extension + \
-                    " TYPE: " +  it.type + \
-                    " MODULE_GROUP: " + it.moduleVersion.id.group + \
-                    " MODULE_NAME: " + it.moduleVersion.id.name + \
-                    " MODULE_VERSION: " + it.moduleVersion.id.version
+                    " TYPE: " + it.extension + \
+                    " MODULE_GROUP: " + component.group + \
+                    " MODULE_NAME: " + component.module + \
+                    " MODULE_VERSION: " + component.version
         }
     }
 }

--- a/server/src/main/resources/template.build.gradle
+++ b/server/src/main/resources/template.build.gradle
@@ -1,4 +1,5 @@
 import com.android.build.gradle.internal.publishing.AndroidArtifacts
+import groovy.json.JsonOutput
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 
 buildscript {
@@ -58,26 +59,23 @@ task downloadDependencies {
     doLast {
         def runtimeClasspath = project.configurations.releaseRuntimeClasspath
         def useJetifier = (project.findProperty("android.enableJetifier") ?: "false").toBoolean()
-        if (!useJetifier) {
-            runtimeClasspath.getResolvedConfiguration().getResolvedArtifacts().each {
-                println "PATH: " + it.file + \
-                        " EXTENSION: " + it.extension + \
-                        " TYPE: " + it.type + \
-                        " MODULE_GROUP: " + it.moduleVersion.id.group + \
-                        " MODULE_NAME: " + it.moduleVersion.id.name + \
-                        " MODULE_VERSION: " + it.moduleVersion.id.version
-            }
-            return
+        def rawModuleArtifacts = runtimeClasspath.incoming.artifacts.artifacts.findAll {
+            it.id.componentIdentifier instanceof ModuleComponentIdentifier
         }
+        def standaloneJarComponents = rawModuleArtifacts.findAll {
+            it.file.name.toLowerCase(Locale.ROOT).endsWith(".jar")
+        }.collect {
+            it.id.componentIdentifier
+        } as Set
 
-        def processedAars = runtimeClasspath.incoming.artifactView {
+        def explodedAars = runtimeClasspath.incoming.artifactView {
             componentFilter {
                 it instanceof ModuleComponentIdentifier
             }
             attributes {
                 attribute(
                     AndroidArtifacts.ARTIFACT_TYPE,
-                    AndroidArtifacts.ArtifactType.PROCESSED_AAR.type)
+                    AndroidArtifacts.ArtifactType.EXPLODED_AAR.type)
             }
         }.artifacts.artifacts
         def getOriginalFileName = { artifact ->
@@ -86,40 +84,57 @@ task downloadDependencies {
                     ? identifier.originalFileName
                     : artifact.file.name
         }
-        def aarArtifactKeys = processedAars.collect {
+        def aarArtifactKeys = explodedAars.collect {
             [it.id.componentIdentifier, getOriginalFileName(it)]
         } as Set
-        def processedJars = runtimeClasspath.incoming.artifactView {
-            componentFilter {
-                it instanceof ModuleComponentIdentifier
+
+        def standaloneJars
+        if (useJetifier && !standaloneJarComponents.isEmpty()) {
+            standaloneJars = runtimeClasspath.incoming.artifactView {
+                componentFilter {
+                    it instanceof ModuleComponentIdentifier && standaloneJarComponents.contains(it)
+                }
+                attributes {
+                    attribute(
+                        AndroidArtifacts.ARTIFACT_TYPE,
+                        AndroidArtifacts.ArtifactType.PROCESSED_JAR.type)
+                }
+            }.artifacts.artifacts.findAll {
+                def artifactKey = [it.id.componentIdentifier, getOriginalFileName(it)]
+                !aarArtifactKeys.contains(artifactKey)
             }
-            attributes {
-                attribute(
-                    AndroidArtifacts.ARTIFACT_TYPE,
-                    AndroidArtifacts.ArtifactType.PROCESSED_JAR.type)
+        } else {
+            standaloneJars = rawModuleArtifacts.findAll {
+                it.file.name.toLowerCase(Locale.ROOT).endsWith(".jar")
             }
-        }.artifacts.artifacts.findAll {
-            def artifactKey = [it.id.componentIdentifier, getOriginalFileName(it)]
-            !aarArtifactKeys.contains(artifactKey)
         }
 
-        def processedArtifacts = []
-        processedAars.each { processedArtifacts << [artifact: it, extension: "aar"] }
-        processedJars.each { processedArtifacts << [artifact: it, extension: "jar"] }
-        processedArtifacts.sort { left, right ->
-            def componentComparison = left.artifact.id.componentIdentifier.toString() <=>
-                    right.artifact.id.componentIdentifier.toString()
-            componentComparison != 0 ? componentComparison :
-                    left.artifact.file.name <=> right.artifact.file.name
-        }.each {
-            def artifact = it.artifact
-            def component = artifact.id.componentIdentifier
-            println "PATH: " + artifact.file + \
-                    " EXTENSION: " + it.extension + \
-                    " TYPE: " + it.extension + \
-                    " MODULE_GROUP: " + component.group + \
-                    " MODULE_NAME: " + component.module + \
-                    " MODULE_VERSION: " + component.version
+        def artifacts = []
+        explodedAars.each {
+            artifacts << [
+                component: it.id.componentIdentifier.toString(),
+                originalFileName: getOriginalFileName(it),
+                kind: "exploded-aar",
+                path: it.file.absolutePath
+            ]
         }
+        standaloneJars.each {
+            artifacts << [
+                component: it.id.componentIdentifier.toString(),
+                originalFileName: getOriginalFileName(it),
+                kind: "jar",
+                path: it.file.absolutePath
+            ]
+        }
+        artifacts.sort { left, right ->
+            def componentComparison = left.component <=> right.component
+            if (componentComparison != 0) return componentComparison
+            def fileComparison = left.originalFileName <=> right.originalFileName
+            fileComparison != 0 ? fileComparison : left.kind <=> right.kind
+        }
+
+        def artifactManifest = file("$buildDir/gradle-artifacts.json")
+        artifactManifest.parentFile.mkdirs()
+        artifactManifest.text = JsonOutput.prettyPrint(JsonOutput.toJson(artifacts))
     }
 }

--- a/server/src/main/resources/template.gradle.properties
+++ b/server/src/main/resources/template.gradle.properties
@@ -1,7 +1,7 @@
 # Gradle will use the Jetifier tool to migrate dependencies to Android X if android.enableJetifier is true
 android.enableJetifier={{android-enable-jetifier}}
 
-# Gradle will stop resolving dependencies if android.useAndroidX is false and a dependency is using Android X
-android.useAndroidX={{android-enable-jetifier}}
+# Dependency graphs may use AndroidX even when none of their artifacts need Jetifier.
+android.useAndroidX=true
 
 org.gradle.java.home=/usr/local/jdk-25+36

--- a/server/src/test/java/com/defold/extender/ExtenderTest.java
+++ b/server/src/test/java/com/defold/extender/ExtenderTest.java
@@ -34,6 +34,18 @@ import java.util.Map;
 import java.util.zip.ZipEntry;
 
 public class ExtenderTest {
+    @Test
+    public void testCompiledResourceDirectoryNamesAreCollisionSafe(@TempDir File temporaryDirectory) {
+        File first = new File(temporaryDirectory, "first/common-1.0/res");
+        File second = new File(temporaryDirectory, "second/common-1.0/res");
+
+        assertEquals("0000-common-1.0", Extender.getCompiledResourceDirectoryName(0, first));
+        assertEquals("0001-common-1.0", Extender.getCompiledResourceDirectoryName(1, second));
+        assertNotEquals(
+                Extender.getCompiledResourceDirectoryName(0, first),
+                Extender.getCompiledResourceDirectoryName(1, second));
+    }
+
     static Map<String, String> createEnv()
     {
         Map<String, String> env = new HashMap<>();

--- a/server/src/test/java/com/defold/extender/ExtenderTest.java
+++ b/server/src/test/java/com/defold/extender/ExtenderTest.java
@@ -46,6 +46,24 @@ public class ExtenderTest {
                 Extender.getCompiledResourceDirectoryName(1, second));
     }
 
+    @Test
+    public void testReturnedResourcePackageNamesPreserveLegacyNamesAndResolveCollisions(
+            @TempDir File temporaryDirectory) {
+        List<String> resourceDirectories = List.of(
+                new File(temporaryDirectory, "first/common-1.0/res").getAbsolutePath(),
+                new File(temporaryDirectory, "second/common-1.0/res").getAbsolutePath(),
+                new File(temporaryDirectory, "third/common-1.0-0001/res").getAbsolutePath(),
+                new File(temporaryDirectory, "fourth/unique-1.0/res").getAbsolutePath());
+
+        assertEquals(
+                List.of(
+                        "common-1.0",
+                        "common-1.0-0001-1",
+                        "common-1.0-0001",
+                        "unique-1.0"),
+                Extender.getReturnedResourcePackageNames(resourceDirectories));
+    }
+
     static Map<String, String> createEnv()
     {
         Map<String, String> env = new HashMap<>();

--- a/server/src/test/java/com/defold/extender/ExtenderTest.java
+++ b/server/src/test/java/com/defold/extender/ExtenderTest.java
@@ -48,7 +48,7 @@ public class ExtenderTest {
 
     @Test
     public void testReturnedResourcePackageNamesPreserveLegacyNamesAndResolveCollisions(
-            @TempDir File temporaryDirectory) {
+            @TempDir File temporaryDirectory) throws IOException {
         List<String> resourceDirectories = List.of(
                 new File(temporaryDirectory, "first/common-1.0/res").getAbsolutePath(),
                 new File(temporaryDirectory, "second/common-1.0/res").getAbsolutePath(),
@@ -61,7 +61,26 @@ public class ExtenderTest {
                         "common-1.0-0001-1",
                         "common-1.0-0001",
                         "unique-1.0"),
-                Extender.getReturnedResourcePackageNames(resourceDirectories));
+                Extender.getReturnedResourcePackageNames(resourceDirectories, Map.of()));
+    }
+
+    @Test
+    public void testReturnedResourcePackageNamesUseGradleArtifactIdentity(
+            @TempDir File temporaryDirectory) throws IOException {
+        File firstPackage = new File(temporaryDirectory, "transforms/first/jetified-library");
+        File secondPackage = new File(temporaryDirectory, "transforms/second/jetified-library");
+        List<String> resourceDirectories = List.of(
+                new File(firstPackage, "res").getAbsolutePath(),
+                new File(secondPackage, "res").getAbsolutePath());
+        String legacyName = "com.example-library-1.0.aar";
+
+        assertEquals(
+                List.of(legacyName, legacyName + "-0001"),
+                Extender.getReturnedResourcePackageNames(
+                        resourceDirectories,
+                        Map.of(
+                                firstPackage.getCanonicalFile(), legacyName,
+                                secondPackage.getCanonicalFile(), legacyName)));
     }
 
     static Map<String, String> createEnv()

--- a/server/src/test/java/com/defold/extender/ExtenderTest.java
+++ b/server/src/test/java/com/defold/extender/ExtenderTest.java
@@ -324,15 +324,14 @@ public class ExtenderTest {
         PlatformConfig android = mergePlatformConfig(config, "armv7-android");
 
         assertTrue(android.r8Cmd.contains("com.android.tools.r8.R8"));
-        assertTrue(android.r8Cmd.contains("{{#useMainDexRules}}{{#mainDexRules}}--main-dex-rules"));
+        assertFalse(android.r8Cmd.contains("--main-dex-rules"));
         assertTrue(android.r8Cmd.contains("--pg-conf \"{{{.}}}\""));
         assertTrue(android.r8Cmd.contains("{{#jars}}\"{{{.}}}\""));
         assertTrue(android.dxCmd.contains("--min-api {{minAndroidSdkVersion}}"));
         assertEquals("{{env.R8_VERSION}}", android.r8Version);
         assertEquals("(?i).+(\\.keep)$", android.r8RuleSourceRe);
         assertTrue(android.aapt2linkCmd.contains("{{#useR8}}--proguard \"{{{aaptKeepRules}}}\""));
-        assertTrue(android.aapt2linkCmd.contains(
-                "{{#useR8MainDexRules}}--proguard-main-dex \"{{{aaptMainDexRules}}}\""));
+        assertFalse(android.aapt2linkCmd.contains("--proguard-main-dex"));
         assertNull(android.proGuardCmd);
         assertNull(android.proGuardSourceRe);
 
@@ -341,23 +340,6 @@ public class ExtenderTest {
                 new File("manifests/android/extension.pro"));
         List<File> rules = ExtenderUtil.filterFiles(candidates, android.r8RuleSourceRe);
         assertEquals(List.of(new File("manifests/android/extension.keep")), rules);
-    }
-
-    // Verifies that aapt2 main-dex rules are requested only by _app/app.keep for Android API levels below 21.
-    @Test
-    public void testAaptMainDexRulesRequireExactAppKeepAndPre21Api(@TempDir File uploadDir)
-            throws Exception {
-        File appDir = new File(uploadDir, "_app");
-        assertTrue(appDir.mkdirs());
-
-        Files.writeString(new File(appDir, "app.pro").toPath(), "-keep class Legacy");
-        assertFalse(Extender.shouldGenerateAaptMainDexRules(uploadDir, 19));
-
-        Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class Current");
-        assertTrue(Extender.shouldGenerateAaptMainDexRules(uploadDir, 19));
-        assertTrue(Extender.shouldGenerateAaptMainDexRules(uploadDir, 20));
-        assertFalse(Extender.shouldGenerateAaptMainDexRules(uploadDir, 21));
-        assertFalse(Extender.shouldGenerateAaptMainDexRules(uploadDir, 35));
     }
 
     // Verifies that an Android build without _app/app.keep can initialize without any R8 path or version in the environment.
@@ -424,14 +406,13 @@ public class ExtenderTest {
                         "        PROGUARD:                 \"{{env.ANDROID_PROGUARD}}\"\n"
                                 + "        LIBRARYJAR:               \"{{env.ANDROID_LIBRARYJAR}}\"\n")
                 .replace(
-                        "    r8Cmd: 'java -cp \"{{{env.R8}}}\" com.android.tools.r8.R8 --release --min-api {{minAndroidSdkVersion}} --lib \"{{{env.LIBRARYJAR}}}\" {{#useMainDexRules}}{{#mainDexRules}}--main-dex-rules \"{{{.}}}\" {{/mainDexRules}}{{/useMainDexRules}}--pg-map-output \"{{{mapping}}}\" --output \"{{{classes_dex_dir}}}\" {{#rules}}--pg-conf \"{{{.}}}\" {{/rules}} {{#jars}}\"{{{.}}}\" {{/jars}}'\n"
+                        "    r8Cmd: 'java -cp \"{{{env.R8}}}\" com.android.tools.r8.R8 --release --min-api {{minAndroidSdkVersion}} --lib \"{{{env.LIBRARYJAR}}}\" --pg-map-output \"{{{mapping}}}\" --output \"{{{classes_dex_dir}}}\" {{#rules}}--pg-conf \"{{{.}}}\" {{/rules}} {{#jars}}\"{{{.}}}\" {{/jars}}'\n"
                                 + "    r8Version: '{{env.R8_VERSION}}'\n"
                                 + "    r8RuleSourceRe: '(?i).+(\\.keep)$'\n",
                         "    proGuardCmd: 'legacy-proguard-command'\n"
                                 + "    proGuardSourceRe: '(?i).+(\\.pro)$'\n")
                 .replace(
-                        " {{#useR8}}--proguard \"{{{aaptKeepRules}}}\" {{/useR8}}"
-                                + "{{#useR8MainDexRules}}--proguard-main-dex \"{{{aaptMainDexRules}}}\" {{/useR8MainDexRules}}",
+                        " {{#useR8}}--proguard \"{{{aaptKeepRules}}}\" {{/useR8}}",
                         " ");
 
         File sdk = new File(tempDir, "legacy-sdk");
@@ -448,7 +429,6 @@ public class ExtenderTest {
         assertNull(android.r8Cmd);
         assertFalse(android.aapt2linkCmd.contains("useR8"));
         assertFalse(android.aapt2linkCmd.contains("aaptKeepRules"));
-        assertFalse(android.aapt2linkCmd.contains("aaptMainDexRules"));
         assertFalse(android.aapt2linkCmd.contains("--proguard"));
 
         File uploadWithoutProguard = new File(tempDir, "upload-without-proguard");

--- a/server/src/test/java/com/defold/extender/ExtenderTest.java
+++ b/server/src/test/java/com/defold/extender/ExtenderTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.zip.ZipEntry;
 
 public class ExtenderTest {
+    // Verifies that compiled Android resource directories include their input index so equal AAR names cannot collide.
     @Test
     public void testCompiledResourceDirectoryNamesAreCollisionSafe(@TempDir File temporaryDirectory) {
         File first = new File(temporaryDirectory, "first/common-1.0/res");
@@ -46,6 +47,7 @@ public class ExtenderTest {
                 Extender.getCompiledResourceDirectoryName(1, second));
     }
 
+    // Verifies that returned resource packages keep legacy names when unique and add deterministic suffixes on collisions.
     @Test
     public void testReturnedResourcePackageNamesPreserveLegacyNamesAndResolveCollisions(
             @TempDir File temporaryDirectory) throws IOException {
@@ -64,6 +66,7 @@ public class ExtenderTest {
                 Extender.getReturnedResourcePackageNames(resourceDirectories, Map.of()));
     }
 
+    // Verifies that Gradle artifact identities, rather than transient exploded-directory names, determine returned package names.
     @Test
     public void testReturnedResourcePackageNamesUseGradleArtifactIdentity(
             @TempDir File temporaryDirectory) throws IOException {
@@ -311,6 +314,7 @@ public class ExtenderTest {
         return env;
     }
 
+    // Verifies that the Android SDK fixture uses only R8 configuration and discovers only the new .keep rule format.
     @Test
     @SuppressWarnings("deprecation")
     public void testAndroidSdkUsesOnlyR8Configuration() throws Exception {
@@ -339,6 +343,7 @@ public class ExtenderTest {
         assertEquals(List.of(new File("manifests/android/extension.keep")), rules);
     }
 
+    // Verifies that aapt2 main-dex rules are requested only by _app/app.keep for Android API levels below 21.
     @Test
     public void testAaptMainDexRulesRequireExactAppKeepAndPre21Api(@TempDir File uploadDir)
             throws Exception {
@@ -355,6 +360,7 @@ public class ExtenderTest {
         assertFalse(Extender.shouldGenerateAaptMainDexRules(uploadDir, 35));
     }
 
+    // Verifies that an Android build without _app/app.keep can initialize without any R8 path or version in the environment.
     @Test
     public void testAndroidWithoutKeepDoesNotRequireR8Environment(@TempDir File tempDir) throws Exception {
         File uploadDir = new File(tempDir, "upload");
@@ -375,6 +381,7 @@ public class ExtenderTest {
                 .build());
     }
 
+    // Verifies that resolved R8 environment values are carried literally into the command context without a second template pass.
     @Test
     public void testAndroidR8EnvironmentIsResolvedOnce(@TempDir File tempDir) throws Exception {
         File uploadDir = new File(tempDir, "upload");
@@ -403,6 +410,7 @@ public class ExtenderTest {
         assertEquals("8.13.19", r8BuilderContext.get("env.R8_VERSION"));
     }
 
+    // Verifies that legacy ProGuard-era SDK YAML still loads while app.pro remains ignored and does not request R8.
     @Test
     @SuppressWarnings("deprecation")
     public void testLegacyAndroidSdkProguardConfigurationIsAcceptedAndIgnored(@TempDir File tempDir) throws Exception {
@@ -416,7 +424,7 @@ public class ExtenderTest {
                         "        PROGUARD:                 \"{{env.ANDROID_PROGUARD}}\"\n"
                                 + "        LIBRARYJAR:               \"{{env.ANDROID_LIBRARYJAR}}\"\n")
                 .replace(
-                        "    r8Cmd: 'java -cp \"{{{env.R8}}}\" com.android.tools.r8.R8 --release --min-api {{minAndroidSdkVersion}} --lib \"{{{env.LIBRARYJAR}}}\" {{#useMainDexRules}}{{#mainDexRules}}--main-dex-rules \"{{{.}}}\" {{/mainDexRules}}{{/useMainDexRules}}--pg-map-output \"{{{mapping}}}\" --no-data-resources --output \"{{{classes_dex_dir}}}\" {{#rules}}--pg-conf \"{{{.}}}\" {{/rules}} {{#jars}}\"{{{.}}}\" {{/jars}}'\n"
+                        "    r8Cmd: 'java -cp \"{{{env.R8}}}\" com.android.tools.r8.R8 --release --min-api {{minAndroidSdkVersion}} --lib \"{{{env.LIBRARYJAR}}}\" {{#useMainDexRules}}{{#mainDexRules}}--main-dex-rules \"{{{.}}}\" {{/mainDexRules}}{{/useMainDexRules}}--pg-map-output \"{{{mapping}}}\" --output \"{{{classes_dex_dir}}}\" {{#rules}}--pg-conf \"{{{.}}}\" {{/rules}} {{#jars}}\"{{{.}}}\" {{/jars}}'\n"
                                 + "    r8Version: '{{env.R8_VERSION}}'\n"
                                 + "    r8RuleSourceRe: '(?i).+(\\.keep)$'\n",
                         "    proGuardCmd: 'legacy-proguard-command'\n"
@@ -476,6 +484,7 @@ public class ExtenderTest {
                 .build());
     }
 
+    // Verifies that embedded consumer-rule entries are excluded from runtime META-INF copying without excluding unrelated metadata.
     @Test
     public void testConsumerRulesAreNotCopiedAsRuntimeMetaInfResources() {
         assertFalse(ExtenderUtil.isMetaInfEntryValuable(new ZipEntry("META-INF/proguard/rules.pro")));

--- a/server/src/test/java/com/defold/extender/ExtenderTest.java
+++ b/server/src/test/java/com/defold/extender/ExtenderTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -30,6 +31,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipEntry;
 
 public class ExtenderTest {
     static Map<String, String> createEnv()
@@ -247,7 +249,8 @@ public class ExtenderTest {
     static Map<String, String> createAndroidEnv()
     {
         Map<String, String> env = createEnv();
-        env.put("ANDROID_PROGUARD", "/opt/android/proguard.jar");
+        env.put("ANDROID_R8", "/opt/android/r8.jar");
+        env.put("ANDROID_R8_VERSION", "8.13.19");
         env.put("ANDROID_LIBRARYJAR", "/opt/android/android.jar");
         env.put("ANDROID_NDK_PATH", "/opt/android/ndk");
         env.put("ANDROID_NDK_SYSROOT", "/opt/android/ndk/sysroot");
@@ -257,6 +260,186 @@ public class ExtenderTest {
         env.put("ANDROID_SDK_VERSION", "36");
         env.put("ANDROID_SDK_BUILD_TOOLS_PATH", "/opt/android/build-tools");
         return env;
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testAndroidSdkUsesOnlyR8Configuration() throws Exception {
+        File root = new File("test-data");
+        File sdk = new File(root, "sdk/a/defoldsdk");
+        Configuration config = Extender.loadYaml(root, new File(sdk, "extender/build.yml"), Configuration.class);
+        PlatformConfig android = mergePlatformConfig(config, "armv7-android");
+
+        assertTrue(android.r8Cmd.contains("com.android.tools.r8.R8"));
+        assertTrue(android.r8Cmd.contains("{{#useMainDexRules}}{{#mainDexRules}}--main-dex-rules"));
+        assertTrue(android.r8Cmd.contains("--pg-conf \"{{{.}}}\""));
+        assertTrue(android.r8Cmd.contains("{{#jars}}\"{{{.}}}\""));
+        assertTrue(android.dxCmd.contains("--min-api {{minAndroidSdkVersion}}"));
+        assertEquals("{{env.R8_VERSION}}", android.r8Version);
+        assertEquals("(?i).+(\\.keep)$", android.r8RuleSourceRe);
+        assertTrue(android.aapt2linkCmd.contains("{{#useR8}}--proguard \"{{{aaptKeepRules}}}\""));
+        assertTrue(android.aapt2linkCmd.contains(
+                "{{#useR8MainDexRules}}--proguard-main-dex \"{{{aaptMainDexRules}}}\""));
+        assertNull(android.proGuardCmd);
+        assertNull(android.proGuardSourceRe);
+
+        Collection<File> candidates = List.of(
+                new File("manifests/android/extension.keep"),
+                new File("manifests/android/extension.pro"));
+        List<File> rules = ExtenderUtil.filterFiles(candidates, android.r8RuleSourceRe);
+        assertEquals(List.of(new File("manifests/android/extension.keep")), rules);
+    }
+
+    @Test
+    public void testAaptMainDexRulesRequireExactAppKeepAndPre21Api(@TempDir File uploadDir)
+            throws Exception {
+        File appDir = new File(uploadDir, "_app");
+        assertTrue(appDir.mkdirs());
+
+        Files.writeString(new File(appDir, "app.pro").toPath(), "-keep class Legacy");
+        assertFalse(Extender.shouldGenerateAaptMainDexRules(uploadDir, 19));
+
+        Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class Current");
+        assertTrue(Extender.shouldGenerateAaptMainDexRules(uploadDir, 19));
+        assertTrue(Extender.shouldGenerateAaptMainDexRules(uploadDir, 20));
+        assertFalse(Extender.shouldGenerateAaptMainDexRules(uploadDir, 21));
+        assertFalse(Extender.shouldGenerateAaptMainDexRules(uploadDir, 35));
+    }
+
+    @Test
+    public void testAndroidWithoutKeepDoesNotRequireR8Environment(@TempDir File tempDir) throws Exception {
+        File uploadDir = new File(tempDir, "upload");
+        File buildDir = new File(tempDir, "build");
+        assertTrue(uploadDir.mkdirs());
+        assertTrue(buildDir.mkdirs());
+        Map<String, String> env = createAndroidEnv();
+        env.remove("ANDROID_R8");
+        env.remove("ANDROID_R8_VERSION");
+
+        assertDoesNotThrow(() -> new Extender.Builder()
+                .setPlatform("armv7-android")
+                .setSdk(new File("test-data/sdk/a/defoldsdk"))
+                .setJobDirectory(tempDir)
+                .setUploadDirectory(uploadDir)
+                .setBuildDirectory(buildDir)
+                .setEnv(env)
+                .build());
+    }
+
+    @Test
+    public void testAndroidR8EnvironmentIsResolvedOnce(@TempDir File tempDir) throws Exception {
+        File uploadDir = new File(tempDir, "upload");
+        File appDir = new File(uploadDir, "_app");
+        File buildDir = new File(tempDir, "build");
+        assertTrue(appDir.mkdirs());
+        assertTrue(buildDir.mkdirs());
+        Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class Example");
+
+        Map<String, String> env = createAndroidEnv();
+        env.put("ANDROID_R8", "/opt/android/{{literal}}/r8.jar");
+        Extender extender = new Extender.Builder()
+                .setPlatform("armv7-android")
+                .setSdk(new File("test-data/sdk/a/defoldsdk"))
+                .setJobDirectory(tempDir)
+                .setUploadDirectory(uploadDir)
+                .setBuildDirectory(buildDir)
+                .setEnv(env)
+                .build();
+
+        assertEquals("/opt/android/{{literal}}/r8.jar", extender.getPlatformContext().get("env.R8"));
+
+        Map<String, Object> r8BuilderContext =
+                extender.createR8BuilderContext(extender.getMergedAppContext());
+        assertEquals("/opt/android/{{literal}}/r8.jar", r8BuilderContext.get("env.R8"));
+        assertEquals("8.13.19", r8BuilderContext.get("env.R8_VERSION"));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testLegacyAndroidSdkProguardConfigurationIsAcceptedAndIgnored(@TempDir File tempDir) throws Exception {
+        String buildYaml = Files.readString(
+                new File("test-data/sdk/a/defoldsdk/extender/build.yml").toPath());
+        buildYaml = buildYaml
+                .replace("        R8:                       \"{{env.ANDROID_R8}}\"\n", "")
+                .replace("        R8_VERSION:               \"{{env.ANDROID_R8_VERSION}}\"\n", "")
+                .replace(
+                        "        LIBRARYJAR:               \"{{env.ANDROID_LIBRARYJAR}}\"\n",
+                        "        PROGUARD:                 \"{{env.ANDROID_PROGUARD}}\"\n"
+                                + "        LIBRARYJAR:               \"{{env.ANDROID_LIBRARYJAR}}\"\n")
+                .replace(
+                        "    r8Cmd: 'java -cp \"{{{env.R8}}}\" com.android.tools.r8.R8 --release --min-api {{minAndroidSdkVersion}} --lib \"{{{env.LIBRARYJAR}}}\" {{#useMainDexRules}}{{#mainDexRules}}--main-dex-rules \"{{{.}}}\" {{/mainDexRules}}{{/useMainDexRules}}--pg-map-output \"{{{mapping}}}\" --no-data-resources --output \"{{{classes_dex_dir}}}\" {{#rules}}--pg-conf \"{{{.}}}\" {{/rules}} {{#jars}}\"{{{.}}}\" {{/jars}}'\n"
+                                + "    r8Version: '{{env.R8_VERSION}}'\n"
+                                + "    r8RuleSourceRe: '(?i).+(\\.keep)$'\n",
+                        "    proGuardCmd: 'legacy-proguard-command'\n"
+                                + "    proGuardSourceRe: '(?i).+(\\.pro)$'\n")
+                .replace(
+                        " {{#useR8}}--proguard \"{{{aaptKeepRules}}}\" {{/useR8}}"
+                                + "{{#useR8MainDexRules}}--proguard-main-dex \"{{{aaptMainDexRules}}}\" {{/useR8MainDexRules}}",
+                        " ");
+
+        File sdk = new File(tempDir, "legacy-sdk");
+        File sdkExtenderDir = new File(sdk, "extender");
+        assertTrue(sdkExtenderDir.mkdirs());
+        File buildFile = new File(sdkExtenderDir, "build.yml");
+        Files.writeString(buildFile.toPath(), buildYaml);
+
+        Configuration config = Extender.loadYaml(tempDir, buildFile, Configuration.class);
+        PlatformConfig android = mergePlatformConfig(config, "armv7-android");
+        assertEquals("legacy-proguard-command", android.proGuardCmd);
+        assertEquals("(?i).+(\\.pro)$", android.proGuardSourceRe);
+        assertEquals("{{env.ANDROID_PROGUARD}}", android.env.get("PROGUARD"));
+        assertNull(android.r8Cmd);
+        assertFalse(android.aapt2linkCmd.contains("useR8"));
+        assertFalse(android.aapt2linkCmd.contains("aaptKeepRules"));
+        assertFalse(android.aapt2linkCmd.contains("aaptMainDexRules"));
+        assertFalse(android.aapt2linkCmd.contains("--proguard"));
+
+        File uploadWithoutProguard = new File(tempDir, "upload-without-proguard");
+        File buildWithoutProguard = new File(tempDir, "build-without-proguard");
+        assertTrue(uploadWithoutProguard.mkdirs());
+        assertTrue(buildWithoutProguard.mkdirs());
+        assertFalse(R8Builder.isRequested(uploadWithoutProguard));
+
+        assertDoesNotThrow(() -> new Extender.Builder()
+                .setPlatform("armv7-android")
+                .setSdk(sdk)
+                .setJobDirectory(tempDir)
+                .setUploadDirectory(uploadWithoutProguard)
+                .setBuildDirectory(buildWithoutProguard)
+                .setEnv(createAndroidEnv())
+                .build());
+
+        File uploadWithProguard = new File(tempDir, "upload-with-proguard");
+        File appDir = new File(uploadWithProguard, "_app");
+        File buildWithProguard = new File(tempDir, "build-with-proguard");
+        assertTrue(appDir.mkdirs());
+        assertTrue(buildWithProguard.mkdirs());
+        Files.writeString(new File(appDir, "app.pro").toPath(), "-keep class Legacy");
+        assertFalse(R8Builder.isRequested(uploadWithProguard));
+
+        assertDoesNotThrow(() -> new Extender.Builder()
+                .setPlatform("armv7-android")
+                .setSdk(sdk)
+                .setJobDirectory(tempDir)
+                .setUploadDirectory(uploadWithProguard)
+                .setBuildDirectory(buildWithProguard)
+                .setEnv(createAndroidEnv())
+                .build());
+    }
+
+    @Test
+    public void testConsumerRulesAreNotCopiedAsRuntimeMetaInfResources() {
+        assertFalse(ExtenderUtil.isMetaInfEntryValuable(new ZipEntry("META-INF/proguard/rules.pro")));
+        assertFalse(ExtenderUtil.isMetaInfEntryValuable(new ZipEntry("META-INF/proguard/rules.keep")));
+        assertFalse(ExtenderUtil.isMetaInfEntryValuable(new ZipEntry("META-INF/com.android.tools/r8/rules.keep")));
+        assertFalse(ExtenderUtil.isMetaInfEntryValuable(new ZipEntry(
+                "META-INF/com.android.tools/r8-from-0.0.0-arbitrary/rules.pro")));
+        assertTrue(ExtenderUtil.isMetaInfEntryValuable(new ZipEntry(
+                "META-INF/com.android.tools/r8foo/not-a-rule.txt")));
+        assertTrue(ExtenderUtil.isMetaInfEntryValuable(new ZipEntry(
+                "META-INF/com.android.tools/lint/model.xml")));
+        assertTrue(ExtenderUtil.isMetaInfEntryValuable(new ZipEntry("META-INF/services/com.example.Service")));
+        assertTrue(ExtenderUtil.isMetaInfEntryValuable(new ZipEntry("META-INF/example/info.pro")));
     }
 
     // An .aar in an extension is unpacked into the same exploded layout as a Maven resolved .aar:
@@ -292,6 +475,18 @@ public class ExtenderTest {
         assertTrue(new File(unpacked, "res/values/strings.xml").exists());
         assertTrue(new File(unpacked, "assets/local_aar.txt").exists());
         assertTrue(new File(unpacked, "AndroidManifest.xml").exists());
+
+        List<String> extensionOwnedJars = extender.getExtensionLocalAarJars(extDir);
+        assertEquals(
+                List.of(
+                        new File(unpacked, "classes.jar").getAbsolutePath(),
+                        new File(unpacked, "libs/InnerJar.jar").getAbsolutePath()),
+                extensionOwnedJars);
+        R8Builder.ExtensionContext r8Context = R8Builder.createExtensionContext(
+                extDir,
+                extensionOwnedJars,
+                "(?i).+(\\.keep)$");
+        assertEquals(extensionOwnedJars, r8Context.protectedJars);
 
         FileUtils.deleteQuietly(jobDir);
     }

--- a/server/src/test/java/com/defold/extender/ExtenderTest.java
+++ b/server/src/test/java/com/defold/extender/ExtenderTest.java
@@ -342,56 +342,6 @@ public class ExtenderTest {
         assertEquals(List.of(new File("manifests/android/extension.keep")), rules);
     }
 
-    // Verifies that an Android build without _app/app.keep can initialize without any R8 path or version in the environment.
-    @Test
-    public void testAndroidWithoutKeepDoesNotRequireR8Environment(@TempDir File tempDir) throws Exception {
-        File uploadDir = new File(tempDir, "upload");
-        File buildDir = new File(tempDir, "build");
-        assertTrue(uploadDir.mkdirs());
-        assertTrue(buildDir.mkdirs());
-        Map<String, String> env = createAndroidEnv();
-        env.remove("ANDROID_R8");
-        env.remove("ANDROID_R8_VERSION");
-
-        assertDoesNotThrow(() -> new Extender.Builder()
-                .setPlatform("armv7-android")
-                .setSdk(new File("test-data/sdk/a/defoldsdk"))
-                .setJobDirectory(tempDir)
-                .setUploadDirectory(uploadDir)
-                .setBuildDirectory(buildDir)
-                .setEnv(env)
-                .build());
-    }
-
-    // Verifies that resolved R8 environment values are carried literally into the command context without a second template pass.
-    @Test
-    public void testAndroidR8EnvironmentIsResolvedOnce(@TempDir File tempDir) throws Exception {
-        File uploadDir = new File(tempDir, "upload");
-        File appDir = new File(uploadDir, "_app");
-        File buildDir = new File(tempDir, "build");
-        assertTrue(appDir.mkdirs());
-        assertTrue(buildDir.mkdirs());
-        Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class Example");
-
-        Map<String, String> env = createAndroidEnv();
-        env.put("ANDROID_R8", "/opt/android/{{literal}}/r8.jar");
-        Extender extender = new Extender.Builder()
-                .setPlatform("armv7-android")
-                .setSdk(new File("test-data/sdk/a/defoldsdk"))
-                .setJobDirectory(tempDir)
-                .setUploadDirectory(uploadDir)
-                .setBuildDirectory(buildDir)
-                .setEnv(env)
-                .build();
-
-        assertEquals("/opt/android/{{literal}}/r8.jar", extender.getPlatformContext().get("env.R8"));
-
-        Map<String, Object> r8BuilderContext =
-                extender.createR8BuilderContext(extender.getMergedAppContext());
-        assertEquals("/opt/android/{{literal}}/r8.jar", r8BuilderContext.get("env.R8"));
-        assertEquals("8.13.19", r8BuilderContext.get("env.R8_VERSION"));
-    }
-
     // Verifies that legacy ProGuard-era SDK YAML still loads while app.pro remains ignored and does not request R8.
     @Test
     @SuppressWarnings("deprecation")
@@ -464,7 +414,7 @@ public class ExtenderTest {
                 .build());
     }
 
-    // Verifies that embedded consumer-rule entries are excluded from runtime META-INF copying without excluding unrelated metadata.
+    // Verifies that consumer rules and legacy .pro metadata are excluded from runtime META-INF copying.
     @Test
     public void testConsumerRulesAreNotCopiedAsRuntimeMetaInfResources() {
         assertFalse(ExtenderUtil.isMetaInfEntryValuable(new ZipEntry("META-INF/proguard/rules.pro")));
@@ -477,7 +427,7 @@ public class ExtenderTest {
         assertTrue(ExtenderUtil.isMetaInfEntryValuable(new ZipEntry(
                 "META-INF/com.android.tools/lint/model.xml")));
         assertTrue(ExtenderUtil.isMetaInfEntryValuable(new ZipEntry("META-INF/services/com.example.Service")));
-        assertTrue(ExtenderUtil.isMetaInfEntryValuable(new ZipEntry("META-INF/example/info.pro")));
+        assertFalse(ExtenderUtil.isMetaInfEntryValuable(new ZipEntry("META-INF/example/info.pro")));
     }
 
     // An .aar in an extension is unpacked into the same exploded layout as a Maven resolved .aar:

--- a/server/src/test/java/com/defold/extender/IntegrationTest.java
+++ b/server/src/test/java/com/defold/extender/IntegrationTest.java
@@ -20,6 +20,7 @@ import org.springframework.boot.logging.LogLevel;
 import org.springframework.boot.logging.LoggingSystem;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -30,6 +31,8 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -38,6 +41,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+import java.util.jar.JarOutputStream;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
 
 @Tag("integration")
 @Execution(ExecutionMode.SAME_THREAD)
@@ -479,7 +486,7 @@ public class IntegrationTest {
         doBuild(sourceFiles, configuration);
     }
 
-    private boolean checkClassesDexClasses(File buildZip, List<String> classes) throws IOException {
+    private Set<String> getClassesDexClasses(File buildZip) throws IOException {
         Set<String> dexClasses = new HashSet<>();
 
         try (ZipFile zipFile = new ZipFile(buildZip)) {
@@ -503,6 +510,12 @@ public class IntegrationTest {
             }
         }
 
+        return dexClasses;
+    }
+
+    private boolean checkClassesDexClasses(File buildZip, List<String> classes) throws IOException {
+        Set<String> dexClasses = getClassesDexClasses(buildZip);
+
         for (String cls : classes) {
             if (!dexClasses.contains(cls)) {
                 System.err.println(String.format("Missing class %s", cls));
@@ -510,6 +523,170 @@ public class IntegrationTest {
             }
         }
         return true;
+    }
+
+    private Path createGradleHandoffClassifierJar(Path fixtureDirectory) throws IOException {
+        Path source = fixtureDirectory.resolve("android/support/annotation/Nullable.java");
+        Path classes = fixtureDirectory.resolve("classifier-classes");
+        Files.createDirectories(source.getParent());
+        Files.createDirectories(classes);
+        Files.writeString(
+                source,
+                "package android.support.annotation;\n" +
+                "public @interface Nullable {}\n",
+                StandardCharsets.UTF_8);
+
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        assertNotNull(compiler, "The integration test requires a JDK");
+        assertEquals(
+                0,
+                compiler.run(
+                        null,
+                        null,
+                        null,
+                        "--release",
+                        "8",
+                        "-d",
+                        classes.toString(),
+                        source.toString()));
+
+        Path outputJar = fixtureDirectory.resolve("handoff-1.0-extras.jar");
+        try (ZipFile sourceJar = new ZipFile("test-data/ext/lib/android/JarDep.jar");
+             OutputStream fileOutput = Files.newOutputStream(outputJar);
+             JarOutputStream jarOutput = new JarOutputStream(fileOutput)) {
+            ZipEntry jarDependency = sourceJar.getEntry("com/defold/JarDep.class");
+            assertNotNull(jarDependency);
+            jarOutput.putNextEntry(new ZipEntry(jarDependency.getName()));
+            try (InputStream input = sourceJar.getInputStream(jarDependency)) {
+                input.transferTo(jarOutput);
+            }
+            jarOutput.closeEntry();
+
+            Path nullableClass = classes.resolve("android/support/annotation/Nullable.class");
+            jarOutput.putNextEntry(new ZipEntry("android/support/annotation/Nullable.class"));
+            Files.copy(nullableClass, jarOutput);
+            jarOutput.closeEntry();
+        }
+        return outputJar;
+    }
+
+    private TestConfiguration latestAndroidConfiguration() {
+        return data().stream()
+                .filter(configuration -> configuration.platform.endsWith("-android"))
+                .max(Comparator
+                        .comparingInt((TestConfiguration configuration) -> configuration.version.version.major)
+                        .thenComparingInt(configuration -> configuration.version.version.middle)
+                        .thenComparingInt(configuration -> configuration.version.version.minor)
+                        .thenComparing(configuration -> configuration.platform))
+                .orElseThrow(() -> new IllegalArgumentException("No Android integration configuration selected"));
+    }
+
+    private List<ExtenderResource> gradleArtifactHandoffResources(
+            Path fixtureDirectory,
+            TestConfiguration configuration,
+            boolean useJetifier) throws IOException {
+        Path repositoryVersion = fixtureDirectory.resolve("repo/com/defold/test/handoff/1.0");
+        Files.createDirectories(repositoryVersion);
+        Path aar = repositoryVersion.resolve("handoff-1.0.aar");
+        Path classifierJar = repositoryVersion.resolve("handoff-1.0-extras.jar");
+        Path pom = repositoryVersion.resolve("handoff-1.0.pom");
+        Files.copy(
+                Path.of("test-data/ext/lib/android/LocalAar.aar"),
+                aar,
+                StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(
+                createGradleHandoffClassifierJar(fixtureDirectory),
+                classifierJar,
+                StandardCopyOption.REPLACE_EXISTING);
+        Files.writeString(
+                pom,
+                "<project xmlns=\"http://maven.apache.org/POM/4.0.0\">\n" +
+                "  <modelVersion>4.0.0</modelVersion>\n" +
+                "  <groupId>com.defold.test</groupId>\n" +
+                "  <artifactId>handoff</artifactId>\n" +
+                "  <version>1.0</version>\n" +
+                "  <packaging>aar</packaging>\n" +
+                "</project>\n",
+                StandardCharsets.UTF_8);
+
+        Path buildGradle = fixtureDirectory.resolve("build.gradle");
+        Files.writeString(
+                buildGradle,
+                "repositories {\n" +
+                "    maven { url uri(\"$rootDir/upload/ext/manifests/android/repo\") }\n" +
+                "}\n" +
+                "dependencies {\n" +
+                "    implementation 'com.defold.test:handoff:1.0@aar'\n" +
+                "    implementation 'com.defold.test:handoff:1.0:extras@jar'\n" +
+                "}\n",
+                StandardCharsets.UTF_8);
+        Path appManifest = fixtureDirectory.resolve("app.manifest");
+        Files.writeString(
+                appManifest,
+                "platforms:\n" +
+                "    android:\n" +
+                "        context:\n" +
+                "            jetifier: " + useJetifier + "\n",
+                StandardCharsets.UTF_8);
+
+        String repositoryZipRoot = "ext/manifests/android/repo/com/defold/test/handoff/1.0/";
+        return Lists.newArrayList(
+                new FileExtenderResource("test-data/AndroidManifest.xml", "AndroidManifest.xml"),
+                new FileExtenderResource("test-data/ext/ext.manifest"),
+                new FileExtenderResource("test-data/ext/src/test_ext.cpp"),
+                new FileExtenderResource("test-data/ext/src/TestGradleHandoff.java"),
+                new FileExtenderResource(
+                        String.format("test-data/ext/lib/%s/libalib.a", configuration.platform)),
+                new FileExtenderResource(buildGradle.toString(), "ext/manifests/android/build.gradle"),
+                new FileExtenderResource(appManifest.toString(), "_app/app.manifest"),
+                new FileExtenderResource(aar.toString(), repositoryZipRoot + aar.getFileName()),
+                new FileExtenderResource(
+                        classifierJar.toString(),
+                        repositoryZipRoot + classifierJar.getFileName()),
+                new FileExtenderResource(pom.toString(), repositoryZipRoot + pom.getFileName()));
+    }
+
+    @Test
+    public void buildAndroidGradleArtifactHandoff(@org.junit.jupiter.api.io.TempDir Path fixtureDirectory)
+            throws IOException, ExtenderClientException {
+        Set<String> selectedPlatforms = TestUtils.selectedPlatforms();
+        assumeTrue(
+                selectedPlatforms.isEmpty()
+                        || selectedPlatforms.stream().anyMatch(platform -> platform.endsWith("-android")),
+                "This test is only run when an Android target is selected");
+        TestConfiguration configuration = latestAndroidConfiguration();
+
+        for (boolean useJetifier : List.of(true, false)) {
+            Path buildFixture = Files.createDirectory(
+                    fixtureDirectory.resolve(useJetifier ? "jetifier-on" : "jetifier-off"));
+            File destination = doBuild(
+                    gradleArtifactHandoffResources(buildFixture, configuration, useJetifier),
+                    configuration);
+
+            Set<String> dexClasses = getClassesDexClasses(destination);
+            assertTrue(dexClasses.containsAll(List.of(
+                    "Lcom/defold/GradleHandoffTest;",
+                    "Lcom/defold/JarDep;",
+                    "Lcom/defold/localaar/InnerJar;",
+                    "Lcom/defold/localaar/LocalAar;",
+                    "Lcom/defold/localaar/R;")));
+            String expectedAnnotation = useJetifier
+                    ? "Landroidx/annotation/Nullable;"
+                    : "Landroid/support/annotation/Nullable;";
+            String unexpectedAnnotation = useJetifier
+                    ? "Landroid/support/annotation/Nullable;"
+                    : "Landroidx/annotation/Nullable;";
+            assertTrue(dexClasses.contains(expectedAnnotation));
+            assertFalse(dexClasses.contains(unexpectedAnnotation));
+            try (ZipFile zipFile = new ZipFile(destination)) {
+                assertNotNull(zipFile.getEntry("assets/local_aar.txt"));
+                assertTrue(zipFile.stream().anyMatch(entry ->
+                        entry.getName().startsWith("packages/")
+                                && entry.getName().endsWith("/res/values/strings.xml")));
+                assertNotNull(zipFile.getEntry("gradle.lockfile"));
+                assertNotNull(zipFile.getEntry("gradle.dependencytree"));
+            }
+        }
     }
 
     @ParameterizedTest(name = "[{index}] {displayName} {arguments}")

--- a/server/src/test/java/com/defold/extender/IntegrationTest.java
+++ b/server/src/test/java/com/defold/extender/IntegrationTest.java
@@ -646,6 +646,7 @@ public class IntegrationTest {
                 new FileExtenderResource(pom.toString(), repositoryZipRoot + pom.getFileName()));
     }
 
+    // Verifies that AAR and classifier-JAR artifacts survive Gradle handoff, Jetifier selection, dexing, and packaging end to end.
     @Test
     public void buildAndroidGradleArtifactHandoff(@org.junit.jupiter.api.io.TempDir Path fixtureDirectory)
             throws IOException, ExtenderClientException {

--- a/server/src/test/java/com/defold/extender/IntegrationTest.java
+++ b/server/src/test/java/com/defold/extender/IntegrationTest.java
@@ -680,9 +680,8 @@ public class IntegrationTest {
             assertFalse(dexClasses.contains(unexpectedAnnotation));
             try (ZipFile zipFile = new ZipFile(destination)) {
                 assertNotNull(zipFile.getEntry("assets/local_aar.txt"));
-                assertTrue(zipFile.stream().anyMatch(entry ->
-                        entry.getName().startsWith("packages/")
-                                && entry.getName().endsWith("/res/values/strings.xml")));
+                assertNotNull(zipFile.getEntry(
+                        "packages/com.defold.test-handoff-1.0.aar/res/values/strings.xml"));
                 assertNotNull(zipFile.getEntry("gradle.lockfile"));
                 assertNotNull(zipFile.getEntry("gradle.dependencytree"));
             }

--- a/server/src/test/java/com/defold/extender/R8BuilderTest.java
+++ b/server/src/test/java/com/defold/extender/R8BuilderTest.java
@@ -130,13 +130,13 @@ public class R8BuilderTest {
         return bytes.toByteArray();
     }
 
-    private static byte[] createOversizedClassFileHeader() throws IOException {
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream(R8Builder.MAX_CLASSFILE_HEADER_BYTES + 65536);
+    private static byte[] createOversizedClassFileHeader(int maxClassfileHeaderBytes) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream(maxClassfileHeaderBytes + 65536);
         try (DataOutputStream output = new DataOutputStream(bytes)) {
             output.writeInt(0xCAFEBABE);
             output.writeShort(0);
             output.writeShort(52);
-            int utf8Count = R8Builder.MAX_CLASSFILE_HEADER_BYTES / 65538 + 2;
+            int utf8Count = maxClassfileHeaderBytes / 65538 + 2;
             output.writeShort(utf8Count + 1);
             String padding = "a".repeat(65535);
             for (int index = 0; index < utf8Count; ++index) {
@@ -204,6 +204,7 @@ public class R8BuilderTest {
                 List.of(),
                 new HashMap<>(),
                 21,
+                new R8Configuration(),
                 new TemplateExecutor(),
                 (command, context) -> {
                     throw new AssertionError("R8 command must not execute without app.keep");
@@ -294,6 +295,7 @@ public class R8BuilderTest {
                 List.of(),
                 new HashMap<>(),
                 21,
+                new R8Configuration(),
                 new TemplateExecutor(),
                 (command, context) -> commandExecuted[0] = true);
 
@@ -329,6 +331,7 @@ public class R8BuilderTest {
                 List.of(),
                 new HashMap<>(),
                 24,
+                new R8Configuration(),
                 new TemplateExecutor(),
                 (command, context) -> commandExecuted[0] = true);
 
@@ -356,6 +359,7 @@ public class R8BuilderTest {
                 List.of(),
                 new HashMap<>(),
                 21,
+                new R8Configuration(),
                 new TemplateExecutor(),
                 (command, context) -> {
                     throw new AssertionError("R8 command must not execute with missing configuration");
@@ -393,6 +397,7 @@ public class R8BuilderTest {
                 List.of(),
                 commandContext,
                 21,
+                new R8Configuration(),
                 new TemplateExecutor(),
                 (command, context) -> {
                     throw new AssertionError("R8 command must not execute with unresolved configuration");
@@ -821,14 +826,22 @@ public class R8BuilderTest {
     @Test
     public void testGeneratedRulesBoundClassFileHeaderDecompression(@TempDir File tempDir)
             throws Exception {
+        R8Configuration r8Configuration = new R8Configuration();
+        r8Configuration.setMaxClassfileHeaderBytes(1024);
         File jar = createJarWithBytes(
                 new File(tempDir, "oversized-class-header.jar"),
-                Map.of("p/Oversized.class", createOversizedClassFileHeader()));
+                Map.of(
+                        "p/Oversized.class",
+                        createOversizedClassFileHeader(
+                                r8Configuration.getMaxClassfileHeaderBytes())));
         File output = new File(tempDir, "generated.keep");
 
         ExtenderException exception = assertThrows(
                 ExtenderException.class,
-                () -> R8Builder.writeProtectedJarKeepRules(List.of(jar.getAbsolutePath()), output));
+                () -> R8Builder.writeProtectedJarKeepRules(
+                        List.of(jar.getAbsolutePath()),
+                        output,
+                        r8Configuration));
 
         assertTrue(exception.getMessage().contains("Class file header exceeds"));
         assertFalse(output.exists());
@@ -838,9 +851,13 @@ public class R8BuilderTest {
     @Test
     public void testGeneratedRuleClassCountIsBoundedDuringJarEnumeration(@TempDir File tempDir)
             throws Exception {
+        R8Configuration r8Configuration = new R8Configuration();
+        r8Configuration.setMaxGeneratedExtensionClasses(3);
         Map<String, byte[]> entries = new LinkedHashMap<>();
         byte[] classFile = createMinimalClassFile("p/Repeated");
-        for (int index = 0; index <= R8Builder.MAX_GENERATED_EXTENSION_CLASSES; ++index) {
+        for (int index = 0;
+                index <= r8Configuration.getMaxGeneratedExtensionClasses();
+                ++index) {
             entries.put(String.format("p/C%05d.class", index), classFile);
         }
         File jar = createJarWithBytes(new File(tempDir, "too-many-classes.jar"), entries);
@@ -848,7 +865,10 @@ public class R8BuilderTest {
 
         ExtenderException exception = assertThrows(
                 ExtenderException.class,
-                () -> R8Builder.writeProtectedJarKeepRules(List.of(jar.getAbsolutePath()), output));
+                () -> R8Builder.writeProtectedJarKeepRules(
+                        List.of(jar.getAbsolutePath()),
+                        output,
+                        r8Configuration));
 
         assertTrue(exception.getMessage().contains("Too many classes"));
         assertFalse(output.exists());
@@ -858,9 +878,11 @@ public class R8BuilderTest {
     @Test
     public void testGeneratedRuleBytesAreBoundedDuringJarEnumeration(@TempDir File tempDir)
             throws Exception {
+        R8Configuration r8Configuration = new R8Configuration();
+        r8Configuration.setMaxRuleFileBytes(512);
         Map<String, byte[]> entries = new LinkedHashMap<>();
-        String longName = "a".repeat(6000);
-        for (int index = 0; index < 200; ++index) {
+        String longName = "a".repeat(200);
+        for (int index = 0; index < 3; ++index) {
             String internalName = String.format("p/C%03d%s", index, longName);
             entries.put(internalName + ".class", createMinimalClassFile(internalName));
         }
@@ -869,7 +891,10 @@ public class R8BuilderTest {
 
         ExtenderException exception = assertThrows(
                 ExtenderException.class,
-                () -> R8Builder.writeProtectedJarKeepRules(List.of(jar.getAbsolutePath()), output));
+                () -> R8Builder.writeProtectedJarKeepRules(
+                        List.of(jar.getAbsolutePath()),
+                        output,
+                        r8Configuration));
 
         assertTrue(exception.getMessage().contains("Generated R8 keep rules are too large"));
         assertFalse(output.exists());
@@ -964,6 +989,7 @@ public class R8BuilderTest {
                 List.of(dependencyAar),
                 new HashMap<>(),
                 24,
+                new R8Configuration(),
                 new TemplateExecutor(),
                 (command, context) -> {
                     assertTrue(command.startsWith("r8-command "));
@@ -1178,15 +1204,20 @@ public class R8BuilderTest {
     // Verifies that the number of embedded consumer-rule files is bounded before extraction.
     @Test
     public void testEmbeddedRuleEntryCountIsBounded(@TempDir File tempDir) throws Exception {
+        R8Configuration r8Configuration = new R8Configuration();
+        r8Configuration.setMaxRuleFiles(3);
         Map<String, String> entries = new LinkedHashMap<>();
-        for (int index = 0; index <= R8RulePolicy.MAX_RULE_FILES; ++index) {
+        for (int index = 0; index <= r8Configuration.getMaxRuleFiles(); ++index) {
             entries.put(String.format("META-INF/proguard/rule-%04d.pro", index), "-keep class Example");
         }
         File jar = createJar(new File(tempDir, "too-many-rules.jar"), entries);
 
         ExtenderException exception = assertThrows(
                 ExtenderException.class,
-                () -> R8Builder.selectEmbeddedRuleEntries(jar, "8.13.19"));
+                () -> R8Builder.selectEmbeddedRuleEntries(
+                        jar,
+                        "8.13.19",
+                        r8Configuration));
 
         assertTrue(exception.getMessage().contains("Too many embedded R8 rule files"));
     }
@@ -1194,7 +1225,9 @@ public class R8BuilderTest {
     // Verifies that expanded embedded rule data is size-bounded and leaves no partial extracted files on failure.
     @Test
     public void testEmbeddedRuleExpandedSizeIsBounded(@TempDir File tempDir) throws Exception {
-        String oversizedRule = " ".repeat((int) R8RulePolicy.MAX_RULE_FILE_BYTES + 1);
+        R8Configuration r8Configuration = new R8Configuration();
+        r8Configuration.setMaxRuleFileBytes(32);
+        String oversizedRule = " ".repeat((int) r8Configuration.getMaxRuleFileBytes() + 1);
         File jar = createJar(
                 new File(tempDir, "oversized-rule.jar"),
                 Map.of("META-INF/proguard/oversized.pro", oversizedRule));
@@ -1206,7 +1239,8 @@ public class R8BuilderTest {
                         List.of(jar.getAbsolutePath()),
                         List.of(),
                         "8.13.19",
-                        outputDir));
+                        outputDir,
+                        r8Configuration));
 
         assertTrue(exception.getMessage().contains("R8 rule file is too large"));
         assertEquals(0, outputDir.listFiles().length);

--- a/server/src/test/java/com/defold/extender/R8BuilderTest.java
+++ b/server/src/test/java/com/defold/extender/R8BuilderTest.java
@@ -763,6 +763,33 @@ public class R8BuilderTest {
     }
 
     @Test
+    public void testAndroidPackageJarsSupportLocalAndAgpExplodedLayouts(@TempDir File tempDir)
+            throws Exception {
+        File localAar = new File(tempDir, "local.aar");
+        assertTrue(new File(localAar, "libs").mkdirs());
+        File localClasses = new File(localAar, "classes.jar");
+        File localLibrary = new File(localAar, "libs/local-library.jar");
+        Files.writeString(localClasses.toPath(), "classes");
+        Files.writeString(localLibrary.toPath(), "library");
+
+        File explodedAar = new File(tempDir, "jetified-library");
+        assertTrue(new File(explodedAar, "jars/libs").mkdirs());
+        File explodedClasses = new File(explodedAar, "jars/classes.jar");
+        File explodedLibrary = new File(explodedAar, "jars/libs/embedded-library.jar");
+        Files.writeString(explodedClasses.toPath(), "classes");
+        Files.writeString(explodedLibrary.toPath(), "library");
+
+        assertEquals(localClasses, R8Builder.getAndroidPackageClassesJar(localAar));
+        assertEquals(explodedClasses, R8Builder.getAndroidPackageClassesJar(explodedAar));
+        assertEquals(
+                List.of(localClasses.getAbsolutePath(), localLibrary.getAbsolutePath()),
+                R8Builder.getAndroidPackageJars(localAar));
+        assertEquals(
+                List.of(explodedClasses.getAbsolutePath(), explodedLibrary.getAbsolutePath()),
+                R8Builder.getAndroidPackageJars(explodedAar));
+    }
+
+    @Test
     public void testCollectJarAndAarConsumerRulesDeterministically(@TempDir File tempDir) throws Exception {
         File standaloneJar = createJar(
                 new File(tempDir, "standalone.jar"),
@@ -770,10 +797,10 @@ public class R8BuilderTest {
                         "META-INF/proguard/legacy.pro", "-keep class JarLegacy",
                         "META-INF/com.android.tools/r8-from-8.0.0/rules.keep", "-keep class JarTarget"));
 
-        File targetedAar = new File(tempDir, "targeted.aar");
-        assertTrue(targetedAar.mkdirs());
+        File targetedAar = new File(tempDir, "jetified-targeted");
+        assertTrue(new File(targetedAar, "jars").mkdirs());
         File targetedClasses = createJar(
-                new File(targetedAar, "classes.jar"),
+                new File(targetedAar, "jars/classes.jar"),
                 Map.of("META-INF/com.android.tools/r8/rules.keep", "-keep class AarTarget"));
         Files.writeString(new File(targetedAar, "proguard.txt").toPath(), "-keep class AarRootIgnored");
 
@@ -793,7 +820,7 @@ public class R8BuilderTest {
         }
 
         assertEquals(
-                List.of("-keep class JarTarget", "-keep class AarTarget", "-keep class AarLegacy"),
+                List.of("-keep class AarTarget", "-keep class JarTarget", "-keep class AarLegacy"),
                 contents);
     }
 

--- a/server/src/test/java/com/defold/extender/R8BuilderTest.java
+++ b/server/src/test/java/com/defold/extender/R8BuilderTest.java
@@ -169,51 +169,6 @@ public class R8BuilderTest {
         return new File(firstLine.substring(quoteStart + 1, quoteEnd));
     }
 
-    private static String buildAndRenderR8Command(File tempDir, int minAndroidSdkVersion) throws Exception {
-        File uploadDir = new File(tempDir, "upload");
-        File appDir = new File(uploadDir, "_app");
-        File buildDir = new File(tempDir, "build");
-        assertTrue(appDir.mkdirs());
-        assertTrue(buildDir.mkdirs());
-        Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class App");
-        File aaptRules = new File(buildDir, "aapt-generated.keep");
-        Files.writeString(aaptRules.toPath(), "-keep class AaptGenerated");
-        File mainDexRules = new File(tempDir, "main-dex.keep");
-        Files.writeString(mainDexRules.toPath(), "-keep class Main");
-        File aaptMainDexRules = null;
-        if (minAndroidSdkVersion < 21) {
-            aaptMainDexRules = new File(buildDir, "aapt-main-dex-generated.keep");
-            Files.writeString(aaptMainDexRules.toPath(), "-keep class AaptMainDex");
-        }
-
-        PlatformConfig config = new PlatformConfig();
-        config.r8Cmd = "r8 {{#useMainDexRules}}{{#mainDexRules}}--main-dex-rules \"{{{.}}}\" {{/mainDexRules}}{{/useMainDexRules}}--output \"{{{classes_dex_dir}}}\"";
-        config.r8Version = "8.13.19";
-        Map<String, String> captured = new HashMap<>();
-        R8Builder builder = new R8Builder(
-                uploadDir,
-                buildDir,
-                config,
-                List.of(),
-                new HashMap<>(),
-                minAndroidSdkVersion,
-                new TemplateExecutor(),
-                (command, context) -> {
-                    captured.put("command", command);
-                    try {
-                        Files.writeString(
-                                new File((String) context.get("classes_dex_dir"), "classes.dex").toPath(),
-                                "dex");
-                        Files.writeString(new File((String) context.get("mapping")).toPath(), "mapping");
-                    } catch (IOException e) {
-                        throw new ExtenderException(e, "Failed to create fake R8 outputs");
-                    }
-                });
-
-        builder.build(List.of(), Map.of(), mainDexRules, aaptRules, aaptMainDexRules);
-        return captured.get("command");
-    }
-
     // Verifies that only _app/app.keep opts into R8; app.pro and extension consumer rules alone do not.
     @Test
     public void testOnlyAppKeepRequestsR8(@TempDir File uploadDir) throws Exception {
@@ -240,8 +195,6 @@ public class R8BuilderTest {
         File buildDir = new File(tempDir, "build");
         assertTrue(uploadDir.mkdirs());
         assertTrue(buildDir.mkdirs());
-        File mainDexRules = new File(tempDir, "main-dex.keep");
-        Files.writeString(mainDexRules.toPath(), "-keep class Main");
         PlatformConfig config = new PlatformConfig();
 
         R8Builder builder = new R8Builder(
@@ -250,45 +203,13 @@ public class R8BuilderTest {
                 config,
                 List.of(),
                 new HashMap<>(),
-                19,
+                21,
                 new TemplateExecutor(),
                 (command, context) -> {
                     throw new AssertionError("R8 command must not execute without app.keep");
                 });
 
-        assertNull(builder.build(List.of(), Map.of(), mainDexRules, null, null));
-    }
-
-    // Verifies that pre-21 builds pass sanitized engine and aapt main-dex rules while API 21+ builds pass none.
-    @Test
-    public void testMainDexRulesAreOnlyPassedBelowApi21(@TempDir File tempDir) throws Exception {
-        File api19Dir = new File(tempDir, "api19");
-        File api21Dir = new File(tempDir, "api21");
-        assertTrue(api19Dir.mkdirs());
-        assertTrue(api21Dir.mkdirs());
-
-        String api19Command = buildAndRenderR8Command(api19Dir, 19);
-        String api21Command = buildAndRenderR8Command(api21Dir, 21);
-
-        assertEquals(
-                2,
-                CommandLineTokenizer.parse(api19Command).stream()
-                        .filter("--main-dex-rules"::equals)
-                        .count());
-        List<String> api19Arguments = CommandLineTokenizer.parse(api19Command);
-        assertTrue(api19Arguments.contains(new File(api19Dir, "main-dex.keep").getAbsolutePath()));
-        assertFalse(api19Arguments.contains(
-                new File(api19Dir, "build/aapt-main-dex-generated.keep").getAbsolutePath()));
-        assertTrue(api19Arguments.stream().anyMatch(
-                argument -> argument.endsWith(new File(
-                        "r8-sanitized-rules",
-                        "aapt-main-dex-generated.keep").getPath())));
-        File sanitizedAaptMainDexRules = new File(
-                api19Dir,
-                "build/r8-sanitized-rules/aapt-main-dex-generated.keep");
-        assertEquals("-keep class AaptMainDex", sanitizedRuleBody(sanitizedAaptMainDexRules));
-        assertEquals(0, sanitizedRuleBase(sanitizedAaptMainDexRules).listFiles().length);
-        assertFalse(api21Command.contains("--main-dex-rules"));
+        assertNull(builder.build(List.of(), Map.of(), null));
     }
 
     // Verifies that R8/aapt commands preserve exact quoting and literals, conditional rule flags, and data resources.
@@ -304,20 +225,16 @@ public class R8BuilderTest {
 
         String r8Jar = "/tmp/R8 tools/{{literal}}/r8\\\"tool.jar";
         String androidJar = "/tmp/Android SDK/android\\lib.jar";
-        String mainDexRules = "/tmp/Main Dex/main\"dex.keep";
         String mapping = "/tmp/Output dir/mapping\\symbols.txt";
         String dexDir = "/tmp/Output dir/dex {{literal}} & files";
         String appRules = "/tmp/Rules dir/app\"rules.keep";
         String aaptRules = "/tmp/Rules dir/aapt&generated.keep";
-        String aaptMainDexRules = "/tmp/Main Dex/aapt&main.keep";
         String programJar = "/tmp/Program jars/game\\code.jar";
 
         Map<String, Object> context = new HashMap<>();
         context.put("env.R8", r8Jar);
         context.put("env.LIBRARYJAR", androidJar);
-        context.put("minAndroidSdkVersion", 19);
-        context.put("useMainDexRules", true);
-        context.put("mainDexRules", List.of(mainDexRules, aaptMainDexRules));
+        context.put("minAndroidSdkVersion", 21);
         context.put("mapping", mapping);
         context.put("classes_dex_dir", dexDir);
         context.put("rules", List.of(appRules, aaptRules));
@@ -333,8 +250,6 @@ public class R8BuilderTest {
         assertTrue(rendered.contains("{{literal}}"));
         assertTrue(arguments.contains(r8Jar));
         assertTrue(arguments.contains(androidJar));
-        assertTrue(arguments.contains(mainDexRules));
-        assertTrue(arguments.contains(aaptMainDexRules));
         assertTrue(arguments.contains(mapping));
         assertTrue(arguments.contains(dexDir));
         assertTrue(arguments.contains(appRules));
@@ -347,11 +262,9 @@ public class R8BuilderTest {
         context.put("outApkFile", "/tmp/Compiled resources/resources.apk");
         context.put("resourceIdsFile", "/tmp/Compiled resources/resource ids.txt");
         context.put("aaptKeepRules", aaptRules);
-        context.put("aaptMainDexRules", aaptMainDexRules);
         context.put("resourceListFile", "/tmp/Compiled resources/list.txt");
         context.put("extraPackages", "");
         context.put("useR8", false);
-        context.put("useR8MainDexRules", false);
         String d8AaptCommand = new TemplateExecutor().execute(android.aapt2linkCmd, context);
         assertFalse(d8AaptCommand.contains("--proguard"));
 
@@ -359,12 +272,6 @@ public class R8BuilderTest {
         String r8AaptCommand = new TemplateExecutor().execute(android.aapt2linkCmd, context);
         assertTrue(r8AaptCommand.contains("--proguard"));
         assertTrue(CommandLineTokenizer.parse(r8AaptCommand).contains(aaptRules));
-
-        context.put("useR8MainDexRules", true);
-        String pre21R8AaptCommand = new TemplateExecutor().execute(android.aapt2linkCmd, context);
-        List<String> aaptArguments = CommandLineTokenizer.parse(pre21R8AaptCommand);
-        assertTrue(aaptArguments.contains("--proguard-main-dex"));
-        assertTrue(aaptArguments.contains(aaptMainDexRules));
     }
 
     // Verifies that requested R8 builds fail before command execution when aapt-generated keep rules are missing.
@@ -376,10 +283,6 @@ public class R8BuilderTest {
         assertTrue(appDir.mkdirs());
         assertTrue(buildDir.mkdirs());
         Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class App");
-        File mainDexRules = new File(tempDir, "main-dex.keep");
-        Files.writeString(mainDexRules.toPath(), "-keep class Main");
-        File aaptMainDexRules = new File(buildDir, "aapt-main-dex-generated.keep");
-        Files.writeString(aaptMainDexRules.toPath(), "-keep class AaptMainDex");
         PlatformConfig config = new PlatformConfig();
         config.r8Cmd = "r8-command";
         config.r8Version = "8.13.19";
@@ -390,7 +293,7 @@ public class R8BuilderTest {
                 config,
                 List.of(),
                 new HashMap<>(),
-                19,
+                21,
                 new TemplateExecutor(),
                 (command, context) -> commandExecuted[0] = true);
 
@@ -399,49 +302,8 @@ public class R8BuilderTest {
                 () -> builder.build(
                         List.of(),
                         Map.of(),
-                        mainDexRules,
-                        new File(buildDir, "missing-aapt-generated.keep"),
-                        aaptMainDexRules));
+                        new File(buildDir, "missing-aapt-generated.keep")));
         assertTrue(exception.getMessage().contains("aapt-generated.keep"));
-        assertFalse(commandExecuted[0]);
-    }
-
-    // Verifies that pre-21 R8 builds fail before command execution when aapt main-dex rules are missing.
-    @Test
-    public void testMissingPre21AaptMainDexRulesIsAnError(@TempDir File tempDir) throws Exception {
-        File uploadDir = new File(tempDir, "upload");
-        File appDir = new File(uploadDir, "_app");
-        File buildDir = new File(tempDir, "build");
-        assertTrue(appDir.mkdirs());
-        assertTrue(buildDir.mkdirs());
-        Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class App");
-        File mainDexRules = new File(tempDir, "main-dex.keep");
-        Files.writeString(mainDexRules.toPath(), "-keep class Main");
-        File aaptRules = new File(buildDir, "aapt-generated.keep");
-        Files.writeString(aaptRules.toPath(), "-keep class AaptGenerated");
-        PlatformConfig config = new PlatformConfig();
-        config.r8Cmd = "r8-command";
-        config.r8Version = "8.13.19";
-        boolean[] commandExecuted = {false};
-        R8Builder builder = new R8Builder(
-                uploadDir,
-                buildDir,
-                config,
-                List.of(),
-                new HashMap<>(),
-                19,
-                new TemplateExecutor(),
-                (command, context) -> commandExecuted[0] = true);
-
-        ExtenderException exception = assertThrows(
-                ExtenderException.class,
-                () -> builder.build(
-                        List.of(),
-                        Map.of(),
-                        mainDexRules,
-                        aaptRules,
-                        new File(buildDir, "missing-aapt-main-dex-generated.keep")));
-        assertTrue(exception.getMessage().contains("aapt-main-dex-generated.keep"));
         assertFalse(commandExecuted[0]);
     }
 
@@ -472,49 +334,7 @@ public class R8BuilderTest {
 
         ExtenderException exception = assertThrows(
                 ExtenderException.class,
-                () -> builder.build(List.of(), Map.of(), null, aaptRules, null));
-
-        assertTrue(exception.getMessage().contains("forbidden filesystem directive"));
-        assertFalse(commandExecuted[0]);
-    }
-
-    // Verifies that aapt-generated main-dex rules pass the filesystem-directive policy before R8 can execute.
-    @Test
-    public void testAaptMainDexRulesUseFilesystemPolicy(@TempDir File tempDir) throws Exception {
-        File uploadDir = new File(tempDir, "upload");
-        File appDir = new File(uploadDir, "_app");
-        File buildDir = new File(tempDir, "build");
-        assertTrue(appDir.mkdirs());
-        assertTrue(buildDir.mkdirs());
-        Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class App");
-        File aaptRules = new File(buildDir, "aapt-generated.keep");
-        Files.writeString(aaptRules.toPath(), "-keep class AaptGenerated");
-        File mainDexRules = new File(tempDir, "main-dex.keep");
-        Files.writeString(mainDexRules.toPath(), "-keep class Main");
-        File aaptMainDexRules = new File(buildDir, "aapt-main-dex-generated.keep");
-        Files.writeString(aaptMainDexRules.toPath(), "}-include /etc/hosts");
-        PlatformConfig config = new PlatformConfig();
-        config.r8Cmd = "r8-command";
-        config.r8Version = "8.13.19";
-        boolean[] commandExecuted = {false};
-        R8Builder builder = new R8Builder(
-                uploadDir,
-                buildDir,
-                config,
-                List.of(),
-                new HashMap<>(),
-                19,
-                new TemplateExecutor(),
-                (command, context) -> commandExecuted[0] = true);
-
-        ExtenderException exception = assertThrows(
-                ExtenderException.class,
-                () -> builder.build(
-                        List.of(),
-                        Map.of(),
-                        mainDexRules,
-                        aaptRules,
-                        aaptMainDexRules));
+                () -> builder.build(List.of(), Map.of(), aaptRules));
 
         assertTrue(exception.getMessage().contains("forbidden filesystem directive"));
         assertFalse(commandExecuted[0]);
@@ -529,16 +349,13 @@ public class R8BuilderTest {
         assertTrue(appDir.mkdirs());
         assertTrue(buildDir.mkdirs());
         Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class App");
-        File mainDexRules = new File(tempDir, "main-dex.keep");
-        Files.writeString(mainDexRules.toPath(), "-keep class Main");
-
         R8Builder builder = new R8Builder(
                 uploadDir,
                 buildDir,
                 new PlatformConfig(),
                 List.of(),
                 new HashMap<>(),
-                19,
+                21,
                 new TemplateExecutor(),
                 (command, context) -> {
                     throw new AssertionError("R8 command must not execute with missing configuration");
@@ -546,7 +363,7 @@ public class R8BuilderTest {
 
         ExtenderException exception = assertThrows(
                 ExtenderException.class,
-                () -> builder.build(List.of(), Map.of(), mainDexRules, null, null));
+                () -> builder.build(List.of(), Map.of(), null));
         assertTrue(exception.getMessage().contains("does not provide r8Cmd and r8Version"));
         assertFalse(exception.getMessage().contains("aapt-generated.keep"));
     }
@@ -562,8 +379,6 @@ public class R8BuilderTest {
         Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class App");
         File aaptRules = new File(buildDir, "aapt-generated.keep");
         Files.writeString(aaptRules.toPath(), "-keep class AaptGenerated");
-        File mainDexRules = new File(tempDir, "main-dex.keep");
-        Files.writeString(mainDexRules.toPath(), "-keep class Main");
         PlatformConfig config = new PlatformConfig();
         config.env.put("R8", "{{env.ANDROID_R8}}");
         config.r8Cmd = "java -cp \"{{{env.R8}}}\" com.android.tools.r8.R8";
@@ -577,7 +392,7 @@ public class R8BuilderTest {
                 config,
                 List.of(),
                 commandContext,
-                19,
+                21,
                 new TemplateExecutor(),
                 (command, context) -> {
                     throw new AssertionError("R8 command must not execute with unresolved configuration");
@@ -585,7 +400,7 @@ public class R8BuilderTest {
 
         ExtenderException exception = assertThrows(
                 ExtenderException.class,
-                () -> builder.build(List.of(), Map.of(), mainDexRules, aaptRules, null));
+                () -> builder.build(List.of(), Map.of(), aaptRules));
         assertTrue(exception.getOutput().contains("does not provide r8Cmd and r8Version"));
     }
 
@@ -1136,8 +951,6 @@ public class R8BuilderTest {
                         "-keep class Dependency"));
         Files.writeString(new File(dependencyAar, "proguard.txt").toPath(), "-keep class Dependency");
 
-        File mainDexRules = new File(tempDir, "main-dex.keep");
-        Files.writeString(mainDexRules.toPath(), "-keep class Main");
         PlatformConfig config = new PlatformConfig();
         config.r8Cmd = "r8-command {{#jars}}\"{{{.}}}\" {{/jars}}";
         config.r8Version = "8.13.19";
@@ -1169,9 +982,7 @@ public class R8BuilderTest {
         R8Builder.BuildOutput output = builder.build(
                 List.of(extensionJar.getAbsolutePath(), dependencyJar.getAbsolutePath()),
                 Map.of(extensionJar.getAbsolutePath(), extensionContext),
-                mainDexRules,
-                aaptRules,
-                null);
+                aaptRules);
 
         assertNotNull(output);
         assertEquals(List.of("classes.dex"), Arrays.stream(output.dexFiles).map(File::getName).toList());
@@ -1201,7 +1012,7 @@ public class R8BuilderTest {
         assertFalse(assembledRules.contains(unselectedEngineRules.getAbsolutePath()));
         assertFalse(assembledRules.contains(extensionRules.getAbsolutePath()));
         assertFalse(assembledRules.stream().anyMatch(path -> path.endsWith("ignored.pro")));
-        assertFalse((Boolean) executedContext.get("useMainDexRules"));
+        assertFalse(executedContext.containsKey("mainDexRules"));
         List<File> sanitizedRules = assembledRules.stream()
                 .map(File::new)
                 .filter(rule -> {

--- a/server/src/test/java/com/defold/extender/R8BuilderTest.java
+++ b/server/src/test/java/com/defold/extender/R8BuilderTest.java
@@ -1,0 +1,1362 @@
+package com.defold.extender;
+
+import com.defold.extender.process.CommandLineTokenizer;
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.CRC32;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class R8BuilderTest {
+    private static final String KEEP_RULE_REGEX = "(?i).+(\\.keep)$";
+
+    private static File createJar(File jar, Map<String, String> entries) throws IOException {
+        try (ZipOutputStream output = new ZipOutputStream(new FileOutputStream(jar))) {
+            for (Map.Entry<String, String> entry : entries.entrySet()) {
+                output.putNextEntry(new ZipEntry(entry.getKey()));
+                output.write(entry.getValue().getBytes(StandardCharsets.UTF_8));
+                output.closeEntry();
+            }
+        }
+        return jar;
+    }
+
+    private static File createJarWithBytes(File jar, Map<String, byte[]> entries) throws IOException {
+        try (ZipOutputStream output = new ZipOutputStream(new FileOutputStream(jar))) {
+            for (Map.Entry<String, byte[]> entry : entries.entrySet()) {
+                output.putNextEntry(new ZipEntry(entry.getKey()));
+                output.write(entry.getValue());
+                output.closeEntry();
+            }
+        }
+        return jar;
+    }
+
+    private static File createJarWithDuplicateEntries(
+            File jar,
+            String entryName,
+            String firstContents,
+            String secondContents) throws IOException {
+        try (ZipArchiveOutputStream output = new ZipArchiveOutputStream(jar)) {
+            for (String contents : List.of(firstContents, secondContents)) {
+                byte[] bytes = contents.getBytes(StandardCharsets.UTF_8);
+                ZipArchiveEntry entry = new ZipArchiveEntry(entryName);
+                output.putArchiveEntry(entry);
+                output.write(bytes);
+                output.closeArchiveEntry();
+            }
+        }
+        return jar;
+    }
+
+    private static void writeZipEntry(
+            ZipOutputStream output,
+            String name,
+            byte[] contents,
+            int method) throws IOException {
+        ZipEntry entry = new ZipEntry(name);
+        entry.setMethod(method);
+        if (method == ZipEntry.STORED) {
+            CRC32 crc = new CRC32();
+            crc.update(contents);
+            entry.setSize(contents.length);
+            entry.setCompressedSize(contents.length);
+            entry.setCrc(crc.getValue());
+        }
+        output.putNextEntry(entry);
+        output.write(contents);
+        output.closeEntry();
+    }
+
+    private static List<String> zipEntryNames(File jar) throws IOException {
+        List<String> names = new ArrayList<>();
+        try (ZipFile zipFile = new ZipFile(jar)) {
+            zipFile.entries().asIterator().forEachRemaining(entry -> names.add(entry.getName()));
+        }
+        return names;
+    }
+
+    private static byte[] createMinimalClassFile(String internalName) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (DataOutputStream output = new DataOutputStream(bytes)) {
+            output.writeInt(0xCAFEBABE);
+            output.writeShort(0); // minor_version
+            output.writeShort(52); // major_version (Java 8)
+            output.writeShort(5); // constant_pool_count
+            output.writeByte(1); // CONSTANT_Utf8
+            output.writeUTF(internalName);
+            output.writeByte(7); // CONSTANT_Class
+            output.writeShort(1);
+            output.writeByte(1); // CONSTANT_Utf8
+            output.writeUTF("java/lang/Object");
+            output.writeByte(7); // CONSTANT_Class
+            output.writeShort(3);
+            output.writeShort(0x0021); // public, super
+            output.writeShort(2); // this_class
+            output.writeShort(4); // super_class
+            output.writeShort(0); // interfaces_count
+            output.writeShort(0); // fields_count
+            output.writeShort(0); // methods_count
+            output.writeShort(0); // attributes_count
+        }
+        return bytes.toByteArray();
+    }
+
+    private static byte[] createOversizedClassFileHeader() throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream(R8Builder.MAX_CLASSFILE_HEADER_BYTES + 65536);
+        try (DataOutputStream output = new DataOutputStream(bytes)) {
+            output.writeInt(0xCAFEBABE);
+            output.writeShort(0);
+            output.writeShort(52);
+            int utf8Count = R8Builder.MAX_CLASSFILE_HEADER_BYTES / 65538 + 2;
+            output.writeShort(utf8Count + 1);
+            String padding = "a".repeat(65535);
+            for (int index = 0; index < utf8Count; ++index) {
+                output.writeByte(1);
+                output.writeUTF(padding);
+            }
+        }
+        return bytes.toByteArray();
+    }
+
+    private static String sanitizedRuleBody(File rule) throws IOException {
+        String contents = Files.readString(rule.toPath());
+        assertTrue(contents.startsWith("-basedirectory "));
+        int firstLineEnd = contents.indexOf('\n');
+        assertTrue(firstLineEnd >= 0);
+        return contents.substring(firstLineEnd + 1);
+    }
+
+    private static File sanitizedRuleBase(File rule) throws IOException {
+        String firstLine = Files.readString(rule.toPath()).lines().findFirst().orElseThrow();
+        int quoteStart = firstLine.indexOf('"');
+        char quote = '"';
+        if (quoteStart < 0) {
+            quoteStart = firstLine.indexOf('\'');
+            quote = '\'';
+        }
+        assertTrue(quoteStart >= 0);
+        int quoteEnd = firstLine.indexOf(quote, quoteStart + 1);
+        assertTrue(quoteEnd > quoteStart);
+        return new File(firstLine.substring(quoteStart + 1, quoteEnd));
+    }
+
+    private static String buildAndRenderR8Command(File tempDir, int minAndroidSdkVersion) throws Exception {
+        File uploadDir = new File(tempDir, "upload");
+        File appDir = new File(uploadDir, "_app");
+        File buildDir = new File(tempDir, "build");
+        assertTrue(appDir.mkdirs());
+        assertTrue(buildDir.mkdirs());
+        Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class App");
+        File aaptRules = new File(buildDir, "aapt-generated.keep");
+        Files.writeString(aaptRules.toPath(), "-keep class AaptGenerated");
+        File mainDexRules = new File(tempDir, "main-dex.keep");
+        Files.writeString(mainDexRules.toPath(), "-keep class Main");
+        File aaptMainDexRules = null;
+        if (minAndroidSdkVersion < 21) {
+            aaptMainDexRules = new File(buildDir, "aapt-main-dex-generated.keep");
+            Files.writeString(aaptMainDexRules.toPath(), "-keep class AaptMainDex");
+        }
+
+        PlatformConfig config = new PlatformConfig();
+        config.r8Cmd = "r8 {{#useMainDexRules}}{{#mainDexRules}}--main-dex-rules \"{{{.}}}\" {{/mainDexRules}}{{/useMainDexRules}}--output \"{{{classes_dex_dir}}}\"";
+        config.r8Version = "8.13.19";
+        Map<String, String> captured = new HashMap<>();
+        R8Builder builder = new R8Builder(
+                uploadDir,
+                buildDir,
+                config,
+                List.of(),
+                new HashMap<>(),
+                minAndroidSdkVersion,
+                new TemplateExecutor(),
+                (command, context) -> {
+                    captured.put("command", command);
+                    try {
+                        Files.writeString(new File(buildDir, "classes.dex").toPath(), "dex");
+                        Files.writeString(new File((String) context.get("mapping")).toPath(), "mapping");
+                    } catch (IOException e) {
+                        throw new ExtenderException(e, "Failed to create fake R8 outputs");
+                    }
+                });
+
+        builder.build(List.of(), Map.of(), mainDexRules, aaptRules, aaptMainDexRules);
+        return captured.get("command");
+    }
+
+    @Test
+    public void testOnlyAppKeepRequestsR8(@TempDir File uploadDir) throws Exception {
+        File appDir = new File(uploadDir, "_app");
+        assertTrue(appDir.mkdirs());
+        Files.writeString(new File(appDir, "app.pro").toPath(), "-keep class Legacy");
+        assertFalse(R8Builder.isRequested(uploadDir));
+
+        Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class Current");
+        assertTrue(R8Builder.isRequested(uploadDir));
+    }
+
+    @Test
+    public void testNoAppKeepSkipsR8WithoutAaptRules(@TempDir File tempDir) throws Exception {
+        File uploadDir = new File(tempDir, "upload");
+        File buildDir = new File(tempDir, "build");
+        assertTrue(uploadDir.mkdirs());
+        assertTrue(buildDir.mkdirs());
+        File mainDexRules = new File(tempDir, "main-dex.keep");
+        Files.writeString(mainDexRules.toPath(), "-keep class Main");
+        PlatformConfig config = new PlatformConfig();
+
+        R8Builder builder = new R8Builder(
+                uploadDir,
+                buildDir,
+                config,
+                List.of(),
+                new HashMap<>(),
+                19,
+                new TemplateExecutor(),
+                (command, context) -> {
+                    throw new AssertionError("R8 command must not execute without app.keep");
+                });
+
+        assertNull(builder.build(List.of(), Map.of(), mainDexRules, null, null));
+    }
+
+    @Test
+    public void testMainDexRulesAreOnlyPassedBelowApi21(@TempDir File tempDir) throws Exception {
+        File api19Dir = new File(tempDir, "api19");
+        File api21Dir = new File(tempDir, "api21");
+        assertTrue(api19Dir.mkdirs());
+        assertTrue(api21Dir.mkdirs());
+
+        String api19Command = buildAndRenderR8Command(api19Dir, 19);
+        String api21Command = buildAndRenderR8Command(api21Dir, 21);
+
+        assertEquals(
+                2,
+                CommandLineTokenizer.parse(api19Command).stream()
+                        .filter("--main-dex-rules"::equals)
+                        .count());
+        List<String> api19Arguments = CommandLineTokenizer.parse(api19Command);
+        assertTrue(api19Arguments.contains(new File(api19Dir, "main-dex.keep").getAbsolutePath()));
+        assertFalse(api19Arguments.contains(
+                new File(api19Dir, "build/aapt-main-dex-generated.keep").getAbsolutePath()));
+        assertTrue(api19Arguments.stream().anyMatch(
+                argument -> argument.endsWith(new File(
+                        "r8-sanitized-rules",
+                        "aapt-main-dex-generated.keep").getPath())));
+        File sanitizedAaptMainDexRules = new File(
+                api19Dir,
+                "build/r8-sanitized-rules/aapt-main-dex-generated.keep");
+        assertEquals("-keep class AaptMainDex", sanitizedRuleBody(sanitizedAaptMainDexRules));
+        assertEquals(0, sanitizedRuleBase(sanitizedAaptMainDexRules).listFiles().length);
+        assertFalse(api21Command.contains("--main-dex-rules"));
+    }
+
+    @Test
+    public void testConfiguredCommandPreservesQuotedPathSpecialCharacters() throws Exception {
+        File root = new File("test-data");
+        File sdk = new File(root, "sdk/a/defoldsdk");
+        Configuration config = Extender.loadYaml(
+                root,
+                new File(sdk, "extender/build.yml"),
+                Configuration.class);
+        PlatformConfig android = ExtenderTest.mergePlatformConfig(config, "armv7-android");
+
+        String r8Jar = "/tmp/R8 tools/{{literal}}/r8\\\"tool.jar";
+        String androidJar = "/tmp/Android SDK/android\\lib.jar";
+        String mainDexRules = "/tmp/Main Dex/main\"dex.keep";
+        String mapping = "/tmp/Output dir/mapping\\symbols.txt";
+        String dexDir = "/tmp/Output dir/dex {{literal}} & files";
+        String appRules = "/tmp/Rules dir/app\"rules.keep";
+        String aaptRules = "/tmp/Rules dir/aapt&generated.keep";
+        String aaptMainDexRules = "/tmp/Main Dex/aapt&main.keep";
+        String programJar = "/tmp/Program jars/game\\code.jar";
+
+        Map<String, Object> context = new HashMap<>();
+        context.put("env.R8", r8Jar);
+        context.put("env.LIBRARYJAR", androidJar);
+        context.put("minAndroidSdkVersion", 19);
+        context.put("useMainDexRules", true);
+        context.put("mainDexRules", List.of(mainDexRules, aaptMainDexRules));
+        context.put("mapping", mapping);
+        context.put("classes_dex_dir", dexDir);
+        context.put("rules", List.of(appRules, aaptRules));
+        context.put("jars", List.of(programJar));
+
+        String rendered = new TemplateExecutor().executeOnceWithoutLogging(
+                android.r8Cmd,
+                R8Builder.createR8CommandContext(context));
+        List<String> arguments = CommandLineTokenizer.parse(rendered);
+
+        assertFalse(rendered.contains("&amp;"));
+        assertTrue(rendered.contains("{{literal}}"));
+        assertTrue(arguments.contains(r8Jar));
+        assertTrue(arguments.contains(androidJar));
+        assertTrue(arguments.contains(mainDexRules));
+        assertTrue(arguments.contains(aaptMainDexRules));
+        assertTrue(arguments.contains(mapping));
+        assertTrue(arguments.contains(dexDir));
+        assertTrue(arguments.contains(appRules));
+        assertTrue(arguments.contains(aaptRules));
+        assertTrue(arguments.contains(programJar));
+
+        context.put("env.ANDROID_BUILD_TOOLS_PATH", "/tmp/Android SDK/build tools");
+        context.put("manifestFile", "/tmp/Manifest dir/AndroidManifest.xml");
+        context.put("outJavaDirectory", "/tmp/Generated Java");
+        context.put("outApkFile", "/tmp/Compiled resources/resources.apk");
+        context.put("resourceIdsFile", "/tmp/Compiled resources/resource ids.txt");
+        context.put("aaptKeepRules", aaptRules);
+        context.put("aaptMainDexRules", aaptMainDexRules);
+        context.put("resourceListFile", "/tmp/Compiled resources/list.txt");
+        context.put("extraPackages", "");
+        context.put("useR8", false);
+        context.put("useR8MainDexRules", false);
+        String d8AaptCommand = new TemplateExecutor().execute(android.aapt2linkCmd, context);
+        assertFalse(d8AaptCommand.contains("--proguard"));
+
+        context.put("useR8", true);
+        String r8AaptCommand = new TemplateExecutor().execute(android.aapt2linkCmd, context);
+        assertTrue(r8AaptCommand.contains("--proguard"));
+        assertTrue(CommandLineTokenizer.parse(r8AaptCommand).contains(aaptRules));
+
+        context.put("useR8MainDexRules", true);
+        String pre21R8AaptCommand = new TemplateExecutor().execute(android.aapt2linkCmd, context);
+        List<String> aaptArguments = CommandLineTokenizer.parse(pre21R8AaptCommand);
+        assertTrue(aaptArguments.contains("--proguard-main-dex"));
+        assertTrue(aaptArguments.contains(aaptMainDexRules));
+    }
+
+    @Test
+    public void testMissingAaptGeneratedRulesIsAnError(@TempDir File tempDir) throws Exception {
+        File uploadDir = new File(tempDir, "upload");
+        File appDir = new File(uploadDir, "_app");
+        File buildDir = new File(tempDir, "build");
+        assertTrue(appDir.mkdirs());
+        assertTrue(buildDir.mkdirs());
+        Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class App");
+        File mainDexRules = new File(tempDir, "main-dex.keep");
+        Files.writeString(mainDexRules.toPath(), "-keep class Main");
+        File aaptMainDexRules = new File(buildDir, "aapt-main-dex-generated.keep");
+        Files.writeString(aaptMainDexRules.toPath(), "-keep class AaptMainDex");
+        PlatformConfig config = new PlatformConfig();
+        config.r8Cmd = "r8-command";
+        config.r8Version = "8.13.19";
+        boolean[] commandExecuted = {false};
+        R8Builder builder = new R8Builder(
+                uploadDir,
+                buildDir,
+                config,
+                List.of(),
+                new HashMap<>(),
+                19,
+                new TemplateExecutor(),
+                (command, context) -> commandExecuted[0] = true);
+
+        ExtenderException exception = assertThrows(
+                ExtenderException.class,
+                () -> builder.build(
+                        List.of(),
+                        Map.of(),
+                        mainDexRules,
+                        new File(buildDir, "missing-aapt-generated.keep"),
+                        aaptMainDexRules));
+        assertTrue(exception.getMessage().contains("aapt-generated.keep"));
+        assertFalse(commandExecuted[0]);
+    }
+
+    @Test
+    public void testMissingPre21AaptMainDexRulesIsAnError(@TempDir File tempDir) throws Exception {
+        File uploadDir = new File(tempDir, "upload");
+        File appDir = new File(uploadDir, "_app");
+        File buildDir = new File(tempDir, "build");
+        assertTrue(appDir.mkdirs());
+        assertTrue(buildDir.mkdirs());
+        Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class App");
+        File mainDexRules = new File(tempDir, "main-dex.keep");
+        Files.writeString(mainDexRules.toPath(), "-keep class Main");
+        File aaptRules = new File(buildDir, "aapt-generated.keep");
+        Files.writeString(aaptRules.toPath(), "-keep class AaptGenerated");
+        PlatformConfig config = new PlatformConfig();
+        config.r8Cmd = "r8-command";
+        config.r8Version = "8.13.19";
+        boolean[] commandExecuted = {false};
+        R8Builder builder = new R8Builder(
+                uploadDir,
+                buildDir,
+                config,
+                List.of(),
+                new HashMap<>(),
+                19,
+                new TemplateExecutor(),
+                (command, context) -> commandExecuted[0] = true);
+
+        ExtenderException exception = assertThrows(
+                ExtenderException.class,
+                () -> builder.build(
+                        List.of(),
+                        Map.of(),
+                        mainDexRules,
+                        aaptRules,
+                        new File(buildDir, "missing-aapt-main-dex-generated.keep")));
+        assertTrue(exception.getMessage().contains("aapt-main-dex-generated.keep"));
+        assertFalse(commandExecuted[0]);
+    }
+
+    @Test
+    public void testAaptGeneratedRulesUseFilesystemPolicy(@TempDir File tempDir) throws Exception {
+        File uploadDir = new File(tempDir, "upload");
+        File appDir = new File(uploadDir, "_app");
+        File buildDir = new File(tempDir, "build");
+        assertTrue(appDir.mkdirs());
+        assertTrue(buildDir.mkdirs());
+        Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class App");
+        File aaptRules = new File(buildDir, "aapt-generated.keep");
+        Files.writeString(aaptRules.toPath(), "}-include /etc/hosts");
+        PlatformConfig config = new PlatformConfig();
+        config.r8Cmd = "r8-command";
+        config.r8Version = "8.13.19";
+        boolean[] commandExecuted = {false};
+        R8Builder builder = new R8Builder(
+                uploadDir,
+                buildDir,
+                config,
+                List.of(),
+                new HashMap<>(),
+                24,
+                new TemplateExecutor(),
+                (command, context) -> commandExecuted[0] = true);
+
+        ExtenderException exception = assertThrows(
+                ExtenderException.class,
+                () -> builder.build(List.of(), Map.of(), null, aaptRules, null));
+
+        assertTrue(exception.getMessage().contains("forbidden filesystem directive"));
+        assertFalse(commandExecuted[0]);
+    }
+
+    @Test
+    public void testAaptMainDexRulesUseFilesystemPolicy(@TempDir File tempDir) throws Exception {
+        File uploadDir = new File(tempDir, "upload");
+        File appDir = new File(uploadDir, "_app");
+        File buildDir = new File(tempDir, "build");
+        assertTrue(appDir.mkdirs());
+        assertTrue(buildDir.mkdirs());
+        Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class App");
+        File aaptRules = new File(buildDir, "aapt-generated.keep");
+        Files.writeString(aaptRules.toPath(), "-keep class AaptGenerated");
+        File mainDexRules = new File(tempDir, "main-dex.keep");
+        Files.writeString(mainDexRules.toPath(), "-keep class Main");
+        File aaptMainDexRules = new File(buildDir, "aapt-main-dex-generated.keep");
+        Files.writeString(aaptMainDexRules.toPath(), "}-include /etc/hosts");
+        PlatformConfig config = new PlatformConfig();
+        config.r8Cmd = "r8-command";
+        config.r8Version = "8.13.19";
+        boolean[] commandExecuted = {false};
+        R8Builder builder = new R8Builder(
+                uploadDir,
+                buildDir,
+                config,
+                List.of(),
+                new HashMap<>(),
+                19,
+                new TemplateExecutor(),
+                (command, context) -> commandExecuted[0] = true);
+
+        ExtenderException exception = assertThrows(
+                ExtenderException.class,
+                () -> builder.build(
+                        List.of(),
+                        Map.of(),
+                        mainDexRules,
+                        aaptRules,
+                        aaptMainDexRules));
+
+        assertTrue(exception.getMessage().contains("forbidden filesystem directive"));
+        assertFalse(commandExecuted[0]);
+    }
+
+    @Test
+    public void testMissingR8ConfigurationIsReportedBeforeMissingAaptRules(@TempDir File tempDir) throws Exception {
+        File uploadDir = new File(tempDir, "upload");
+        File appDir = new File(uploadDir, "_app");
+        File buildDir = new File(tempDir, "build");
+        assertTrue(appDir.mkdirs());
+        assertTrue(buildDir.mkdirs());
+        Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class App");
+        File mainDexRules = new File(tempDir, "main-dex.keep");
+        Files.writeString(mainDexRules.toPath(), "-keep class Main");
+
+        R8Builder builder = new R8Builder(
+                uploadDir,
+                buildDir,
+                new PlatformConfig(),
+                List.of(),
+                new HashMap<>(),
+                19,
+                new TemplateExecutor(),
+                (command, context) -> {
+                    throw new AssertionError("R8 command must not execute with missing configuration");
+                });
+
+        ExtenderException exception = assertThrows(
+                ExtenderException.class,
+                () -> builder.build(List.of(), Map.of(), mainDexRules, null, null));
+        assertTrue(exception.getMessage().contains("does not provide r8Cmd and r8Version"));
+        assertFalse(exception.getMessage().contains("aapt-generated.keep"));
+    }
+
+    @Test
+    public void testBlankResolvedR8EnvironmentProducesClearConfigurationError(@TempDir File tempDir) throws Exception {
+        File uploadDir = new File(tempDir, "upload");
+        File appDir = new File(uploadDir, "_app");
+        File buildDir = new File(tempDir, "build");
+        assertTrue(appDir.mkdirs());
+        assertTrue(buildDir.mkdirs());
+        Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class App");
+        File aaptRules = new File(buildDir, "aapt-generated.keep");
+        Files.writeString(aaptRules.toPath(), "-keep class AaptGenerated");
+        File mainDexRules = new File(tempDir, "main-dex.keep");
+        Files.writeString(mainDexRules.toPath(), "-keep class Main");
+        PlatformConfig config = new PlatformConfig();
+        config.env.put("R8", "{{env.ANDROID_R8}}");
+        config.r8Cmd = "java -cp \"{{{env.R8}}}\" com.android.tools.r8.R8";
+        config.r8Version = "8.13.19";
+        Map<String, Object> commandContext = new HashMap<>();
+        commandContext.put("env.R8", " ");
+
+        R8Builder builder = new R8Builder(
+                uploadDir,
+                buildDir,
+                config,
+                List.of(),
+                commandContext,
+                19,
+                new TemplateExecutor(),
+                (command, context) -> {
+                    throw new AssertionError("R8 command must not execute with unresolved configuration");
+                });
+
+        ExtenderException exception = assertThrows(
+                ExtenderException.class,
+                () -> builder.build(List.of(), Map.of(), mainDexRules, aaptRules, null));
+        assertTrue(exception.getOutput().contains("does not provide r8Cmd and r8Version"));
+    }
+
+    @Test
+    public void testMissingConfigurationIsAnError() {
+        ExtenderException missing = assertThrows(
+                ExtenderException.class,
+                () -> R8Builder.validateConfiguration(null, "8.13.19"));
+        assertTrue(missing.getMessage().contains("does not provide r8Cmd and r8Version"));
+
+        ExtenderException invalid = assertThrows(
+                ExtenderException.class,
+                () -> R8Builder.validateConfiguration("r8", "8.13-dev"));
+        assertTrue(invalid.getMessage().contains("Invalid r8Version"));
+    }
+
+    @Test
+    public void testRuleVersionRanges() {
+        assertTrue(R8Builder.isApplicableRuleDirectory("r8", "8.13.19"));
+        assertTrue(R8Builder.isApplicableRuleDirectory("r8-from-8.13.19", "8.13.19"));
+        assertTrue(R8Builder.isApplicableRuleDirectory("r8-from-8.13.18-dev", "8.13.19"));
+        assertTrue(R8Builder.isApplicableRuleDirectory("r8-from-0.0.0-arbitrary", "8.13.19"));
+        assertTrue(R8Builder.isApplicableRuleDirectory("r8-upto-8.13.20", "8.13.19"));
+        assertTrue(R8Builder.isApplicableRuleDirectory("r8-from-8.0.0-upto-9.0.0", "8.13.19"));
+        assertFalse(R8Builder.isApplicableRuleDirectory("r8-upto-8.13.19", "8.13.19"));
+        assertFalse(R8Builder.isApplicableRuleDirectory("r8-from-8.13.20", "8.13.19"));
+        assertFalse(R8Builder.isApplicableRuleDirectory("r8-from-invalid", "8.13.19"));
+        assertFalse(R8Builder.isApplicableRuleDirectory("r8foo", "8.13.19"));
+    }
+
+    @Test
+    public void testSelectTargetedRulesWithLegacyFallback(@TempDir File tempDir) throws Exception {
+        Map<String, String> entries = new HashMap<>();
+        entries.put("META-INF/proguard/legacy.pro", "-keep class Legacy");
+        entries.put("META-INF/com.android.tools/r8-upto-8.0.0/old.keep", "-keep class Old");
+        entries.put("META-INF/com.android.tools/r8-from-8.0.0/z.keep", "-keep class Z");
+        entries.put("META-INF/com.android.tools/r8-from-8.0.0/a.keep", "-keep class A");
+        File targetedJar = createJar(new File(tempDir, "targeted.jar"), entries);
+
+        assertEquals(
+                List.of(
+                        "META-INF/com.android.tools/r8-from-8.0.0/a.keep",
+                        "META-INF/com.android.tools/r8-from-8.0.0/z.keep"),
+                R8Builder.selectEmbeddedRuleEntries(targetedJar, "8.13.19"));
+
+        entries.remove("META-INF/com.android.tools/r8-from-8.0.0/a.keep");
+        entries.remove("META-INF/com.android.tools/r8-from-8.0.0/z.keep");
+        File legacyJar = createJar(new File(tempDir, "legacy.jar"), entries);
+        assertEquals(
+                List.of("META-INF/proguard/legacy.pro"),
+                R8Builder.selectEmbeddedRuleEntries(legacyJar, "8.13.19"));
+    }
+
+    @Test
+    public void testSelectTargetedRulesMatchesPinnedR8SuffixHandling(@TempDir File tempDir)
+            throws Exception {
+        File jar = createJar(
+                new File(tempDir, "suffixes.jar"),
+                Map.of(
+                        "META-INF/com.android.tools/r8-from-8.13.18-dev/prerelease.keep",
+                        "-keep class Prerelease",
+                        "META-INF/com.android.tools/r8-from-0.0.0-arbitrary/malformed.keep",
+                        "-keep class MalformedSuffix",
+                        "META-INF/com.android.tools/r8-from-9.0.0-future/future.keep",
+                        "-keep class Future",
+                        "META-INF/com.android.tools/r8foo/not-a-rule.txt",
+                        "metadata"));
+
+        assertEquals(
+                List.of(
+                        "META-INF/com.android.tools/r8-from-0.0.0-arbitrary/malformed.keep",
+                        "META-INF/com.android.tools/r8-from-8.13.18-dev/prerelease.keep"),
+                R8Builder.selectEmbeddedRuleEntries(jar, "8.13.19"));
+    }
+
+    @Test
+    public void testDuplicateEmbeddedRuleNamesAreRejected(@TempDir File tempDir) throws Exception {
+        File jar = createJarWithDuplicateEntries(
+                new File(tempDir, "duplicate-rules.jar"),
+                "META-INF/proguard/rules.pro",
+                "-keep class First",
+                "-keep class Second");
+
+        ExtenderException exception = assertThrows(
+                ExtenderException.class,
+                () -> R8Builder.selectEmbeddedRuleEntries(jar, "8.13.19"));
+
+        assertTrue(exception.getMessage().contains("Duplicate embedded R8 rule entry"));
+    }
+
+    @Test
+    public void testStripEmbeddedRulesRetainsAllOtherRawJarEntries(@TempDir File tempDir)
+            throws Exception {
+        File original = createJar(
+                new File(tempDir, "original.jar"),
+                new LinkedHashMap<>(Map.of(
+                        "classes/example/Retained.class", "class bytes",
+                        "assets/data.bin", "retained data",
+                        "META-INF/proguard/legacy.pro", "-keep class Legacy",
+                        "META-INF/com.android.tools/r8/rules.keep", "-keep class R8",
+                        "META-INF/com.android.tools/r8-from-0.0.0-arbitrary/hidden.pro", "-keep class Hidden",
+                        "META-INF/com.android.tools/r8-upto-99.0.0/future.keep", "-keep class Future",
+                        "META-INF/com.android.tools/r8foo/not-a-rule.txt", "retained r8 metadata",
+                        "META-INF/com.android.tools/lint/model.xml", "retained lint metadata",
+                        "META-INF/proguarded/not-a-rule.txt", "retained proguard metadata")));
+        File requestedOutput = new File(tempDir, "stripped/program-0000.jar");
+
+        File stripped = R8Builder.stripEmbeddedRuleEntries(original, requestedOutput);
+
+        assertEquals(requestedOutput.getCanonicalFile(), stripped.getCanonicalFile());
+        assertEquals(
+                List.of(
+                        "META-INF/com.android.tools/lint/model.xml",
+                        "META-INF/com.android.tools/r8foo/not-a-rule.txt",
+                        "META-INF/proguarded/not-a-rule.txt",
+                        "assets/data.bin",
+                        "classes/example/Retained.class"),
+                zipEntryNames(stripped).stream().sorted().toList());
+        try (ZipFile originalZip = new ZipFile(original);
+             ZipFile strippedZip = new ZipFile(stripped)) {
+            ZipEntry originalClass = originalZip.getEntry("classes/example/Retained.class");
+            ZipEntry strippedClass = strippedZip.getEntry("classes/example/Retained.class");
+            assertEquals(originalClass.getMethod(), strippedClass.getMethod());
+            assertEquals(originalClass.getCrc(), strippedClass.getCrc());
+            assertEquals(originalClass.getCompressedSize(), strippedClass.getCompressedSize());
+            assertEquals(
+                    "class bytes",
+                    new String(strippedZip.getInputStream(strippedClass).readAllBytes(), StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    public void testStripEmbeddedRulesReturnsOriginalWhenNoRulesExist(@TempDir File tempDir)
+            throws Exception {
+        File original = createJar(
+                new File(tempDir, "original.jar"),
+                Map.of(
+                        "classes/example/Retained.class", "class bytes",
+                        "META-INF/com.android.tools/r8foo/not-a-rule.txt", "metadata"));
+        File requestedOutput = new File(tempDir, "stripped/program-0000.jar");
+
+        File result = R8Builder.stripEmbeddedRuleEntries(original, requestedOutput);
+
+        assertEquals(original.getCanonicalFile(), result.getCanonicalFile());
+        assertFalse(requestedOutput.exists());
+    }
+
+    @Test
+    public void testStripEmbeddedRulesPreservesStoredDeflatedAndDirectoryEntries(@TempDir File tempDir)
+            throws Exception {
+        File original = new File(tempDir, "mixed.jar");
+        try (ZipOutputStream output = new ZipOutputStream(new FileOutputStream(original))) {
+            writeZipEntry(output, "assets/", new byte[0], ZipEntry.STORED);
+            writeZipEntry(
+                    output,
+                    "assets/stored.bin",
+                    "stored bytes".getBytes(StandardCharsets.UTF_8),
+                    ZipEntry.STORED);
+            writeZipEntry(
+                    output,
+                    "assets/deflated.bin",
+                    "deflated bytes".getBytes(StandardCharsets.UTF_8),
+                    ZipEntry.DEFLATED);
+            writeZipEntry(output, "META-INF/proguard/", new byte[0], ZipEntry.STORED);
+            writeZipEntry(
+                    output,
+                    "META-INF/proguard/rules.pro",
+                    "-keep class Removed".getBytes(StandardCharsets.UTF_8),
+                    ZipEntry.DEFLATED);
+        }
+
+        File stripped = R8Builder.stripEmbeddedRuleEntries(
+                original,
+                new File(tempDir, "stripped/mixed.jar"));
+
+        assertEquals(
+                List.of(
+                        "META-INF/proguard/",
+                        "assets/",
+                        "assets/deflated.bin",
+                        "assets/stored.bin"),
+                zipEntryNames(stripped).stream().sorted().toList());
+        try (ZipFile zipFile = new ZipFile(stripped)) {
+            ZipEntry stored = zipFile.getEntry("assets/stored.bin");
+            ZipEntry deflated = zipFile.getEntry("assets/deflated.bin");
+            assertEquals(ZipEntry.STORED, stored.getMethod());
+            assertEquals(ZipEntry.DEFLATED, deflated.getMethod());
+            assertEquals(
+                    "stored bytes",
+                    new String(zipFile.getInputStream(stored).readAllBytes(), StandardCharsets.UTF_8));
+            assertEquals(
+                    "deflated bytes",
+                    new String(zipFile.getInputStream(deflated).readAllBytes(), StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    public void testCollectJarAndAarConsumerRulesDeterministically(@TempDir File tempDir) throws Exception {
+        File standaloneJar = createJar(
+                new File(tempDir, "standalone.jar"),
+                Map.of(
+                        "META-INF/proguard/legacy.pro", "-keep class JarLegacy",
+                        "META-INF/com.android.tools/r8-from-8.0.0/rules.keep", "-keep class JarTarget"));
+
+        File targetedAar = new File(tempDir, "targeted.aar");
+        assertTrue(targetedAar.mkdirs());
+        File targetedClasses = createJar(
+                new File(targetedAar, "classes.jar"),
+                Map.of("META-INF/com.android.tools/r8/rules.keep", "-keep class AarTarget"));
+        Files.writeString(new File(targetedAar, "proguard.txt").toPath(), "-keep class AarRootIgnored");
+
+        File legacyAar = new File(tempDir, "legacy.aar");
+        assertTrue(legacyAar.mkdirs());
+        File legacyClasses = createJar(new File(legacyAar, "classes.jar"), Map.of("example/Legacy.class", "class"));
+        Files.writeString(new File(legacyAar, "proguard.txt").toPath(), "-keep class AarLegacy");
+
+        List<String> rules = R8Builder.collectConsumerRules(
+                List.of(targetedClasses.getAbsolutePath(), standaloneJar.getAbsolutePath(), legacyClasses.getAbsolutePath()),
+                List.of(targetedAar, legacyAar),
+                "8.13.19",
+                new File(tempDir, "rules"));
+        List<String> contents = new ArrayList<>();
+        for (String rule : rules) {
+            contents.add(sanitizedRuleBody(new File(rule)));
+        }
+
+        assertEquals(
+                List.of("-keep class JarTarget", "-keep class AarTarget", "-keep class AarLegacy"),
+                contents);
+    }
+
+    @Test
+    public void testGeneratedRulesProtectValidJarClasses(@TempDir File tempDir) throws Exception {
+        Map<String, byte[]> entries = new LinkedHashMap<>();
+        entries.put("com/example/Outer.class", createMinimalClassFile("com/example/Outer"));
+        entries.put("com/example/Outer$Inner.class", createMinimalClassFile("com/example/Outer$Inner"));
+        entries.put("com/example/Foo-Bar.class", createMinimalClassFile("com/example/Foo-Bar"));
+        entries.put("com/example/9Patch.class", createMinimalClassFile("com/example/9Patch"));
+        entries.put("com/example/Über.class", createMinimalClassFile("com/example/Über"));
+        entries.put("com/example/Supplementary.class", createMinimalClassFile("com/example/𐐀Name"));
+        entries.put("com/example/NonJavaIdentifier.class", createMinimalClassFile("com/example/¡Name"));
+        entries.put("com/example/Combining.class", createMinimalClassFile("com/example/éName"));
+        entries.put("com/example/UnicodeSpace.class", createMinimalClassFile("com/example/ Name"));
+        entries.put("com/example/UnsupportedSpace.class", createMinimalClassFile("com/example/ Name"));
+        entries.put("META-INF/versions/9/com/example/Versioned.class", "not parsed".getBytes(StandardCharsets.UTF_8));
+        entries.put("decoy/NotModule.class", createMinimalClassFile("module-info"));
+        entries.put("module-info.class", createMinimalClassFile("com/example/ActuallyClass"));
+        entries.put("com/example/package-info.class", createMinimalClassFile("com/example/package-info"));
+        File jar = createJarWithBytes(new File(tempDir, "extension.jar"), entries);
+        File rules = R8Builder.writeProtectedJarKeepRules(
+                List.of(jar.getAbsolutePath()),
+                new File(tempDir, "generated.keep"));
+        String contents = Files.readString(rules.toPath());
+
+        assertTrue(contents.startsWith(
+                "-keepattributes *Annotation*,Signature,InnerClasses,EnclosingMethod,MethodParameters,Exceptions"));
+        assertTrue(contents.contains("-keep class com.example.Outer { *; }"));
+        assertTrue(contents.contains("-keep class com.example.Outer$Inner { *; }"));
+        assertTrue(contents.contains("-keep class com.example.Foo-Bar { *; }"));
+        assertTrue(contents.contains("-keep class com.example.9Patch { *; }"));
+        assertTrue(contents.contains("-keep class com.example.Über { *; }"));
+        assertTrue(contents.contains("-keep class com.example.𐐀Name { *; }"));
+        assertTrue(contents.contains("-keep class com.example.¡Name { *; }"));
+        assertTrue(contents.contains("-keep class com.example.éName { *; }"));
+        assertTrue(contents.contains("-keep class com.example.?Name { *; }"));
+        assertFalse(contents.contains("com.example. Name"));
+        assertFalse(contents.contains("com.example. Name"));
+        assertTrue(contents.contains("-keep class com.example.ActuallyClass { *; }"));
+        assertTrue(contents.contains("-keep class com.example.package-info { *; }"));
+        assertFalse(contents.contains("Versioned"));
+        assertFalse(contents.contains("module-info"));
+    }
+
+    @Test
+    public void testGeneratedRulesUseClassFileNameInsteadOfZipEntryName(@TempDir File tempDir)
+            throws Exception {
+        File jar = createJarWithBytes(
+                new File(tempDir, "mismatched.jar"),
+                Map.of("x/Entry.class", createMinimalClassFile("test/LambdaProbe")));
+
+        String contents = Files.readString(R8Builder.writeProtectedJarKeepRules(
+                List.of(jar.getAbsolutePath()),
+                new File(tempDir, "generated.keep")).toPath());
+
+        assertTrue(contents.contains("-keep class test.LambdaProbe { *; }"));
+        assertFalse(contents.contains("x.Entry"));
+    }
+
+    @Test
+    public void testGeneratedRulesNeutralizeClassNameMetacharacters(@TempDir File tempDir)
+            throws Exception {
+        String internalName = "safe/Bad#\"'{}()\\\n\r\t @*!?%,:=~<>!&|-include /etc/hosts";
+        File jar = createJarWithBytes(
+                new File(tempDir, "metacharacters.jar"),
+                Map.of("safe/Decoy.class", createMinimalClassFile(internalName)));
+
+        String contents = Files.readString(R8Builder.writeProtectedJarKeepRules(
+                List.of(jar.getAbsolutePath()),
+                new File(tempDir, "generated.keep")).toPath());
+        List<String> lines = contents.lines().toList();
+        assertEquals(2, lines.size());
+        String prefix = "-keep class ";
+        String suffix = " { *; }";
+        assertTrue(lines.get(1).startsWith(prefix));
+        assertTrue(lines.get(1).endsWith(suffix));
+        String pattern = lines.get(1).substring(prefix.length(), lines.get(1).length() - suffix.length());
+
+        assertTrue(pattern.startsWith("safe.Bad"));
+        assertTrue(pattern.endsWith(".etc.hosts"));
+        assertTrue(pattern.contains("?"));
+        assertFalse(pattern.contains("#"));
+        assertFalse(pattern.contains("\""));
+        assertFalse(pattern.contains("'"));
+        assertFalse(pattern.contains("{"));
+        assertFalse(pattern.contains("}"));
+        assertFalse(pattern.contains("\\"));
+        assertFalse(pattern.contains("/"));
+        assertFalse(pattern.codePoints().anyMatch(Character::isWhitespace));
+    }
+
+    @Test
+    public void testGeneratedRulesIgnoreMaliciousZipEntryName(@TempDir File tempDir)
+            throws Exception {
+        File jar = createJarWithBytes(
+                new File(tempDir, "malicious-entry.jar"),
+                Map.of(
+                        "decoy/Entry.class\n-include /etc/hosts.class",
+                        createMinimalClassFile("safe/Actual")));
+
+        String contents = Files.readString(R8Builder.writeProtectedJarKeepRules(
+                List.of(jar.getAbsolutePath()),
+                new File(tempDir, "generated.keep")).toPath());
+
+        assertTrue(contents.contains("-keep class safe.Actual { *; }"));
+        assertFalse(contents.contains("-include"));
+        assertFalse(contents.contains("/etc/hosts"));
+        assertEquals(2, contents.lines().count());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"p//Foo", "p/Foo.Bar", "p/Foo;Bar", "p/Foo[Bar", "/Foo", "Foo/"})
+    public void testGeneratedRulesRejectMalformedInternalClassNames(
+            String internalName,
+            @TempDir File tempDir) throws Exception {
+        File jar = createJarWithBytes(
+                new File(tempDir, "malformed-name.jar"),
+                Map.of("p/Entry.class", createMinimalClassFile(internalName)));
+        File output = new File(tempDir, "generated.keep");
+
+        ExtenderException exception = assertThrows(
+                ExtenderException.class,
+                () -> R8Builder.writeProtectedJarKeepRules(List.of(jar.getAbsolutePath()), output));
+
+        assertTrue(exception.getOutput().contains("Invalid class name"));
+        assertFalse(output.exists());
+    }
+
+    @Test
+    public void testGeneratedRulesRejectMalformedClassFile(@TempDir File tempDir) throws Exception {
+        File jar = createJar(
+                new File(tempDir, "malformed-class.jar"),
+                Map.of("p/Broken.class", "not a class file"));
+        File output = new File(tempDir, "generated.keep");
+
+        ExtenderException exception = assertThrows(
+                ExtenderException.class,
+                () -> R8Builder.writeProtectedJarKeepRules(List.of(jar.getAbsolutePath()), output));
+
+        assertTrue(exception.getOutput().contains("Failed to read class file"));
+        assertTrue(exception.getMessage().contains("Invalid class file magic"));
+        assertFalse(output.exists());
+    }
+
+    @Test
+    public void testGeneratedRulesBoundClassFileHeaderDecompression(@TempDir File tempDir)
+            throws Exception {
+        File jar = createJarWithBytes(
+                new File(tempDir, "oversized-class-header.jar"),
+                Map.of("p/Oversized.class", createOversizedClassFileHeader()));
+        File output = new File(tempDir, "generated.keep");
+
+        ExtenderException exception = assertThrows(
+                ExtenderException.class,
+                () -> R8Builder.writeProtectedJarKeepRules(List.of(jar.getAbsolutePath()), output));
+
+        assertTrue(exception.getMessage().contains("Class file header exceeds"));
+        assertFalse(output.exists());
+    }
+
+    @Test
+    public void testGeneratedRuleClassCountIsBoundedDuringJarEnumeration(@TempDir File tempDir)
+            throws Exception {
+        Map<String, byte[]> entries = new LinkedHashMap<>();
+        byte[] classFile = createMinimalClassFile("p/Repeated");
+        for (int index = 0; index <= R8Builder.MAX_GENERATED_EXTENSION_CLASSES; ++index) {
+            entries.put(String.format("p/C%05d.class", index), classFile);
+        }
+        File jar = createJarWithBytes(new File(tempDir, "too-many-classes.jar"), entries);
+        File output = new File(tempDir, "generated.keep");
+
+        ExtenderException exception = assertThrows(
+                ExtenderException.class,
+                () -> R8Builder.writeProtectedJarKeepRules(List.of(jar.getAbsolutePath()), output));
+
+        assertTrue(exception.getMessage().contains("Too many classes"));
+        assertFalse(output.exists());
+    }
+
+    @Test
+    public void testGeneratedRuleBytesAreBoundedDuringJarEnumeration(@TempDir File tempDir)
+            throws Exception {
+        Map<String, byte[]> entries = new LinkedHashMap<>();
+        String longName = "a".repeat(6000);
+        for (int index = 0; index < 200; ++index) {
+            String internalName = String.format("p/C%03d%s", index, longName);
+            entries.put(internalName + ".class", createMinimalClassFile(internalName));
+        }
+        File jar = createJarWithBytes(new File(tempDir, "oversized-generated-rules.jar"), entries);
+        File output = new File(tempDir, "generated.keep");
+
+        ExtenderException exception = assertThrows(
+                ExtenderException.class,
+                () -> R8Builder.writeProtectedJarKeepRules(List.of(jar.getAbsolutePath()), output));
+
+        assertTrue(exception.getMessage().contains("Generated R8 keep rules are too large"));
+        assertFalse(output.exists());
+    }
+
+    @Test
+    public void testExtensionRuleDiscoveryIsRecursiveAndFolderScoped(@TempDir File tempDir) throws Exception {
+        File extensionDir = new File(tempDir, "extension");
+        File manifestsDir = new File(extensionDir, "manifests/android");
+        File nestedDir = new File(manifestsDir, "nested");
+        assertTrue(nestedDir.mkdirs());
+
+        File rootKeep = new File(manifestsDir, "root.keep");
+        File nestedKeep = new File(nestedDir, "nested.keep");
+        Files.writeString(rootKeep.toPath(), "-keep class Root");
+        Files.writeString(nestedKeep.toPath(), "-keep class Nested");
+        Files.writeString(new File(manifestsDir, "legacy.pro").toPath(), "-keep class Legacy");
+        Files.writeString(new File(extensionDir, "outside.keep").toPath(), "-keep class Outside");
+
+        R8Builder.ExtensionContext context = R8Builder.createExtensionContext(
+                extensionDir,
+                List.of("extension.jar"),
+                KEEP_RULE_REGEX);
+
+        assertEquals(
+                List.of(nestedKeep.getAbsolutePath(), rootKeep.getAbsolutePath()),
+                context.ruleFiles);
+        assertTrue(context.protectedJars.isEmpty());
+    }
+
+    @Test
+    public void testRulesOnlyPlaceholderNeverBecomesAProgramJar() {
+        R8Builder.ExtensionContext context = new R8Builder.ExtensionContext();
+        Map<String, R8Builder.ExtensionContext> extensionJars = new HashMap<>();
+        extensionJars.put("/tmp/real.jar", context);
+        extensionJars.put("/tmp/" + R8Builder.RULES_WITHOUT_JAR, context);
+
+        assertEquals(List.of("/tmp/real.jar"), R8Builder.getCompiledJars(extensionJars));
+    }
+
+    @Test
+    public void testBuildAssemblesExtensionAndAarRulesAndReturnsMapping(@TempDir File tempDir) throws Exception {
+        File uploadDir = new File(tempDir, "upload");
+        File appDir = new File(uploadDir, "_app");
+        File buildDir = new File(tempDir, "build");
+        assertTrue(appDir.mkdirs());
+        assertTrue(buildDir.mkdirs());
+        File appRules = new File(appDir, "app.keep");
+        Files.writeString(appRules.toPath(), "-keep class App");
+        File unselectedEngineRules = new File(appDir, "dmengine.keep");
+        Files.writeString(unselectedEngineRules.toPath(), "-keep class UnselectedEngine");
+        File aaptRules = new File(buildDir, "aapt-generated.keep");
+        Files.writeString(aaptRules.toPath(), "-keep class AaptGenerated");
+
+        File extensionDir = new File(uploadDir, "extension");
+        File extensionRulesDir = new File(extensionDir, "manifests/android");
+        assertTrue(extensionRulesDir.mkdirs());
+        File extensionRules = new File(extensionRulesDir, "extension.keep");
+        Files.writeString(extensionRules.toPath(), "-keep class Extension");
+        Files.writeString(new File(extensionRulesDir, "ignored.pro").toPath(), "-keep class Ignored");
+        File extensionJar = createJar(
+                new File(tempDir, "extension.jar"),
+                Map.of("com/example/Extension.class", "class"));
+        R8Builder.ExtensionContext extensionContext = R8Builder.createExtensionContext(
+                extensionDir,
+                List.of(extensionJar.getAbsolutePath()),
+                KEEP_RULE_REGEX);
+
+        File dependencyAar = new File(tempDir, "dependency.aar");
+        assertTrue(dependencyAar.mkdirs());
+        File dependencyJar = createJar(
+                new File(dependencyAar, "classes.jar"),
+                Map.of(
+                        "com/example/Dependency.class", "class",
+                        "META-INF/com.android.tools/r8-from-0.0.0-arbitrary/dependency.keep",
+                        "-keep class Dependency"));
+        Files.writeString(new File(dependencyAar, "proguard.txt").toPath(), "-keep class Dependency");
+
+        File mainDexRules = new File(tempDir, "main-dex.keep");
+        Files.writeString(mainDexRules.toPath(), "-keep class Main");
+        PlatformConfig config = new PlatformConfig();
+        config.r8Cmd = "r8-command {{#jars}}\"{{{.}}}\" {{/jars}}";
+        config.r8Version = "8.13.19";
+
+        Map<String, Object> executedContext = new HashMap<>();
+        Map<String, String> executedCommand = new HashMap<>();
+        R8Builder builder = new R8Builder(
+                uploadDir,
+                buildDir,
+                config,
+                List.of(dependencyAar),
+                new HashMap<>(),
+                24,
+                new TemplateExecutor(),
+                (command, context) -> {
+                    assertTrue(command.startsWith("r8-command "));
+                    executedCommand.put("command", command);
+                    executedContext.putAll(context);
+                    try {
+                        Files.writeString(new File(buildDir, "classes.dex").toPath(), "dex");
+                        Files.writeString(new File((String) context.get("mapping")).toPath(), "mapping");
+                    } catch (IOException e) {
+                        throw new ExtenderException(e, "Failed to create fake R8 outputs");
+                    }
+                });
+
+        R8Builder.BuildOutput output = builder.build(
+                List.of(extensionJar.getAbsolutePath(), dependencyJar.getAbsolutePath()),
+                Map.of(extensionJar.getAbsolutePath(), extensionContext),
+                mainDexRules,
+                aaptRules,
+                null);
+
+        assertNotNull(output);
+        assertEquals(List.of("classes.dex"), Arrays.stream(output.dexFiles).map(File::getName).toList());
+        assertEquals("mapping.txt", output.mappingFile.getName());
+        assertEquals(output.mappingFile.getAbsolutePath(), executedContext.get("mapping"));
+
+        @SuppressWarnings("unchecked")
+        List<String> programJars = (List<String>) executedContext.get("jars");
+        assertTrue(programJars.contains(extensionJar.getAbsolutePath()));
+        assertFalse(programJars.contains(dependencyJar.getAbsolutePath()));
+        String strippedDependencyJar = programJars.stream()
+                .filter(path -> path.contains("r8-program-jars"))
+                .findFirst()
+                .orElseThrow();
+        assertTrue(new File(strippedDependencyJar).isFile());
+        assertTrue(zipEntryNames(new File(strippedDependencyJar)).contains("com/example/Dependency.class"));
+        assertFalse(zipEntryNames(new File(strippedDependencyJar)).stream()
+                .anyMatch(R8Builder::isEmbeddedRuleEntryName));
+        assertTrue(executedCommand.get("command").contains(strippedDependencyJar));
+        assertFalse(executedCommand.get("command").contains(dependencyJar.getAbsolutePath()));
+
+        @SuppressWarnings("unchecked")
+        List<String> assembledRules = (List<String>) executedContext.get("rules");
+        assertFalse(assembledRules.contains(appRules.getAbsolutePath()));
+        assertFalse(assembledRules.contains(aaptRules.getAbsolutePath()));
+        assertFalse(assembledRules.contains(unselectedEngineRules.getAbsolutePath()));
+        assertFalse(assembledRules.contains(extensionRules.getAbsolutePath()));
+        assertFalse(assembledRules.stream().anyMatch(path -> path.endsWith("ignored.pro")));
+        assertFalse((Boolean) executedContext.get("useMainDexRules"));
+        List<File> sanitizedRules = assembledRules.stream()
+                .map(File::new)
+                .filter(rule -> {
+                    try {
+                        return Files.readString(rule.toPath()).startsWith("-basedirectory ");
+                    } catch (IOException e) {
+                        return false;
+                    }
+                })
+                .toList();
+        assertEquals(4, sanitizedRules.size());
+        assertTrue(sanitizedRules.stream().anyMatch(rule -> {
+            try {
+                return sanitizedRuleBody(rule).contains("-keep class App");
+            } catch (IOException e) {
+                return false;
+            }
+        }));
+        assertTrue(sanitizedRules.stream().anyMatch(rule -> {
+            try {
+                return sanitizedRuleBody(rule).contains("-keep class Extension");
+            } catch (IOException e) {
+                return false;
+            }
+        }));
+        assertTrue(sanitizedRules.stream().anyMatch(rule -> {
+            try {
+                return sanitizedRuleBody(rule).contains("-keep class AaptGenerated");
+            } catch (IOException e) {
+                return false;
+            }
+        }));
+        assertTrue(sanitizedRules.stream().anyMatch(rule -> {
+            try {
+                return sanitizedRuleBody(rule).contains("-keep class Dependency");
+            } catch (IOException e) {
+                return false;
+            }
+        }));
+        File ruleBase = sanitizedRuleBase(sanitizedRules.get(0));
+        assertTrue(ruleBase.isDirectory());
+        assertEquals(0, ruleBase.listFiles().length);
+        for (File sanitizedRule : sanitizedRules) {
+            assertEquals(ruleBase.getCanonicalFile(), sanitizedRuleBase(sanitizedRule).getCanonicalFile());
+            assertFalse(sanitizedRule.toPath().startsWith(ruleBase.toPath()));
+        }
+    }
+
+    @Test
+    public void testRulePolicyAllowsAnnotationRules() {
+        String rules = String.join("\n",
+                "# Annotation-based Gson and Android rules are supported",
+                "-keep,allowoptimization @com.example.JsonAdapter class *",
+                "-keep @com.example.Outer$Marker class *",
+                "-keep,allowoptimization",
+                "@com.example.MultilineAdapter class *",
+                "-keep @interface androidx.annotation.Keep",
+                "-keep public class * extends @com.example.BaseType ** {",
+                "    @androidx.annotation.Keep <methods>;",
+                "    java.lang.String source();",
+                "}",
+                "-maximumremovedandroidloglevel 2 @com.example.Marker class * { *; }");
+
+        assertDoesNotThrow(() -> R8RulePolicy.validateRules(rules, "safe.keep"));
+    }
+
+    @Test
+    public void testSanitizedRuleUsesSeparateEmptyBaseAndNormalizesBom(@TempDir File tempDir)
+            throws Exception {
+        File source = new File(tempDir, "source.keep");
+        Files.writeString(
+                source.toPath(),
+                "\uFEFF@local.keep\n-keep @com.example.Marker class *");
+        File emptyBase = R8RulePolicy.createEmptyBaseDirectory(tempDir);
+        File sanitized = new File(tempDir, "sanitized/rule.keep");
+
+        R8RulePolicy.writeSanitized(
+                sanitized,
+                R8RulePolicy.readAndValidate(source, new R8RulePolicy.Budget()),
+                emptyBase);
+
+        assertEquals(
+                "@local.keep\n-keep @com.example.Marker class *",
+                sanitizedRuleBody(sanitized));
+        assertEquals(emptyBase.getCanonicalFile(), sanitizedRuleBase(sanitized).getCanonicalFile());
+        assertEquals(0, emptyBase.listFiles().length);
+        assertFalse(sanitized.toPath().startsWith(emptyBase.toPath()));
+
+        Files.writeString(new File(emptyBase, "unexpected.keep").toPath(), "-keep class Unexpected");
+        ExtenderException exception = assertThrows(
+                ExtenderException.class,
+                () -> R8RulePolicy.writeSanitized(
+                        new File(tempDir, "second.keep"),
+                        "-keep class Second".getBytes(StandardCharsets.UTF_8),
+                        emptyBase));
+        assertTrue(exception.getMessage().contains("sandbox is not empty"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "-alwaysinline",
+            "-checkenumstringsdiscarded",
+            "-assumenoexternalsideeffects",
+            "-checkenumunboxed",
+            "-alwaysclassinline"
+    })
+    public void testRulePolicyAllowsPinnedR8ClassSpecOptions(String option) {
+        assertDoesNotThrow(() -> R8RulePolicy.validateRules(
+                option + "\n@com.example.Marker class *",
+                "class-spec.keep"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "@/etc/passwd",
+            "@ /etc/hosts",
+            "@# hidden operand\n/etc/hosts",
+            "@\"/etc/hosts\"",
+            "@file:///etc/hosts",
+            "@../other-job/rules.keep",
+            "@~/rules.keep",
+            "@C:\\server\\rules.keep",
+            "@${user.home}/rules.keep",
+            "@<java.home>/rules.keep",
+            "-keepkotlinmetadata\n@/etc/hosts",
+            "-maximumremovedandroidloglevel 4\n@/etc/hosts",
+            "-keepkotlinmetadata\r@/etc/hosts",
+            "# -include /etc/passwd",
+            "# harmless comment\r-include /etc/hosts",
+            "\uFEFF-include /etc/hosts",
+            "-renamesourcefileattribute \"-include /etc/hosts\"",
+            "-renamesourcefileattribute \"foo\\\" -include /etc/hosts \"",
+            "-renamesourcefileattribute {\n@/etc/hosts",
+            "}-include /etc/hosts",
+            "-keep class Safe @../other-job/rules.keep",
+            "-include /etc/passwd",
+            "-basedirectory /",
+            "-injars /tmp/input.jar",
+            "-outjars /tmp/output.jar",
+            "-libraryjars /tmp/library.jar",
+            "-applymapping /tmp/mapping.txt",
+            "-obfuscationdictionary /tmp/words.txt",
+            "-classobfuscationdictionary /tmp/classes.txt",
+            "-packageobfuscationdictionary /tmp/packages.txt",
+            "-printusage /tmp/usage.txt",
+            "-printconfiguration /tmp/configuration.txt",
+            "-printmapping /tmp/mapping.txt",
+            "-printseeds /tmp/seeds.txt",
+            "-dump /tmp/dump.txt"
+    })
+    public void testRulePolicyRejectsFilesystemDirectives(String rules) {
+        ExtenderException exception = assertThrows(
+                ExtenderException.class,
+                () -> R8RulePolicy.validateRules(rules, "unsafe.keep"));
+
+        assertTrue(exception.getMessage().contains("forbidden filesystem directive"));
+    }
+
+    @Test
+    public void testEmbeddedRuleEntryCountIsBounded(@TempDir File tempDir) throws Exception {
+        Map<String, String> entries = new LinkedHashMap<>();
+        for (int index = 0; index <= R8RulePolicy.MAX_RULE_FILES; ++index) {
+            entries.put(String.format("META-INF/proguard/rule-%04d.pro", index), "-keep class Example");
+        }
+        File jar = createJar(new File(tempDir, "too-many-rules.jar"), entries);
+
+        ExtenderException exception = assertThrows(
+                ExtenderException.class,
+                () -> R8Builder.selectEmbeddedRuleEntries(jar, "8.13.19"));
+
+        assertTrue(exception.getMessage().contains("Too many embedded R8 rule files"));
+    }
+
+    @Test
+    public void testEmbeddedRuleExpandedSizeIsBounded(@TempDir File tempDir) throws Exception {
+        String oversizedRule = " ".repeat((int) R8RulePolicy.MAX_RULE_FILE_BYTES + 1);
+        File jar = createJar(
+                new File(tempDir, "oversized-rule.jar"),
+                Map.of("META-INF/proguard/oversized.pro", oversizedRule));
+        File outputDir = new File(tempDir, "collected");
+
+        ExtenderException exception = assertThrows(
+                ExtenderException.class,
+                () -> R8Builder.collectConsumerRules(
+                        List.of(jar.getAbsolutePath()),
+                        List.of(),
+                        "8.13.19",
+                        outputDir));
+
+        assertTrue(exception.getMessage().contains("R8 rule file is too large"));
+        assertEquals(0, outputDir.listFiles().length);
+    }
+
+    @Test
+    public void testEmbeddedConsumerRuleUsesFilesystemPolicy(@TempDir File tempDir) throws Exception {
+        File jar = createJar(
+                new File(tempDir, "unsafe-consumer-rule.jar"),
+                Map.of("META-INF/proguard/unsafe.pro", "-include /etc/passwd"));
+
+        ExtenderException exception = assertThrows(
+                ExtenderException.class,
+                () -> R8Builder.collectConsumerRules(
+                        List.of(jar.getAbsolutePath()),
+                        List.of(),
+                        "8.13.19",
+                        new File(tempDir, "collected")));
+
+        assertTrue(exception.getMessage().contains("forbidden filesystem directive"));
+    }
+
+    @Test
+    public void testMalformedR8SuffixConsumerRuleUsesFilesystemPolicy(@TempDir File tempDir)
+            throws Exception {
+        File jar = createJar(
+                new File(tempDir, "unsafe-malformed-suffix.jar"),
+                Map.of(
+                        "META-INF/com.android.tools/r8-from-0.0.0-arbitrary/unsafe.pro",
+                        "-include /etc/passwd"));
+
+        ExtenderException exception = assertThrows(
+                ExtenderException.class,
+                () -> R8Builder.collectConsumerRules(
+                        List.of(jar.getAbsolutePath()),
+                        List.of(),
+                        "8.13.19",
+                        new File(tempDir, "collected")));
+
+        assertTrue(exception.getMessage().contains("forbidden filesystem directive"));
+    }
+}

--- a/server/src/test/java/com/defold/extender/R8BuilderTest.java
+++ b/server/src/test/java/com/defold/extender/R8BuilderTest.java
@@ -201,7 +201,9 @@ public class R8BuilderTest {
                 (command, context) -> {
                     captured.put("command", command);
                     try {
-                        Files.writeString(new File(buildDir, "classes.dex").toPath(), "dex");
+                        Files.writeString(
+                                new File((String) context.get("classes_dex_dir"), "classes.dex").toPath(),
+                                "dex");
                         Files.writeString(new File((String) context.get("mapping")).toPath(), "mapping");
                     } catch (IOException e) {
                         throw new ExtenderException(e, "Failed to create fake R8 outputs");
@@ -212,6 +214,7 @@ public class R8BuilderTest {
         return captured.get("command");
     }
 
+    // Verifies that only _app/app.keep opts into R8; app.pro and extension consumer rules alone do not.
     @Test
     public void testOnlyAppKeepRequestsR8(@TempDir File uploadDir) throws Exception {
         File appDir = new File(uploadDir, "_app");
@@ -219,10 +222,18 @@ public class R8BuilderTest {
         Files.writeString(new File(appDir, "app.pro").toPath(), "-keep class Legacy");
         assertFalse(R8Builder.isRequested(uploadDir));
 
+        File extensionRulesDir = new File(uploadDir, "extension/manifests/android");
+        assertTrue(extensionRulesDir.mkdirs());
+        Files.writeString(
+                new File(extensionRulesDir, "consumer.keep").toPath(),
+                "-keep class ExtensionConsumer");
+        assertFalse(R8Builder.isRequested(uploadDir));
+
         Files.writeString(new File(appDir, "app.keep").toPath(), "-keep class Current");
         assertTrue(R8Builder.isRequested(uploadDir));
     }
 
+    // Verifies that a build without _app/app.keep skips R8 before requiring aapt rules or executing its command.
     @Test
     public void testNoAppKeepSkipsR8WithoutAaptRules(@TempDir File tempDir) throws Exception {
         File uploadDir = new File(tempDir, "upload");
@@ -248,6 +259,7 @@ public class R8BuilderTest {
         assertNull(builder.build(List.of(), Map.of(), mainDexRules, null, null));
     }
 
+    // Verifies that pre-21 builds pass sanitized engine and aapt main-dex rules while API 21+ builds pass none.
     @Test
     public void testMainDexRulesAreOnlyPassedBelowApi21(@TempDir File tempDir) throws Exception {
         File api19Dir = new File(tempDir, "api19");
@@ -279,6 +291,7 @@ public class R8BuilderTest {
         assertFalse(api21Command.contains("--main-dex-rules"));
     }
 
+    // Verifies that R8/aapt commands preserve exact quoting and literals, conditional rule flags, and data resources.
     @Test
     public void testConfiguredCommandPreservesQuotedPathSpecialCharacters() throws Exception {
         File root = new File("test-data");
@@ -316,6 +329,7 @@ public class R8BuilderTest {
         List<String> arguments = CommandLineTokenizer.parse(rendered);
 
         assertFalse(rendered.contains("&amp;"));
+        assertFalse(arguments.contains("--no-data-resources"));
         assertTrue(rendered.contains("{{literal}}"));
         assertTrue(arguments.contains(r8Jar));
         assertTrue(arguments.contains(androidJar));
@@ -353,6 +367,7 @@ public class R8BuilderTest {
         assertTrue(aaptArguments.contains(aaptMainDexRules));
     }
 
+    // Verifies that requested R8 builds fail before command execution when aapt-generated keep rules are missing.
     @Test
     public void testMissingAaptGeneratedRulesIsAnError(@TempDir File tempDir) throws Exception {
         File uploadDir = new File(tempDir, "upload");
@@ -391,6 +406,7 @@ public class R8BuilderTest {
         assertFalse(commandExecuted[0]);
     }
 
+    // Verifies that pre-21 R8 builds fail before command execution when aapt main-dex rules are missing.
     @Test
     public void testMissingPre21AaptMainDexRulesIsAnError(@TempDir File tempDir) throws Exception {
         File uploadDir = new File(tempDir, "upload");
@@ -429,6 +445,7 @@ public class R8BuilderTest {
         assertFalse(commandExecuted[0]);
     }
 
+    // Verifies that aapt-generated keep rules pass the filesystem-directive policy before R8 can execute.
     @Test
     public void testAaptGeneratedRulesUseFilesystemPolicy(@TempDir File tempDir) throws Exception {
         File uploadDir = new File(tempDir, "upload");
@@ -461,6 +478,7 @@ public class R8BuilderTest {
         assertFalse(commandExecuted[0]);
     }
 
+    // Verifies that aapt-generated main-dex rules pass the filesystem-directive policy before R8 can execute.
     @Test
     public void testAaptMainDexRulesUseFilesystemPolicy(@TempDir File tempDir) throws Exception {
         File uploadDir = new File(tempDir, "upload");
@@ -502,6 +520,7 @@ public class R8BuilderTest {
         assertFalse(commandExecuted[0]);
     }
 
+    // Verifies that missing SDK R8 configuration is reported before secondary missing-rule validation.
     @Test
     public void testMissingR8ConfigurationIsReportedBeforeMissingAaptRules(@TempDir File tempDir) throws Exception {
         File uploadDir = new File(tempDir, "upload");
@@ -532,6 +551,7 @@ public class R8BuilderTest {
         assertFalse(exception.getMessage().contains("aapt-generated.keep"));
     }
 
+    // Verifies that a blank resolved R8 path produces a clear configuration error without invoking R8.
     @Test
     public void testBlankResolvedR8EnvironmentProducesClearConfigurationError(@TempDir File tempDir) throws Exception {
         File uploadDir = new File(tempDir, "upload");
@@ -569,6 +589,7 @@ public class R8BuilderTest {
         assertTrue(exception.getOutput().contains("does not provide r8Cmd and r8Version"));
     }
 
+    // Verifies that absent R8 command fields and malformed pinned versions are rejected with distinct errors.
     @Test
     public void testMissingConfigurationIsAnError() {
         ExtenderException missing = assertThrows(
@@ -582,6 +603,7 @@ public class R8BuilderTest {
         assertTrue(invalid.getMessage().contains("Invalid r8Version"));
     }
 
+    // Verifies that supported R8 rule-directory ranges and suffixes use inclusive from and exclusive upto matching.
     @Test
     public void testRuleVersionRanges() {
         assertTrue(R8Builder.isApplicableRuleDirectory("r8", "8.13.19"));
@@ -596,6 +618,7 @@ public class R8BuilderTest {
         assertFalse(R8Builder.isApplicableRuleDirectory("r8foo", "8.13.19"));
     }
 
+    // Verifies that targeted-rule selection is deterministic and falls back to legacy META-INF/proguard rules when needed.
     @Test
     public void testSelectTargetedRulesWithLegacyFallback(@TempDir File tempDir) throws Exception {
         Map<String, String> entries = new HashMap<>();
@@ -619,6 +642,7 @@ public class R8BuilderTest {
                 R8Builder.selectEmbeddedRuleEntries(legacyJar, "8.13.19"));
     }
 
+    // Verifies that pinned R8 handles prerelease, arbitrary, future, and lookalike rule-directory suffixes correctly.
     @Test
     public void testSelectTargetedRulesMatchesPinnedR8SuffixHandling(@TempDir File tempDir)
             throws Exception {
@@ -641,6 +665,7 @@ public class R8BuilderTest {
                 R8Builder.selectEmbeddedRuleEntries(jar, "8.13.19"));
     }
 
+    // Verifies that duplicate embedded consumer-rule entry names are rejected instead of being applied ambiguously.
     @Test
     public void testDuplicateEmbeddedRuleNamesAreRejected(@TempDir File tempDir) throws Exception {
         File jar = createJarWithDuplicateEntries(
@@ -656,6 +681,7 @@ public class R8BuilderTest {
         assertTrue(exception.getMessage().contains("Duplicate embedded R8 rule entry"));
     }
 
+    // Verifies that stripping consumer rules removes every supported rule namespace while preserving all other JAR entries.
     @Test
     public void testStripEmbeddedRulesRetainsAllOtherRawJarEntries(@TempDir File tempDir)
             throws Exception {
@@ -697,6 +723,7 @@ public class R8BuilderTest {
         }
     }
 
+    // Verifies that a JAR without embedded consumer rules is returned unchanged and no replacement JAR is written.
     @Test
     public void testStripEmbeddedRulesReturnsOriginalWhenNoRulesExist(@TempDir File tempDir)
             throws Exception {
@@ -713,6 +740,7 @@ public class R8BuilderTest {
         assertFalse(requestedOutput.exists());
     }
 
+    // Verifies that rule stripping preserves directory entries, compression methods, and retained entry contents.
     @Test
     public void testStripEmbeddedRulesPreservesStoredDeflatedAndDirectoryEntries(@TempDir File tempDir)
             throws Exception {
@@ -762,6 +790,7 @@ public class R8BuilderTest {
         }
     }
 
+    // Verifies that JAR discovery supports both locally unpacked AARs and AGP exploded-AAR directory layouts.
     @Test
     public void testAndroidPackageJarsSupportLocalAndAgpExplodedLayouts(@TempDir File tempDir)
             throws Exception {
@@ -789,6 +818,7 @@ public class R8BuilderTest {
                 R8Builder.getAndroidPackageJars(explodedAar));
     }
 
+    // Verifies that JAR/AAR consumer rules have deterministic ordering, targeted precedence, and proguard.txt fallback.
     @Test
     public void testCollectJarAndAarConsumerRulesDeterministically(@TempDir File tempDir) throws Exception {
         File standaloneJar = createJar(
@@ -824,6 +854,7 @@ public class R8BuilderTest {
                 contents);
     }
 
+    // Verifies that valid bytecode names generate protection rules across Unicode, package-info, and module edge cases.
     @Test
     public void testGeneratedRulesProtectValidJarClasses(@TempDir File tempDir) throws Exception {
         Map<String, byte[]> entries = new LinkedHashMap<>();
@@ -866,6 +897,7 @@ public class R8BuilderTest {
         assertFalse(contents.contains("module-info"));
     }
 
+    // Verifies that generated keep rules trust the class file's internal name rather than its potentially misleading ZIP path.
     @Test
     public void testGeneratedRulesUseClassFileNameInsteadOfZipEntryName(@TempDir File tempDir)
             throws Exception {
@@ -881,6 +913,7 @@ public class R8BuilderTest {
         assertFalse(contents.contains("x.Entry"));
     }
 
+    // Verifies that class-name metacharacters and directive-like text are neutralized in generated keep patterns.
     @Test
     public void testGeneratedRulesNeutralizeClassNameMetacharacters(@TempDir File tempDir)
             throws Exception {
@@ -913,6 +946,7 @@ public class R8BuilderTest {
         assertFalse(pattern.codePoints().anyMatch(Character::isWhitespace));
     }
 
+    // Verifies that a malicious ZIP entry name cannot inject directives when the bytecode contains a safe class name.
     @Test
     public void testGeneratedRulesIgnoreMaliciousZipEntryName(@TempDir File tempDir)
             throws Exception {
@@ -932,6 +966,7 @@ public class R8BuilderTest {
         assertEquals(2, contents.lines().count());
     }
 
+    // Verifies that malformed JVM internal class names are rejected without leaving a partial generated rules file.
     @ParameterizedTest
     @ValueSource(strings = {"p//Foo", "p/Foo.Bar", "p/Foo;Bar", "p/Foo[Bar", "/Foo", "Foo/"})
     public void testGeneratedRulesRejectMalformedInternalClassNames(
@@ -950,6 +985,7 @@ public class R8BuilderTest {
         assertFalse(output.exists());
     }
 
+    // Verifies that malformed class-file bytes produce a precise error and no generated rules output.
     @Test
     public void testGeneratedRulesRejectMalformedClassFile(@TempDir File tempDir) throws Exception {
         File jar = createJar(
@@ -966,6 +1002,7 @@ public class R8BuilderTest {
         assertFalse(output.exists());
     }
 
+    // Verifies that class-file header inflation is bounded before a compressed input can exhaust memory.
     @Test
     public void testGeneratedRulesBoundClassFileHeaderDecompression(@TempDir File tempDir)
             throws Exception {
@@ -982,6 +1019,7 @@ public class R8BuilderTest {
         assertFalse(output.exists());
     }
 
+    // Verifies that generated extension rules enforce the maximum number of enumerated classes.
     @Test
     public void testGeneratedRuleClassCountIsBoundedDuringJarEnumeration(@TempDir File tempDir)
             throws Exception {
@@ -1001,6 +1039,7 @@ public class R8BuilderTest {
         assertFalse(output.exists());
     }
 
+    // Verifies that generated extension rules enforce a total output-size budget during JAR enumeration.
     @Test
     public void testGeneratedRuleBytesAreBoundedDuringJarEnumeration(@TempDir File tempDir)
             throws Exception {
@@ -1021,6 +1060,7 @@ public class R8BuilderTest {
         assertFalse(output.exists());
     }
 
+    // Verifies that .keep discovery is recursive only under manifests/android and explicit rules disable automatic JAR protection.
     @Test
     public void testExtensionRuleDiscoveryIsRecursiveAndFolderScoped(@TempDir File tempDir) throws Exception {
         File extensionDir = new File(tempDir, "extension");
@@ -1046,6 +1086,7 @@ public class R8BuilderTest {
         assertTrue(context.protectedJars.isEmpty());
     }
 
+    // Verifies that a rules-only extension placeholder is never forwarded to R8 as a program JAR.
     @Test
     public void testRulesOnlyPlaceholderNeverBecomesAProgramJar() {
         R8Builder.ExtensionContext context = new R8Builder.ExtensionContext();
@@ -1056,6 +1097,7 @@ public class R8BuilderTest {
         assertEquals(List.of("/tmp/real.jar"), R8Builder.getCompiledJars(extensionJars));
     }
 
+    // Verifies that a full build assembles and sanitizes rules, strips consumer entries, and returns dex and mapping outputs.
     @Test
     public void testBuildAssemblesExtensionAndAarRulesAndReturnsMapping(@TempDir File tempDir) throws Exception {
         File uploadDir = new File(tempDir, "upload");
@@ -1115,7 +1157,9 @@ public class R8BuilderTest {
                     executedCommand.put("command", command);
                     executedContext.putAll(context);
                     try {
-                        Files.writeString(new File(buildDir, "classes.dex").toPath(), "dex");
+                        Files.writeString(
+                                new File((String) context.get("classes_dex_dir"), "classes.dex").toPath(),
+                                "dex");
                         Files.writeString(new File((String) context.get("mapping")).toPath(), "mapping");
                     } catch (IOException e) {
                         throw new ExtenderException(e, "Failed to create fake R8 outputs");
@@ -1132,6 +1176,7 @@ public class R8BuilderTest {
         assertNotNull(output);
         assertEquals(List.of("classes.dex"), Arrays.stream(output.dexFiles).map(File::getName).toList());
         assertEquals("mapping.txt", output.mappingFile.getName());
+        assertEquals(0, output.metaInformationFiles.length);
         assertEquals(output.mappingFile.getAbsolutePath(), executedContext.get("mapping"));
 
         @SuppressWarnings("unchecked")
@@ -1205,6 +1250,7 @@ public class R8BuilderTest {
         }
     }
 
+    // Verifies that supported annotation-based R8 class and member specifications pass rule validation.
     @Test
     public void testRulePolicyAllowsAnnotationRules() {
         String rules = String.join("\n",
@@ -1223,6 +1269,7 @@ public class R8BuilderTest {
         assertDoesNotThrow(() -> R8RulePolicy.validateRules(rules, "safe.keep"));
     }
 
+    // Verifies that rule sanitization normalizes a BOM, uses an empty isolated base, and rejects a contaminated sandbox.
     @Test
     public void testSanitizedRuleUsesSeparateEmptyBaseAndNormalizesBom(@TempDir File tempDir)
             throws Exception {
@@ -1255,6 +1302,7 @@ public class R8BuilderTest {
         assertTrue(exception.getMessage().contains("sandbox is not empty"));
     }
 
+    // Verifies that the pinned R8-only class-spec options accepted by dependencies pass policy validation.
     @ParameterizedTest
     @ValueSource(strings = {
             "-alwaysinline",
@@ -1269,6 +1317,7 @@ public class R8BuilderTest {
                 "class-spec.keep"));
     }
 
+    // Verifies that direct and obfuscated filesystem directives are rejected across includes, paths, and output options.
     @ParameterizedTest
     @ValueSource(strings = {
             "@/etc/passwd",
@@ -1315,6 +1364,7 @@ public class R8BuilderTest {
         assertTrue(exception.getMessage().contains("forbidden filesystem directive"));
     }
 
+    // Verifies that the number of embedded consumer-rule files is bounded before extraction.
     @Test
     public void testEmbeddedRuleEntryCountIsBounded(@TempDir File tempDir) throws Exception {
         Map<String, String> entries = new LinkedHashMap<>();
@@ -1330,6 +1380,7 @@ public class R8BuilderTest {
         assertTrue(exception.getMessage().contains("Too many embedded R8 rule files"));
     }
 
+    // Verifies that expanded embedded rule data is size-bounded and leaves no partial extracted files on failure.
     @Test
     public void testEmbeddedRuleExpandedSizeIsBounded(@TempDir File tempDir) throws Exception {
         String oversizedRule = " ".repeat((int) R8RulePolicy.MAX_RULE_FILE_BYTES + 1);
@@ -1350,6 +1401,7 @@ public class R8BuilderTest {
         assertEquals(0, outputDir.listFiles().length);
     }
 
+    // Verifies that legacy embedded consumer rules are subjected to the same filesystem-directive policy as app rules.
     @Test
     public void testEmbeddedConsumerRuleUsesFilesystemPolicy(@TempDir File tempDir) throws Exception {
         File jar = createJar(
@@ -1367,6 +1419,7 @@ public class R8BuilderTest {
         assertTrue(exception.getMessage().contains("forbidden filesystem directive"));
     }
 
+    // Verifies that rules under malformed-but-applicable R8 suffix directories cannot bypass filesystem policy checks.
     @Test
     public void testMalformedR8SuffixConsumerRuleUsesFilesystemPolicy(@TempDir File tempDir)
             throws Exception {

--- a/server/src/test/java/com/defold/extender/R8ConfigurationTest.java
+++ b/server/src/test/java/com/defold/extender/R8ConfigurationTest.java
@@ -1,0 +1,31 @@
+package com.defold.extender;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+public class R8ConfigurationTest {
+    @Test
+    public void testR8LimitsBindFromServerConfiguration() {
+        R8Configuration configuration = new Binder(new MapConfigurationPropertySource(Map.of(
+                "extender.r8.max-generated-extension-classes", 11,
+                "extender.r8.max-classfile-header-bytes", 12,
+                "extender.r8.max-total-classfile-header-bytes", 13,
+                "extender.r8.max-rule-files", 14,
+                "extender.r8.max-rule-file-bytes", 15,
+                "extender.r8.max-total-rule-bytes", 16)))
+                .bind("extender.r8", R8Configuration.class)
+                .get();
+
+        assertEquals(11, configuration.getMaxGeneratedExtensionClasses());
+        assertEquals(12, configuration.getMaxClassfileHeaderBytes());
+        assertEquals(13, configuration.getMaxTotalClassfileHeaderBytes());
+        assertEquals(14, configuration.getMaxRuleFiles());
+        assertEquals(15, configuration.getMaxRuleFileBytes());
+        assertEquals(16, configuration.getMaxTotalRuleBytes());
+    }
+}

--- a/server/src/test/java/com/defold/extender/R8LambdaRegressionTest.java
+++ b/server/src/test/java/com/defold/extender/R8LambdaRegressionTest.java
@@ -1,0 +1,173 @@
+package com.defold.extender;
+
+import com.android.tools.r8.CompilationMode;
+import com.android.tools.r8.OutputMode;
+import com.android.tools.r8.R8;
+import com.android.tools.r8.R8Command;
+import com.android.tools.r8.Version;
+import com.android.tools.r8.origin.Origin;
+
+import org.jf.dexlib2.DexFileFactory;
+import org.jf.dexlib2.Opcodes;
+import org.jf.dexlib2.iface.ClassDef;
+import org.jf.dexlib2.iface.DexFile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class R8LambdaRegressionTest {
+    private static Path writeSource(Path sourceRoot, String relativePath, String source) throws IOException {
+        Path sourceFile = sourceRoot.resolve(relativePath);
+        Files.createDirectories(sourceFile.getParent());
+        Files.writeString(sourceFile, source);
+        return sourceFile;
+    }
+
+    private static void compileJava8(Path outputDir, List<Path> sources) throws IOException {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        assertNotNull(compiler, "Tests must run on a JDK, not a JRE");
+        Files.createDirectories(outputDir);
+
+        List<String> arguments = new ArrayList<>(List.of(
+                "-Xlint:-options",
+                "--release", "8",
+                "-d", outputDir.toString()));
+        for (Path source : sources) {
+            arguments.add(source.toString());
+        }
+
+        ByteArrayOutputStream diagnostics = new ByteArrayOutputStream();
+        int result = compiler.run(null, diagnostics, diagnostics, arguments.toArray(String[]::new));
+        assertEquals(0, result, diagnostics.toString(StandardCharsets.UTF_8));
+    }
+
+    private static void createJar(Path classesDir, Path jar) throws IOException {
+        List<Path> classFiles;
+        try (Stream<Path> paths = Files.walk(classesDir)) {
+            classFiles = paths.filter(Files::isRegularFile).sorted().toList();
+        }
+
+        try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jar))) {
+            for (Path classFile : classFiles) {
+                String entryName = classesDir.relativize(classFile).toString().replace('\\', '/');
+                JarEntry entry = new JarEntry(entryName);
+                entry.setTime(0L);
+                output.putNextEntry(entry);
+                Files.copy(classFile, output);
+                output.closeEntry();
+            }
+        }
+    }
+
+    @Test
+    void pinnedR8CompilesJava8LambdaWithoutLambdaMetafactorySuppression(@TempDir Path tempDir)
+            throws Exception {
+        assertEquals(8, Version.getMajorVersion());
+        assertEquals(13, Version.getMinorVersion());
+        assertEquals(19, Version.getPatchVersion());
+
+        Path programSources = tempDir.resolve("program-sources");
+        Path programClasses = tempDir.resolve("program-classes");
+        Path programSource = writeSource(
+                programSources,
+                "com/defold/r8test/LambdaProgram.java",
+                """
+                package com.defold.r8test;
+
+                import java.util.function.Function;
+
+                public final class LambdaProgram {
+                    public static String run(String value) {
+                        Function<String, String> prefix = input -> "lambda:" + input;
+                        return prefix.apply(value);
+                    }
+                }
+                """);
+        compileJava8(programClasses, List.of(programSource));
+
+        Path lambdaClass = programClasses.resolve("com/defold/r8test/LambdaProgram.class");
+        String classFileConstants = new String(Files.readAllBytes(lambdaClass), StandardCharsets.ISO_8859_1);
+        assertTrue(classFileConstants.contains("java/lang/invoke/LambdaMetafactory"),
+                "The regression input must contain a real Java 8 invokedynamic lambda");
+
+        Path librarySources = tempDir.resolve("library-sources");
+        Path libraryClasses = tempDir.resolve("library-classes");
+        List<Path> librarySourceFiles = List.of(
+                writeSource(librarySources, "java/lang/Object.java", """
+                        package java.lang;
+                        public class Object {
+                            public Object() {}
+                        }
+                        """),
+                writeSource(librarySources, "java/lang/String.java", """
+                        package java.lang;
+                        public final class String extends Object {}
+                        """),
+                writeSource(librarySources, "java/lang/StringBuilder.java", """
+                        package java.lang;
+                        public final class StringBuilder extends Object {
+                            public StringBuilder() {}
+                            public StringBuilder append(String value) { return this; }
+                            public String toString() { return null; }
+                        }
+                        """),
+                writeSource(librarySources, "java/util/function/Function.java", """
+                        package java.util.function;
+                        public interface Function<T, R> {
+                            R apply(T value);
+                        }
+                        """));
+        compileJava8(libraryClasses, librarySourceFiles);
+
+        Path programJar = tempDir.resolve("program.jar");
+        Path libraryJar = tempDir.resolve("android-minimal.jar");
+        createJar(programClasses, programJar);
+        createJar(libraryClasses, libraryJar);
+        assertFalse(Files.exists(libraryClasses.resolve("java/lang/invoke/LambdaMetafactory.class")),
+                "The Android-like library must not provide LambdaMetafactory");
+
+        List<String> keepRules = List.of("-keep class com.defold.r8test.LambdaProgram { *; }");
+        assertFalse(keepRules.stream().anyMatch(rule -> rule.contains("dontwarn")));
+        assertFalse(keepRules.stream().anyMatch(rule -> rule.contains("LambdaMetafactory")));
+
+        Path outputDir = tempDir.resolve("r8-output");
+        Path mapping = tempDir.resolve("mapping.txt");
+        Files.createDirectories(outputDir);
+        R8Command command = R8Command.builder()
+                .addProgramFiles(programJar)
+                .addLibraryFiles(libraryJar)
+                .setMode(CompilationMode.RELEASE)
+                .setMinApiLevel(21)
+                .setOutput(outputDir, OutputMode.DexIndexed)
+                .addProguardConfiguration(keepRules, Origin.unknown())
+                .setProguardMapOutputPath(mapping)
+                .build();
+        R8.run(command);
+
+        Path classesDex = outputDir.resolve("classes.dex");
+        assertTrue(Files.size(classesDex) > 0);
+        assertTrue(Files.isRegularFile(mapping));
+
+        DexFile dexFile = DexFileFactory.loadDexFile(classesDex.toFile().getAbsolutePath(), Opcodes.forApi(21));
+        assertTrue(dexFile.getClasses().stream()
+                .map(ClassDef::getType)
+                .anyMatch("Lcom/defold/r8test/LambdaProgram;"::equals));
+    }
+}

--- a/server/src/test/java/com/defold/extender/R8LambdaRegressionTest.java
+++ b/server/src/test/java/com/defold/extender/R8LambdaRegressionTest.java
@@ -76,6 +76,7 @@ public class R8LambdaRegressionTest {
         }
     }
 
+    // Verifies that pinned R8 8.13.19 desugars a real Java 8 lambda without requiring LambdaMetafactory or suppression rules.
     @Test
     void pinnedR8CompilesJava8LambdaWithoutLambdaMetafactorySuppression(@TempDir Path tempDir)
             throws Exception {

--- a/server/src/test/java/com/defold/extender/R8ServiceLoaderRegressionTest.java
+++ b/server/src/test/java/com/defold/extender/R8ServiceLoaderRegressionTest.java
@@ -1,0 +1,238 @@
+package com.defold.extender;
+
+import com.android.tools.r8.CompilationFailedException;
+import com.android.tools.r8.CompilationMode;
+import com.android.tools.r8.OutputMode;
+import com.android.tools.r8.R8;
+import com.android.tools.r8.R8Command;
+import com.android.tools.r8.Version;
+import com.android.tools.r8.origin.Origin;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class R8ServiceLoaderRegressionTest {
+    private static final String SERVICE_TYPE = "com.defold.r8test.Greeting";
+    private static final String PROVIDER_TYPE = "com.defold.r8test.GreetingProvider";
+
+    private static Path writeSource(Path sourceRoot, String relativePath, String source) throws IOException {
+        Path sourceFile = sourceRoot.resolve(relativePath);
+        Files.createDirectories(sourceFile.getParent());
+        Files.writeString(sourceFile, source);
+        return sourceFile;
+    }
+
+    private static void compileJava8(Path outputDir, List<Path> sources) throws IOException {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        assertNotNull(compiler, "Tests must run on a JDK, not a JRE");
+        Files.createDirectories(outputDir);
+
+        List<String> arguments = new ArrayList<>(List.of(
+                "-Xlint:-options",
+                "--release", "8",
+                "-d", outputDir.toString()));
+        sources.stream().map(Path::toString).forEach(arguments::add);
+
+        ByteArrayOutputStream diagnostics = new ByteArrayOutputStream();
+        int result = compiler.run(null, diagnostics, diagnostics, arguments.toArray(String[]::new));
+        assertEquals(0, result, diagnostics.toString(StandardCharsets.UTF_8));
+    }
+
+    private static void createJar(Path classesDir, Path jar, Map<String, String> resources)
+            throws IOException {
+        List<Path> classFiles;
+        try (Stream<Path> paths = Files.walk(classesDir)) {
+            classFiles = paths.filter(Files::isRegularFile).sorted().toList();
+        }
+
+        try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jar))) {
+            for (Path classFile : classFiles) {
+                String entryName = classesDir.relativize(classFile).toString().replace('\\', '/');
+                JarEntry entry = new JarEntry(entryName);
+                entry.setTime(0L);
+                output.putNextEntry(entry);
+                Files.copy(classFile, output);
+                output.closeEntry();
+            }
+            for (Map.Entry<String, String> resource : resources.entrySet()) {
+                JarEntry entry = new JarEntry(resource.getKey());
+                entry.setTime(0L);
+                output.putNextEntry(entry);
+                output.write(resource.getValue().getBytes(StandardCharsets.UTF_8));
+                output.closeEntry();
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void runR8(Map<String, Object> context, Path libraryJar) throws ExtenderException {
+        try {
+            List<Path> programJars = ((List<String>) context.get("jars")).stream()
+                    .map(Path::of)
+                    .toList();
+            List<String> rules = new ArrayList<>();
+            for (String ruleFile : (List<String>) context.get("rules")) {
+                rules.addAll(Files.readAllLines(Path.of(ruleFile), StandardCharsets.UTF_8));
+            }
+
+            R8Command command = R8Command.builder()
+                    .addProgramFiles(programJars)
+                    .addLibraryFiles(libraryJar)
+                    .setMode(CompilationMode.RELEASE)
+                    .setMinApiLevel((Integer) context.get("minAndroidSdkVersion"))
+                    .setOutput(Path.of((String) context.get("classes_dex_dir")), OutputMode.DexIndexed)
+                    .addProguardConfiguration(rules, Origin.unknown())
+                    .setProguardMapOutputPath(Path.of((String) context.get("mapping")))
+                    .build();
+            R8.run(command);
+        } catch (CompilationFailedException | IOException e) {
+            throw new ExtenderException(e, "Failed to run the ServiceLoader R8 regression fixture");
+        }
+    }
+
+    // Verifies that R8 output returns the renamed ServiceLoader descriptor and provider instead of stale original names.
+    @Test
+    void returnsR8RewrittenServiceDescriptorInsteadOfOriginalNames(@TempDir Path tempDir)
+            throws Exception {
+        assertEquals(8, Version.getMajorVersion());
+        assertEquals(13, Version.getMinorVersion());
+        assertEquals(19, Version.getPatchVersion());
+
+        Path programSources = tempDir.resolve("program-sources");
+        Path programClasses = tempDir.resolve("program-classes");
+        List<Path> programSourceFiles = List.of(
+                writeSource(programSources, "com/defold/r8test/Greeting.java", """
+                        package com.defold.r8test;
+                        public interface Greeting {
+                            String greet();
+                        }
+                        """),
+                writeSource(programSources, "com/defold/r8test/GreetingProvider.java", """
+                        package com.defold.r8test;
+                        public final class GreetingProvider implements Greeting {
+                            public GreetingProvider() {}
+                            public String greet() { return "hello"; }
+                        }
+                        """),
+                writeSource(programSources, "com/defold/r8test/ServiceMain.java", """
+                        package com.defold.r8test;
+                        import java.util.ServiceLoader;
+                        public final class ServiceMain {
+                            public static String load() {
+                                return ServiceLoader.load(Greeting.class).iterator().next().greet();
+                            }
+                        }
+                        """));
+        compileJava8(programClasses, programSourceFiles);
+
+        Path programJar = tempDir.resolve("program.jar");
+        createJar(
+                programClasses,
+                programJar,
+                Map.of("META-INF/services/" + SERVICE_TYPE, PROVIDER_TYPE + "\n"));
+
+        Path librarySources = tempDir.resolve("library-sources");
+        Path libraryClasses = tempDir.resolve("library-classes");
+        List<Path> librarySourceFiles = List.of(
+                writeSource(librarySources, "java/lang/Object.java", """
+                        package java.lang;
+                        public class Object { public Object() {} }
+                        """),
+                writeSource(librarySources, "java/lang/String.java", """
+                        package java.lang;
+                        public final class String extends Object {}
+                        """),
+                writeSource(librarySources, "java/lang/Class.java", """
+                        package java.lang;
+                        public final class Class<T> extends Object {}
+                        """),
+                writeSource(librarySources, "java/util/Iterator.java", """
+                        package java.util;
+                        public interface Iterator<E> { E next(); }
+                        """),
+                writeSource(librarySources, "java/util/ServiceLoader.java", """
+                        package java.util;
+                        public final class ServiceLoader<S> {
+                            public static <S> ServiceLoader<S> load(Class<S> service) { return null; }
+                            public Iterator<S> iterator() { return null; }
+                        }
+                        """));
+        compileJava8(libraryClasses, librarySourceFiles);
+        Path libraryJar = tempDir.resolve("android-minimal.jar");
+        createJar(libraryClasses, libraryJar, Map.of());
+
+        Path uploadDir = tempDir.resolve("upload");
+        Path appDir = uploadDir.resolve("_app");
+        Path buildDir = tempDir.resolve("build");
+        Files.createDirectories(appDir);
+        Files.createDirectories(buildDir);
+        Files.writeString(
+                appDir.resolve("app.keep"),
+                "-keep class com.defold.r8test.ServiceMain { public static java.lang.String load(); }\n");
+        Path aaptRules = buildDir.resolve("aapt-generated.keep");
+        Files.writeString(aaptRules, "-keep class com.defold.r8test.ServiceMain\n");
+
+        PlatformConfig config = new PlatformConfig();
+        config.r8Cmd = "in-process-r8 --output \"{{{classes_dex_dir}}}\"";
+        config.r8Version = "8.13.19";
+        R8Builder builder = new R8Builder(
+                uploadDir.toFile(),
+                buildDir.toFile(),
+                config,
+                List.of(),
+                new HashMap<>(),
+                21,
+                new TemplateExecutor(),
+                (command, context) -> runR8(context, libraryJar));
+
+        R8Builder.BuildOutput output = builder.build(
+                List.of(programJar.toString()),
+                Map.of(),
+                null,
+                aaptRules.toFile(),
+                null);
+
+        assertEquals(1, output.dexFiles.length);
+        assertEquals(buildDir.resolve("classes.dex"), output.dexFiles[0].toPath());
+        assertTrue(Files.size(output.dexFiles[0].toPath()) > 0);
+        assertEquals(1, output.metaInformationFiles.length);
+
+        String mapping = Files.readString(output.mappingFile.toPath());
+        Matcher providerMapping = Pattern.compile(
+                "^" + Pattern.quote(PROVIDER_TYPE) + " -> ([^:]+):$",
+                Pattern.MULTILINE).matcher(mapping);
+        assertTrue(providerMapping.find(), mapping);
+        String renamedProvider = providerMapping.group(1);
+        assertNotEquals(PROVIDER_TYPE, renamedProvider);
+
+        Path serviceDescriptor = output.metaInformationFiles[0].toPath();
+        String relativeDescriptor = buildDir.relativize(serviceDescriptor).toString().replace('\\', '/');
+        assertTrue(relativeDescriptor.startsWith("META-INF/services/"), relativeDescriptor);
+        assertNotEquals("META-INF/services/" + SERVICE_TYPE, relativeDescriptor);
+        assertEquals(renamedProvider, Files.readString(serviceDescriptor).trim());
+        assertFalse(Files.exists(buildDir.resolve("META-INF/services/" + SERVICE_TYPE)));
+    }
+}

--- a/server/src/test/java/com/defold/extender/R8ServiceLoaderRegressionTest.java
+++ b/server/src/test/java/com/defold/extender/R8ServiceLoaderRegressionTest.java
@@ -205,6 +205,7 @@ public class R8ServiceLoaderRegressionTest {
                 List.of(),
                 new HashMap<>(),
                 21,
+                new R8Configuration(),
                 new TemplateExecutor(),
                 (command, context) -> runR8(context, libraryJar));
 

--- a/server/src/test/java/com/defold/extender/R8ServiceLoaderRegressionTest.java
+++ b/server/src/test/java/com/defold/extender/R8ServiceLoaderRegressionTest.java
@@ -211,9 +211,7 @@ public class R8ServiceLoaderRegressionTest {
         R8Builder.BuildOutput output = builder.build(
                 List.of(programJar.toString()),
                 Map.of(),
-                null,
-                aaptRules.toFile(),
-                null);
+                aaptRules.toFile());
 
         assertEquals(1, output.dexFiles.length);
         assertEquals(buildDir.resolve("classes.dex"), output.dexFiles[0].toPath());

--- a/server/src/test/java/com/defold/extender/services/RealGradleServiceTest.java
+++ b/server/src/test/java/com/defold/extender/services/RealGradleServiceTest.java
@@ -1,0 +1,176 @@
+package com.defold.extender.services;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RealGradleServiceTest {
+    @Test
+    public void testBuildTemplateUsesProcessedAndroidArtifacts() throws Exception {
+        String template;
+        try (InputStream input = RealGradleServiceTest.class.getResourceAsStream(
+                "/template.build.gradle")) {
+            assertNotNull(input);
+            template = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+
+        assertTrue(template.contains("AndroidArtifacts.ArtifactType.PROCESSED_AAR.type"));
+        assertTrue(template.contains("AndroidArtifacts.ArtifactType.PROCESSED_JAR.type"));
+        assertTrue(template.contains("project.findProperty(\"android.enableJetifier\")"));
+        assertTrue(template.contains("if (!useJetifier)"));
+        assertTrue(template.contains("getResolvedConfiguration().getResolvedArtifacts()"));
+        assertTrue(template.contains("instanceof ModuleComponentIdentifier"));
+        assertEquals(2, template.split("componentFilter", -1).length - 1);
+        assertFalse(template.contains("findAll(isModuleArtifact)"));
+        assertTrue(template.contains("aarArtifactKeys"));
+        assertTrue(template.contains("getOriginalFileName"));
+        assertTrue(template.contains("identifier.originalFileName"));
+        assertTrue(template.contains("artifact.file.name"));
+        assertFalse(template.contains("aarComponentIds"));
+        assertFalse(template.contains("Unsupported non-module Android dependency"));
+    }
+
+    @Test
+    public void testProcessedDependencyCachesAreSeparatedByJetifierAndAgpVersion() {
+        String jetified = RealGradleService.getDependencyCacheNamespace("8.13.0", true);
+        String plain = RealGradleService.getDependencyCacheNamespace("8.13.0", false);
+        String otherAgp = RealGradleService.getDependencyCacheNamespace("8.14.0", true);
+
+        assertNotEquals(jetified, plain);
+        assertNotEquals(jetified, otherAgp);
+        assertTrue(jetified.contains("processed-v1"));
+        assertTrue(jetified.endsWith("jetified"));
+        assertTrue(plain.endsWith("plain"));
+    }
+
+    @Test
+    public void testProcessedDependencyCacheNamespaceIsPathSafe() {
+        String namespace = RealGradleService.getDependencyCacheNamespace("8.13.0/../../raw", true);
+
+        assertFalse(namespace.contains("/"));
+        assertFalse(namespace.contains("\\"));
+        assertFalse(namespace.contains(".."));
+    }
+
+    @Test
+    public void testDependencyCacheNameIncludesProcessedArtifactContent(@TempDir Path temporaryDirectory)
+            throws Exception {
+        Path first = temporaryDirectory.resolve("first.jar");
+        Path second = temporaryDirectory.resolve("second.jar");
+        Path duplicate = temporaryDirectory.resolve("duplicate.jar");
+        Files.writeString(first, "first processed artifact");
+        Files.writeString(second, "second processed artifact");
+        Files.writeString(duplicate, "first processed artifact");
+
+        String firstName = RealGradleService.getDependencyCacheName(
+                first.toFile(),
+                ".jar");
+        String secondName = RealGradleService.getDependencyCacheName(
+                second.toFile(),
+                ".jar");
+        String duplicateName = RealGradleService.getDependencyCacheName(
+                duplicate.toFile(),
+                ".jar");
+
+        assertNotEquals(firstName, secondName);
+        assertEquals(firstName, duplicateName);
+        assertTrue(firstName.matches("[0-9a-f]{64}\\.jar"));
+    }
+
+    @Test
+    public void testPublishCacheEntryKeepsExistingFileAndDirectory(@TempDir Path temporaryDirectory)
+            throws Exception {
+        Path fileTarget = temporaryDirectory.resolve("winner.jar");
+        Path fileTemporary = temporaryDirectory.resolve("loser.jar.tmp");
+        Files.writeString(fileTarget, "winner");
+        Files.writeString(fileTemporary, "loser");
+
+        RealGradleService.publishCacheEntry(fileTemporary, fileTarget);
+
+        assertEquals("winner", Files.readString(fileTarget));
+        assertFalse(Files.exists(fileTemporary));
+
+        Path directoryTarget = temporaryDirectory.resolve("winner.aar");
+        Path directoryTemporary = temporaryDirectory.resolve("loser.aar.tmp");
+        Files.createDirectory(directoryTarget);
+        Files.writeString(directoryTarget.resolve("winner"), "winner");
+        Files.createDirectory(directoryTemporary);
+        Files.writeString(directoryTemporary.resolve("loser"), "loser");
+
+        RealGradleService.publishCacheEntry(directoryTemporary, directoryTarget);
+
+        assertTrue(Files.exists(directoryTarget.resolve("winner")));
+        assertFalse(Files.exists(directoryTemporary));
+    }
+
+    @Test
+    public void testPublishCacheEntryRethrowsUnexpectedMoveFailure(@TempDir Path temporaryDirectory)
+            throws Exception {
+        Path temporary = temporaryDirectory.resolve("dependency.jar.tmp");
+        Path target = temporaryDirectory.resolve("missing-parent/dependency.jar");
+        Files.writeString(temporary, "dependency");
+
+        assertThrows(
+                IOException.class,
+                () -> RealGradleService.publishCacheEntry(temporary, target));
+        assertFalse(Files.exists(temporary));
+        assertFalse(Files.exists(target));
+    }
+
+    @Test
+    public void testConcurrentDirectoryPublishAcceptsContentAddressedWinner(@TempDir Path temporaryDirectory)
+            throws Exception {
+        Path first = temporaryDirectory.resolve("first.aar.tmp");
+        Path second = temporaryDirectory.resolve("second.aar.tmp");
+        Path target = temporaryDirectory.resolve("dependency.aar");
+        Files.createDirectory(first);
+        Files.writeString(first.resolve("content"), "same processed artifact");
+        Files.createDirectory(second);
+        Files.writeString(second.resolve("content"), "same processed artifact");
+
+        CyclicBarrier beforeMove = new CyclicBarrier(2);
+        Runnable awaitBothWriters = () -> {
+            try {
+                beforeMove.await();
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+        };
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> firstPublish = executor.submit(() -> {
+                RealGradleService.publishCacheEntry(first, target, awaitBothWriters);
+                return null;
+            });
+            Future<?> secondPublish = executor.submit(() -> {
+                RealGradleService.publishCacheEntry(second, target, awaitBothWriters);
+                return null;
+            });
+
+            firstPublish.get();
+            secondPublish.get();
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertEquals("same processed artifact", Files.readString(target.resolve("content")));
+        assertFalse(Files.exists(first));
+        assertFalse(Files.exists(second));
+    }
+}

--- a/server/src/test/java/com/defold/extender/services/RealGradleServiceTest.java
+++ b/server/src/test/java/com/defold/extender/services/RealGradleServiceTest.java
@@ -1,176 +1,178 @@
 package com.defold.extender.services;
 
+import com.defold.extender.ExtenderBuildState;
+import com.defold.extender.ExtenderException;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.ClassPathResource;
 
-import java.io.IOException;
+import java.io.File;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class RealGradleServiceTest {
-    @Test
-    public void testBuildTemplateUsesProcessedAndroidArtifacts() throws Exception {
-        String template;
-        try (InputStream input = RealGradleServiceTest.class.getResourceAsStream(
-                "/template.build.gradle")) {
+    private static String readResource(String path) throws Exception {
+        try (InputStream input = RealGradleServiceTest.class.getResourceAsStream(path)) {
             assertNotNull(input);
-            template = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
         }
+    }
 
-        assertTrue(template.contains("AndroidArtifacts.ArtifactType.PROCESSED_AAR.type"));
+    @Test
+    public void testBuildTemplateReusesAgpArtifacts() throws Exception {
+        String template = readResource("/template.build.gradle");
+
+        assertTrue(template.contains("AndroidArtifacts.ArtifactType.EXPLODED_AAR.type"));
         assertTrue(template.contains("AndroidArtifacts.ArtifactType.PROCESSED_JAR.type"));
-        assertTrue(template.contains("project.findProperty(\"android.enableJetifier\")"));
-        assertTrue(template.contains("if (!useJetifier)"));
-        assertTrue(template.contains("getResolvedConfiguration().getResolvedArtifacts()"));
-        assertTrue(template.contains("instanceof ModuleComponentIdentifier"));
-        assertEquals(2, template.split("componentFilter", -1).length - 1);
-        assertFalse(template.contains("findAll(isModuleArtifact)"));
-        assertTrue(template.contains("aarArtifactKeys"));
-        assertTrue(template.contains("getOriginalFileName"));
-        assertTrue(template.contains("identifier.originalFileName"));
-        assertTrue(template.contains("artifact.file.name"));
-        assertFalse(template.contains("aarComponentIds"));
-        assertFalse(template.contains("Unsupported non-module Android dependency"));
+        assertFalse(template.contains("AndroidArtifacts.ArtifactType.PROCESSED_AAR.type"));
+        assertTrue(template.contains("standaloneJarComponents"));
+        assertTrue(template.contains("standaloneJarComponents.contains(it)"));
+        assertTrue(template.contains("if (useJetifier && !standaloneJarComponents.isEmpty())"));
+        assertTrue(template.contains("kind: \"exploded-aar\""));
+        assertTrue(template.contains("kind: \"jar\""));
+        assertTrue(template.contains("gradle-artifacts.json"));
+        assertTrue(template.contains("JsonOutput.toJson(artifacts)"));
+        assertFalse(template.contains("println \"PATH:"));
     }
 
     @Test
-    public void testProcessedDependencyCachesAreSeparatedByJetifierAndAgpVersion() {
-        String jetified = RealGradleService.getDependencyCacheNamespace("8.13.0", true);
-        String plain = RealGradleService.getDependencyCacheNamespace("8.13.0", false);
-        String otherAgp = RealGradleService.getDependencyCacheNamespace("8.14.0", true);
+    public void testAndroidXIsIndependentFromJetifier() throws Exception {
+        String template = readResource("/template.gradle.properties");
 
-        assertNotEquals(jetified, plain);
-        assertNotEquals(jetified, otherAgp);
-        assertTrue(jetified.contains("processed-v1"));
-        assertTrue(jetified.endsWith("jetified"));
-        assertTrue(plain.endsWith("plain"));
+        assertTrue(template.contains("android.enableJetifier={{android-enable-jetifier}}"));
+        assertTrue(template.contains("android.useAndroidX=true"));
+        assertFalse(template.contains("android.useAndroidX={{android-enable-jetifier}}"));
     }
 
     @Test
-    public void testProcessedDependencyCacheNamespaceIsPathSafe() {
-        String namespace = RealGradleService.getDependencyCacheNamespace("8.13.0/../../raw", true);
-
-        assertFalse(namespace.contains("/"));
-        assertFalse(namespace.contains("\\"));
-        assertFalse(namespace.contains(".."));
+    public void testDependencyResolutionAndReportShareOneGradleInvocation() {
+        assertEquals(
+                List.of(
+                        "gradle",
+                        "downloadDependencies",
+                        "dependencies",
+                        "--configuration",
+                        "releaseCompileClasspath",
+                        "--write-locks",
+                        "--stacktrace",
+                        "--warning-mode",
+                        "all",
+                        "--no-daemon"),
+                RealGradleService.getGradleResolveCommand());
     }
 
     @Test
-    public void testDependencyCacheNameIncludesProcessedArtifactContent(@TempDir Path temporaryDirectory)
+    @SuppressWarnings("unchecked")
+    public void testArtifactManifestReturnsGradleCachePathsDirectly(@TempDir Path temporaryDirectory)
             throws Exception {
-        Path first = temporaryDirectory.resolve("first.jar");
-        Path second = temporaryDirectory.resolve("second.jar");
-        Path duplicate = temporaryDirectory.resolve("duplicate.jar");
-        Files.writeString(first, "first processed artifact");
-        Files.writeString(second, "second processed artifact");
-        Files.writeString(duplicate, "first processed artifact");
+        Path explodedAar = Files.createDirectory(temporaryDirectory.resolve("jetified-library"));
+        Files.createDirectories(explodedAar.resolve("jars"));
+        Files.writeString(explodedAar.resolve("jars/classes.jar"), "classes");
+        Path jar = temporaryDirectory.resolve("jetified-library.jar");
+        Files.writeString(jar, "jar");
 
-        String firstName = RealGradleService.getDependencyCacheName(
-                first.toFile(),
-                ".jar");
-        String secondName = RealGradleService.getDependencyCacheName(
-                second.toFile(),
-                ".jar");
-        String duplicateName = RealGradleService.getDependencyCacheName(
-                duplicate.toFile(),
-                ".jar");
+        JSONArray manifest = new JSONArray();
+        JSONObject aarEntry = new JSONObject();
+        aarEntry.put("component", "com.example:library:1.0");
+        aarEntry.put("originalFileName", "library-1.0.aar");
+        aarEntry.put("kind", "exploded-aar");
+        aarEntry.put("path", explodedAar.toString());
+        manifest.add(aarEntry);
+        JSONObject jarEntry = new JSONObject();
+        jarEntry.put("component", "com.example:library:1.0");
+        jarEntry.put("originalFileName", "library-1.0.jar");
+        jarEntry.put("kind", "jar");
+        jarEntry.put("path", jar.toString());
+        manifest.add(jarEntry);
+        manifest.add(jarEntry);
 
-        assertNotEquals(firstName, secondName);
-        assertEquals(firstName, duplicateName);
-        assertTrue(firstName.matches("[0-9a-f]{64}\\.jar"));
+        Path manifestFile = temporaryDirectory.resolve("gradle-artifacts.json");
+        Files.writeString(manifestFile, manifest.toJSONString());
+
+        assertEquals(
+                List.of(explodedAar.toFile().getCanonicalFile(), jar.toFile().getCanonicalFile()),
+                RealGradleService.parseGradleArtifacts(manifestFile.toFile()));
     }
 
     @Test
-    public void testPublishCacheEntryKeepsExistingFileAndDirectory(@TempDir Path temporaryDirectory)
+    @SuppressWarnings("unchecked")
+    public void testArtifactManifestRejectsInvalidEntries(@TempDir Path temporaryDirectory)
             throws Exception {
-        Path fileTarget = temporaryDirectory.resolve("winner.jar");
-        Path fileTemporary = temporaryDirectory.resolve("loser.jar.tmp");
-        Files.writeString(fileTarget, "winner");
-        Files.writeString(fileTemporary, "loser");
+        Path missing = temporaryDirectory.resolve("missing.jar");
+        JSONObject entry = new JSONObject();
+        entry.put("kind", "jar");
+        entry.put("path", missing.toString());
+        JSONArray manifest = new JSONArray();
+        manifest.add(entry);
 
-        RealGradleService.publishCacheEntry(fileTemporary, fileTarget);
-
-        assertEquals("winner", Files.readString(fileTarget));
-        assertFalse(Files.exists(fileTemporary));
-
-        Path directoryTarget = temporaryDirectory.resolve("winner.aar");
-        Path directoryTemporary = temporaryDirectory.resolve("loser.aar.tmp");
-        Files.createDirectory(directoryTarget);
-        Files.writeString(directoryTarget.resolve("winner"), "winner");
-        Files.createDirectory(directoryTemporary);
-        Files.writeString(directoryTemporary.resolve("loser"), "loser");
-
-        RealGradleService.publishCacheEntry(directoryTemporary, directoryTarget);
-
-        assertTrue(Files.exists(directoryTarget.resolve("winner")));
-        assertFalse(Files.exists(directoryTemporary));
-    }
-
-    @Test
-    public void testPublishCacheEntryRethrowsUnexpectedMoveFailure(@TempDir Path temporaryDirectory)
-            throws Exception {
-        Path temporary = temporaryDirectory.resolve("dependency.jar.tmp");
-        Path target = temporaryDirectory.resolve("missing-parent/dependency.jar");
-        Files.writeString(temporary, "dependency");
-
+        Path manifestFile = temporaryDirectory.resolve("gradle-artifacts.json");
+        Files.writeString(manifestFile, manifest.toJSONString());
         assertThrows(
-                IOException.class,
-                () -> RealGradleService.publishCacheEntry(temporary, target));
-        assertFalse(Files.exists(temporary));
-        assertFalse(Files.exists(target));
+                ExtenderException.class,
+                () -> RealGradleService.parseGradleArtifacts(manifestFile.toFile()));
+
+        Files.writeString(manifestFile, "not-json");
+        assertThrows(
+                ExtenderException.class,
+                () -> RealGradleService.parseGradleArtifacts(manifestFile.toFile()));
     }
 
     @Test
-    public void testConcurrentDirectoryPublishAcceptsContentAddressedWinner(@TempDir Path temporaryDirectory)
-            throws Exception {
-        Path first = temporaryDirectory.resolve("first.aar.tmp");
-        Path second = temporaryDirectory.resolve("second.aar.tmp");
-        Path target = temporaryDirectory.resolve("dependency.aar");
-        Files.createDirectory(first);
-        Files.writeString(first.resolve("content"), "same processed artifact");
-        Files.createDirectory(second);
-        Files.writeString(second.resolve("content"), "same processed artifact");
+    public void testNoDependenciesSkipsGradle(@TempDir Path temporaryDirectory) throws Exception {
+        Path jobDirectory = Files.createDirectory(temporaryDirectory.resolve("job"));
+        Path buildDirectory = Files.createDirectory(jobDirectory.resolve("build"));
+        ExtenderBuildState buildState = mock(ExtenderBuildState.class);
+        when(buildState.getJobDir()).thenReturn(jobDirectory.toFile());
+        when(buildState.getBuildDir()).thenReturn(buildDirectory.toFile());
+        when(buildState.isUsedJetifier()).thenReturn(true);
 
-        CyclicBarrier beforeMove = new CyclicBarrier(2);
-        Runnable awaitBothWriters = () -> {
-            try {
-                beforeMove.await();
-            } catch (Exception e) {
-                throw new IllegalStateException(e);
-            }
-        };
-        ExecutorService executor = Executors.newFixedThreadPool(2);
-        try {
-            Future<?> firstPublish = executor.submit(() -> {
-                RealGradleService.publishCacheEntry(first, target, awaitBothWriters);
-                return null;
-            });
-            Future<?> secondPublish = executor.submit(() -> {
-                RealGradleService.publishCacheEntry(second, target, awaitBothWriters);
-                return null;
-            });
+        RealGradleService service = new RealGradleService(
+                new ByteArrayResource((
+                        "dependencies {\n" +
+                        "{{#user-dependencies}}{{{.}}}{{/user-dependencies}}\n" +
+                        "}\n").getBytes(StandardCharsets.UTF_8)),
+                new ClassPathResource("template.gradle.properties"),
+                new ClassPathResource("template.local.properties"),
+                new SimpleMeterRegistry());
+        List<File> outputFiles = new ArrayList<>();
 
-            firstPublish.get();
-            secondPublish.get();
-        } finally {
-            executor.shutdownNow();
-        }
+        List<File> artifacts = service.resolveDependencies(
+                buildState,
+                Map.of(
+                        "env.ANDROID_SDK_ROOT", "/unused/android-sdk",
+                        "env.ANDROID_SDK_VERSION", "36"),
+                outputFiles);
 
-        assertEquals("same processed artifact", Files.readString(target.resolve("content")));
-        assertFalse(Files.exists(first));
-        assertFalse(Files.exists(second));
+        assertTrue(artifacts.isEmpty());
+        assertEquals(
+                List.of(
+                        buildDirectory.resolve("gradle.lockfile").toFile(),
+                        buildDirectory.resolve("gradle.dependencytree").toFile()),
+                outputFiles);
+        assertEquals("", Files.readString(buildDirectory.resolve("gradle.lockfile")));
+        assertEquals(
+                "No Gradle dependencies were declared.\n",
+                Files.readString(buildDirectory.resolve("gradle.dependencytree")));
+        assertFalse(Files.exists(jobDirectory.resolve("gradle.properties")));
+        assertFalse(Files.exists(jobDirectory.resolve("local.properties")));
+        assertFalse(Files.exists(buildDirectory.resolve("gradle-artifacts.json")));
     }
 }

--- a/server/src/test/java/com/defold/extender/services/RealGradleServiceTest.java
+++ b/server/src/test/java/com/defold/extender/services/RealGradleServiceTest.java
@@ -37,6 +37,7 @@ public class RealGradleServiceTest {
         }
     }
 
+    // Verifies that the Gradle template reuses AGP's exploded AARs and processed JARs and writes a structured artifact manifest.
     @Test
     public void testBuildTemplateReusesAgpArtifacts() throws Exception {
         String template = readResource("/template.build.gradle");
@@ -54,6 +55,7 @@ public class RealGradleServiceTest {
         assertFalse(template.contains("println \"PATH:"));
     }
 
+    // Verifies that AndroidX stays enabled even when Jetifier itself is disabled.
     @Test
     public void testAndroidXIsIndependentFromJetifier() throws Exception {
         String template = readResource("/template.gradle.properties");
@@ -63,6 +65,7 @@ public class RealGradleServiceTest {
         assertFalse(template.contains("android.useAndroidX={{android-enable-jetifier}}"));
     }
 
+    // Verifies that dependency resolution, reporting, and lock generation use one deterministic Gradle invocation.
     @Test
     public void testDependencyResolutionAndReportShareOneGradleInvocation() {
         assertEquals(
@@ -80,6 +83,7 @@ public class RealGradleServiceTest {
                 RealGradleService.getGradleResolveCommand());
     }
 
+    // Verifies that artifact-manifest parsing preserves canonical Gradle cache paths, metadata, ordering, and de-duplicates entries.
     @Test
     @SuppressWarnings("unchecked")
     public void testArtifactManifestReturnsGradleCachePathsDirectly(@TempDir Path temporaryDirectory)
@@ -142,6 +146,7 @@ public class RealGradleServiceTest {
         assertNull(artifacts.get(3).getResourcePackageName());
     }
 
+    // Verifies that missing artifact paths and malformed artifact-manifest JSON are rejected with Extender errors.
     @Test
     @SuppressWarnings("unchecked")
     public void testArtifactManifestRejectsInvalidEntries(@TempDir Path temporaryDirectory)
@@ -165,6 +170,7 @@ public class RealGradleServiceTest {
                 () -> RealGradleService.parseGradleArtifacts(manifestFile.toFile()));
     }
 
+    // Verifies that an empty dependency set skips Gradle while still emitting empty lock and explanatory dependency reports.
     @Test
     public void testNoDependenciesSkipsGradle(@TempDir Path temporaryDirectory) throws Exception {
         Path jobDirectory = Files.createDirectory(temporaryDirectory.resolve("job"));

--- a/server/src/test/java/com/defold/extender/services/RealGradleServiceTest.java
+++ b/server/src/test/java/com/defold/extender/services/RealGradleServiceTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -86,6 +87,12 @@ public class RealGradleServiceTest {
         Path explodedAar = Files.createDirectory(temporaryDirectory.resolve("jetified-library"));
         Files.createDirectories(explodedAar.resolve("jars"));
         Files.writeString(explodedAar.resolve("jars/classes.jar"), "classes");
+        Path flatDirAar = Files.createDirectory(temporaryDirectory.resolve("jetified-local-aar"));
+        Files.createDirectories(flatDirAar.resolve("jars"));
+        Files.writeString(flatDirAar.resolve("jars/classes.jar"), "classes");
+        Path classifierAar = Files.createDirectory(temporaryDirectory.resolve("jetified-classifier-aar"));
+        Files.createDirectories(classifierAar.resolve("jars"));
+        Files.writeString(classifierAar.resolve("jars/classes.jar"), "classes");
         Path jar = temporaryDirectory.resolve("jetified-library.jar");
         Files.writeString(jar, "jar");
 
@@ -96,6 +103,18 @@ public class RealGradleServiceTest {
         aarEntry.put("kind", "exploded-aar");
         aarEntry.put("path", explodedAar.toString());
         manifest.add(aarEntry);
+        JSONObject flatDirEntry = new JSONObject();
+        flatDirEntry.put("component", ":LocalAar:");
+        flatDirEntry.put("originalFileName", "LocalAar.aar");
+        flatDirEntry.put("kind", "exploded-aar");
+        flatDirEntry.put("path", flatDirAar.toString());
+        manifest.add(flatDirEntry);
+        JSONObject classifierEntry = new JSONObject();
+        classifierEntry.put("component", "com.example:library:1.0");
+        classifierEntry.put("originalFileName", "library-1.0-debug.aar");
+        classifierEntry.put("kind", "exploded-aar");
+        classifierEntry.put("path", classifierAar.toString());
+        manifest.add(classifierEntry);
         JSONObject jarEntry = new JSONObject();
         jarEntry.put("component", "com.example:library:1.0");
         jarEntry.put("originalFileName", "library-1.0.jar");
@@ -107,9 +126,20 @@ public class RealGradleServiceTest {
         Path manifestFile = temporaryDirectory.resolve("gradle-artifacts.json");
         Files.writeString(manifestFile, manifest.toJSONString());
 
-        assertEquals(
-                List.of(explodedAar.toFile().getCanonicalFile(), jar.toFile().getCanonicalFile()),
-                RealGradleService.parseGradleArtifacts(manifestFile.toFile()));
+        List<GradleArtifact> artifacts = RealGradleService.parseGradleArtifacts(manifestFile.toFile());
+        assertEquals(4, artifacts.size());
+        assertEquals(explodedAar.toFile().getCanonicalFile(), artifacts.get(0).getFile());
+        assertEquals("com.example:library:1.0", artifacts.get(0).getComponent());
+        assertEquals("library-1.0.aar", artifacts.get(0).getOriginalFileName());
+        assertEquals(GradleArtifact.Kind.EXPLODED_AAR, artifacts.get(0).getKind());
+        assertEquals("com.example-library-1.0.aar", artifacts.get(0).getResourcePackageName());
+        assertEquals(flatDirAar.toFile().getCanonicalFile(), artifacts.get(1).getFile());
+        assertEquals("LocalAar.aar", artifacts.get(1).getResourcePackageName());
+        assertEquals(classifierAar.toFile().getCanonicalFile(), artifacts.get(2).getFile());
+        assertEquals("com.example-library-1.0.aar", artifacts.get(2).getResourcePackageName());
+        assertEquals(jar.toFile().getCanonicalFile(), artifacts.get(3).getFile());
+        assertEquals(GradleArtifact.Kind.JAR, artifacts.get(3).getKind());
+        assertNull(artifacts.get(3).getResourcePackageName());
     }
 
     @Test
@@ -154,7 +184,7 @@ public class RealGradleServiceTest {
                 new SimpleMeterRegistry());
         List<File> outputFiles = new ArrayList<>();
 
-        List<File> artifacts = service.resolveDependencies(
+        List<GradleArtifact> artifacts = service.resolveDependencies(
                 buildState,
                 Map.of(
                         "env.ANDROID_SDK_ROOT", "/unused/android-sdk",

--- a/server/test-data/ext/src/TestGradleHandoff.java
+++ b/server/test-data/ext/src/TestGradleHandoff.java
@@ -1,0 +1,10 @@
+package com.defold;
+
+import com.defold.localaar.InnerJar;
+import com.defold.localaar.LocalAar;
+
+class GradleHandoffTest {
+    static String doStuff() {
+        return LocalAar.DoStuff() + InnerJar.DoStuff() + JarDep.DoStuff();
+    }
+}

--- a/server/test-data/sdk/a/defoldsdk/extender/build.yml
+++ b/server/test-data/sdk/a/defoldsdk/extender/build.yml
@@ -305,7 +305,7 @@ platforms:
     jarCmd: 'jar cf {{outputJar}} -C {{classesDir}} .'
     # mainDexList is automatically created by listing all classes inside the engine jars
     dxCmd: '{{env.ANDROID_BUILD_TOOLS_PATH}}/d8 --min-api {{minAndroidSdkVersion}} --main-dex-rules {{mainDexList}} --output {{classes_dex_dir}} --release --lib {{env.LIBRARYJAR}} {{#jars}}{{.}} {{/jars}}'
-    r8Cmd: 'java -cp "{{{env.R8}}}" com.android.tools.r8.R8 --release --min-api {{minAndroidSdkVersion}} --lib "{{{env.LIBRARYJAR}}}" {{#useMainDexRules}}{{#mainDexRules}}--main-dex-rules "{{{.}}}" {{/mainDexRules}}{{/useMainDexRules}}--pg-map-output "{{{mapping}}}" --no-data-resources --output "{{{classes_dex_dir}}}" {{#rules}}--pg-conf "{{{.}}}" {{/rules}} {{#jars}}"{{{.}}}" {{/jars}}'
+    r8Cmd: 'java -cp "{{{env.R8}}}" com.android.tools.r8.R8 --release --min-api {{minAndroidSdkVersion}} --lib "{{{env.LIBRARYJAR}}}" {{#useMainDexRules}}{{#mainDexRules}}--main-dex-rules "{{{.}}}" {{/mainDexRules}}{{/useMainDexRules}}--pg-map-output "{{{mapping}}}" --output "{{{classes_dex_dir}}}" {{#rules}}--pg-conf "{{{.}}}" {{/rules}} {{#jars}}"{{{.}}}" {{/jars}}'
     r8Version: '{{env.R8_VERSION}}'
     r8RuleSourceRe: '(?i).+(\.keep)$'
     aapt2compileCmd: '{{env.ANDROID_BUILD_TOOLS_PATH}}/aapt2 compile {{resourceFile}} -o {{outputDirectory}}'

--- a/server/test-data/sdk/a/defoldsdk/extender/build.yml
+++ b/server/test-data/sdk/a/defoldsdk/extender/build.yml
@@ -305,11 +305,11 @@ platforms:
     jarCmd: 'jar cf {{outputJar}} -C {{classesDir}} .'
     # mainDexList is automatically created by listing all classes inside the engine jars
     dxCmd: '{{env.ANDROID_BUILD_TOOLS_PATH}}/d8 --min-api {{minAndroidSdkVersion}} --main-dex-rules {{mainDexList}} --output {{classes_dex_dir}} --release --lib {{env.LIBRARYJAR}} {{#jars}}{{.}} {{/jars}}'
-    r8Cmd: 'java -cp "{{{env.R8}}}" com.android.tools.r8.R8 --release --min-api {{minAndroidSdkVersion}} --lib "{{{env.LIBRARYJAR}}}" {{#useMainDexRules}}{{#mainDexRules}}--main-dex-rules "{{{.}}}" {{/mainDexRules}}{{/useMainDexRules}}--pg-map-output "{{{mapping}}}" --output "{{{classes_dex_dir}}}" {{#rules}}--pg-conf "{{{.}}}" {{/rules}} {{#jars}}"{{{.}}}" {{/jars}}'
+    r8Cmd: 'java -cp "{{{env.R8}}}" com.android.tools.r8.R8 --release --min-api {{minAndroidSdkVersion}} --lib "{{{env.LIBRARYJAR}}}" --pg-map-output "{{{mapping}}}" --output "{{{classes_dex_dir}}}" {{#rules}}--pg-conf "{{{.}}}" {{/rules}} {{#jars}}"{{{.}}}" {{/jars}}'
     r8Version: '{{env.R8_VERSION}}'
     r8RuleSourceRe: '(?i).+(\.keep)$'
     aapt2compileCmd: '{{env.ANDROID_BUILD_TOOLS_PATH}}/aapt2 compile {{resourceFile}} -o {{outputDirectory}}'
-    aapt2linkCmd: '{{env.ANDROID_BUILD_TOOLS_PATH}}/aapt2 link {{#extraPackages.length}}--extra-packages {{#extraPackages}}{{.}}{{/extraPackages}}{{/extraPackages.length}} --proto-format --non-final-ids --auto-add-overlay --manifest {{manifestFile}} -I {{env.LIBRARYJAR}} --java {{outJavaDirectory}} -o {{outApkFile}} --emit-ids {{resourceIdsFile}} {{#useR8}}--proguard "{{{aaptKeepRules}}}" {{/useR8}}{{#useR8MainDexRules}}--proguard-main-dex "{{{aaptMainDexRules}}}" {{/useR8MainDexRules}}-R @{{resourceListFile}}'
+    aapt2linkCmd: '{{env.ANDROID_BUILD_TOOLS_PATH}}/aapt2 link {{#extraPackages.length}}--extra-packages {{#extraPackages}}{{.}}{{/extraPackages}}{{/extraPackages.length}} --proto-format --non-final-ids --auto-add-overlay --manifest {{manifestFile}} -I {{env.LIBRARYJAR}} --java {{outJavaDirectory}} -o {{outApkFile}} --emit-ids {{resourceIdsFile}} {{#useR8}}--proguard "{{{aaptKeepRules}}}" {{/useR8}}-R @{{resourceListFile}}'
     manifestName:     'AndroidManifest.xml'
     manifestMergeCmd: 'java -jar {{env.MANIFEST_MERGE_TOOL}} --platform {{platform}} --main {{mainManifest}} {{#libraries}} --lib {{.}} {{/libraries}} --out {{target}}'
 

--- a/server/test-data/sdk/a/defoldsdk/extender/build.yml
+++ b/server/test-data/sdk/a/defoldsdk/extender/build.yml
@@ -268,7 +268,8 @@ platforms:
 
   android:
     env:
-        PROGUARD:                 "{{env.ANDROID_PROGUARD}}"
+        R8:                       "{{env.ANDROID_R8}}"
+        R8_VERSION:               "{{env.ANDROID_R8_VERSION}}"
         LIBRARYJAR:               "{{env.ANDROID_LIBRARYJAR}}"
         NDK_PATH:                 "{{env.ANDROID_NDK_PATH}}"
         SYSROOT:                  "{{env.ANDROID_NDK_SYSROOT}}"
@@ -303,11 +304,12 @@ platforms:
     javacCmd: 'javac -proc:none -source 1.8 -target 1.8 -J-Xms2048m -J-Xmx2048m -classpath {{env.LIBRARYJAR}}:{{classPath}} -d {{classesDir}} @{{sourcesListFile}}'
     jarCmd: 'jar cf {{outputJar}} -C {{classesDir}} .'
     # mainDexList is automatically created by listing all classes inside the engine jars
-    dxCmd: '{{env.ANDROID_BUILD_TOOLS_PATH}}/d8 --main-dex-rules {{mainDexList}} --output {{classes_dex_dir}} --release --lib {{env.LIBRARYJAR}} {{#jars}}{{.}} {{/jars}}'
-    proGuardCmd: 'java -jar {{env.PROGUARD}} {{#src}}-include {{.}} {{/src}} -libraryjars {{env.LIBRARYJAR}} {{#jars}}-injars {{.}} {{/jars}} {{#libraryjars}}-libraryjars {{.}} {{/libraryjars}} -outjar {{tgt}} -printmapping {{mapping}}'
-    proGuardSourceRe: '(?i).+(\.pro)$'
+    dxCmd: '{{env.ANDROID_BUILD_TOOLS_PATH}}/d8 --min-api {{minAndroidSdkVersion}} --main-dex-rules {{mainDexList}} --output {{classes_dex_dir}} --release --lib {{env.LIBRARYJAR}} {{#jars}}{{.}} {{/jars}}'
+    r8Cmd: 'java -cp "{{{env.R8}}}" com.android.tools.r8.R8 --release --min-api {{minAndroidSdkVersion}} --lib "{{{env.LIBRARYJAR}}}" {{#useMainDexRules}}{{#mainDexRules}}--main-dex-rules "{{{.}}}" {{/mainDexRules}}{{/useMainDexRules}}--pg-map-output "{{{mapping}}}" --no-data-resources --output "{{{classes_dex_dir}}}" {{#rules}}--pg-conf "{{{.}}}" {{/rules}} {{#jars}}"{{{.}}}" {{/jars}}'
+    r8Version: '{{env.R8_VERSION}}'
+    r8RuleSourceRe: '(?i).+(\.keep)$'
     aapt2compileCmd: '{{env.ANDROID_BUILD_TOOLS_PATH}}/aapt2 compile {{resourceFile}} -o {{outputDirectory}}'
-    aapt2linkCmd: '{{env.ANDROID_BUILD_TOOLS_PATH}}/aapt2 link {{#extraPackages.length}}--extra-packages {{#extraPackages}}{{.}}{{/extraPackages}}{{/extraPackages.length}} --proto-format --non-final-ids --auto-add-overlay --manifest {{manifestFile}} -I {{env.LIBRARYJAR}} --java {{outJavaDirectory}} -o {{outApkFile}} --emit-ids {{resourceIdsFile}} -R @{{resourceListFile}}'
+    aapt2linkCmd: '{{env.ANDROID_BUILD_TOOLS_PATH}}/aapt2 link {{#extraPackages.length}}--extra-packages {{#extraPackages}}{{.}}{{/extraPackages}}{{/extraPackages.length}} --proto-format --non-final-ids --auto-add-overlay --manifest {{manifestFile}} -I {{env.LIBRARYJAR}} --java {{outJavaDirectory}} -o {{outApkFile}} --emit-ids {{resourceIdsFile}} {{#useR8}}--proguard "{{{aaptKeepRules}}}" {{/useR8}}{{#useR8MainDexRules}}--proguard-main-dex "{{{aaptMainDexRules}}}" {{/useR8MainDexRules}}-R @{{resourceListFile}}'
     manifestName:     'AndroidManifest.xml'
     manifestMergeCmd: 'java -jar {{env.MANIFEST_MERGE_TOOL}} --platform {{platform}} --main {{mainManifest}} {{#libraries}} --lib {{.}} {{/libraries}} --out {{target}}'
 


### PR DESCRIPTION
Android builds can now use R8 for code shrinking and obfuscation, replacing the legacy ProGuard path. R8 preserves Android entry points, extension APIs, dependency consumer rules, and ServiceLoader metadata while producing a mapping file for deobfuscation. Builds without `_app/app.keep` continue to use D8 without shrinking.

Fix https://github.com/defold/extender/issues/566

### Technical changes

- Adds a dedicated R8 pipeline with bounded rule processing, generated keep rules for unconfigured extensions, version-targeted dependency rules, rewritten `META-INF` metadata, dex output, and `mapping.txt`.
- Generates AAPT keep rules for manifest and resource entry points and combines them with application, extension, JAR, and AAR consumer rules.
- Pins R8 8.13.19 in the Android build environment, exposes its path and version through SDK configuration, removes the ProGuard installation, and replaces `DM_DEBUG_DISABLE_PROGUARD` with `DM_DEBUG_DISABLE_R8`.
- Reworks Gradle dependency resolution into one invocation that resolves `releaseRuntimeClasspath`, writes dependency locks and the dependency tree, and emits a deterministic JSON artifact manifest. Gradle is skipped entirely when no dependencies are declared.
- Uses AGP artifact transforms to obtain `EXPLODED_AAR` directories and Jetifier-aware `PROCESSED_JAR` artifacts. Standalone JARs remain unprocessed when Jetifier is disabled, while `android.useAndroidX` stays enabled independently of transformation.
- Removes Extender’s custom `.gradle/unpacked` cache and its extra copy/unpack pass. Artifact paths are canonicalized, validated, deduplicated, and consumed directly from the shared immutable Gradle/AGP cache, reducing duplicate cache storage and filesystem work.
- Supports both traditional exploded AARs and AGP cache layouts, including `jars/classes.jar`, `jars/libs`, resources, assets, JNI libraries, manifests, and consumer rules.
- Preserves legacy Maven resource package names while using collision-safe internal directories for artifacts with identical filenames from different components.
- Keeps D8 as the non-shrinking fallback. Legacy `_app/app.pro` files no longer invoke ProGuard, and the R8 path targets Defold’s API 21+ platform baseline.
- Adds unit and regression coverage for R8 rule selection and safety limits, AAR/JAR layouts, lambdas, ServiceLoader rewriting, Gradle artifact manifests, resource naming, and end-to-end AAR plus classifier-JAR handoff with Jetifier enabled and disabled.