### PR TITLE
Fix Docker image vulnerabilities reported by GCP scanning

### DIFF
--- a/server/build-docker.sh
+++ b/server/build-docker.sh
@@ -18,11 +18,11 @@ MULTI_ARCH="linux/amd64"
 
 # build env image (shared across Dockerfiles)
 echo "Build env image with archs: $MULTI_ARCH"
-docker buildx build --network host --load --platform $MULTI_ARCH -t $DOCKER_REGISTRY/extender-build-env:1.1.0 -t $DOCKER_REGISTRY/extender-build-env:latest -f $SCRIPT_DIR/docker/Dockerfile.build-env $SCRIPT_DIR/docker
+docker buildx build --network host --load --platform $MULTI_ARCH -t $DOCKER_REGISTRY/extender-build-env:1.2.0 -t $DOCKER_REGISTRY/extender-build-env:latest -f $SCRIPT_DIR/docker/Dockerfile.build-env $SCRIPT_DIR/docker
 
 # base images
 echo "Base image with archs: $MULTI_ARCH"
-docker buildx build --network host --load --platform $MULTI_ARCH -t $DOCKER_REGISTRY/extender-base-env:1.7.0 -t $DOCKER_REGISTRY/extender-base-env:latest -f $SCRIPT_DIR/docker/Dockerfile.base-env $SCRIPT_DIR/docker
+docker buildx build --network host --load --platform $MULTI_ARCH -t $DOCKER_REGISTRY/extender-base-env:1.8.0 -t $DOCKER_REGISTRY/extender-base-env:latest -f $SCRIPT_DIR/docker/Dockerfile.base-env $SCRIPT_DIR/docker
 
 REQUESTED="$@"
 [ -z "$REQUESTED" ] && REQUESTED="android windows web ps4 ps5 nintendo xbox linux"
@@ -77,13 +77,13 @@ for request in $REQUESTED; do
             DM_PACKAGES_URL=$DM_PACKAGES_URL docker buildx build --network host --load --secret id=DM_PACKAGES_URL --platform linux/amd64 -t $DOCKER_XBOX_PRIVATE_REGISTRY/extender-${install}-env:latest -f $SCRIPT_DIR/docker/Dockerfile.$(echo $install | sed 's,-,.,')-env $SCRIPT_DIR/docker
             ;;
         wine)
-            DM_PACKAGES_URL=$DM_PACKAGES_URL docker buildx build --network host --load --secret id=DM_PACKAGES_URL --platform linux/amd64 -t $DOCKER_REGISTRY/extender-wine-env:1.9.0 -t $DOCKER_REGISTRY/extender-wine-env:latest -f $SCRIPT_DIR/docker/Dockerfile.wine-env $SCRIPT_DIR/docker
+            DM_PACKAGES_URL=$DM_PACKAGES_URL docker buildx build --network host --load --secret id=DM_PACKAGES_URL --platform linux/amd64 -t $DOCKER_REGISTRY/extender-wine-env:1.10.0 -t $DOCKER_REGISTRY/extender-wine-env:latest -f $SCRIPT_DIR/docker/Dockerfile.wine-env $SCRIPT_DIR/docker
             ;;
         android)
-            DM_PACKAGES_URL=$DM_PACKAGES_URL docker buildx build --network host --load --secret id=DM_PACKAGES_URL --platform linux/amd64 -t $DOCKER_REGISTRY/extender-android-env:1.8.0 -t $DOCKER_REGISTRY/extender-android-env:latest -f $SCRIPT_DIR/docker/Dockerfile.android-env $SCRIPT_DIR/docker
+            DM_PACKAGES_URL=$DM_PACKAGES_URL docker buildx build --network host --load --secret id=DM_PACKAGES_URL --platform linux/amd64 -t $DOCKER_REGISTRY/extender-android-env:1.9.0 -t $DOCKER_REGISTRY/extender-android-env:latest -f $SCRIPT_DIR/docker/Dockerfile.android-env $SCRIPT_DIR/docker
             ;;
         winsdk-2026_145136231)
-            DM_PACKAGES_URL=$DM_PACKAGES_URL docker buildx build --network host --load --secret id=DM_PACKAGES_URL --platform linux/amd64 -t $DOCKER_REGISTRY/extender-winsdk-2026_145136231-env:1.2.0 -t $DOCKER_REGISTRY/extender-winsdk-2026_145136231-env:latest -f $SCRIPT_DIR/docker/Dockerfile.winsdk.2026_145136231-env $SCRIPT_DIR/docker
+            DM_PACKAGES_URL=$DM_PACKAGES_URL docker buildx build --network host --load --secret id=DM_PACKAGES_URL --platform linux/amd64 -t $DOCKER_REGISTRY/extender-winsdk-2026_145136231-env:1.3.0 -t $DOCKER_REGISTRY/extender-winsdk-2026_145136231-env:latest -f $SCRIPT_DIR/docker/Dockerfile.winsdk.2026_145136231-env $SCRIPT_DIR/docker
             ;;
         android-ndk*|winsdk-*|emsdk-*)
             DM_PACKAGES_URL=$DM_PACKAGES_URL docker buildx build --network host --load --secret id=DM_PACKAGES_URL --platform linux/amd64 -t $DOCKER_REGISTRY/extender-${install}-env:latest -f $SCRIPT_DIR/docker/Dockerfile.$(echo $install | sed 's,-,.,')-env $SCRIPT_DIR/docker

--- a/server/docker/Dockerfile.android-env
+++ b/server/docker/Dockerfile.android-env
@@ -1,4 +1,4 @@
-ARG GRADLE_VERSION=9.7.1
+ARG GRADLE_VERSION=9.5.1
 
 FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.2.0 AS build
 

--- a/server/docker/Dockerfile.android-env
+++ b/server/docker/Dockerfile.android-env
@@ -1,4 +1,4 @@
-ARG GRADLE_VERSION=9.5.1
+ARG GRADLE_VERSION=9.7.1
 
 FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.2.0 AS build
 
@@ -21,7 +21,7 @@ ARG GRADLE_VERSION
 
 ENV GRADLE_USER_HOME=/tmp/.gradle
 ENV GRADLE_VERSION=${GRADLE_VERSION}
-ENV GRADLE_PLUGIN_VERSION=8.13.0
+ENV GRADLE_PLUGIN_VERSION=9.4.0
 ENV PATH=${PATH}:/opt/gradle/gradle-${GRADLE_VERSION}/bin
 
 COPY --from=build /opt/gradle /opt/gradle

--- a/server/docker/Dockerfile.android-env
+++ b/server/docker/Dockerfile.android-env
@@ -1,6 +1,6 @@
-ARG GRADLE_VERSION=9.1.0
+ARG GRADLE_VERSION=9.7.1
 
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.1.0 AS build
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.2.0 AS build
 
 ARG GRADLE_VERSION
 
@@ -15,7 +15,7 @@ RUN \
   unzip -q -d /opt/gradle gradle-${GRADLE_VERSION}-bin.zip && \
   rm gradle-${GRADLE_VERSION}-bin.zip
 
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-base-env:1.7.0
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-base-env:1.8.0
 
 ARG GRADLE_VERSION
 

--- a/server/docker/Dockerfile.android.ndk25_sdk36-env
+++ b/server/docker/Dockerfile.android.ndk25_sdk36-env
@@ -15,7 +15,7 @@ ARG ANDROID_NDK_BIN_PATH=${ANDROID_NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_
 ARG ANDROID_SDK_BUILD_TOOLS_PATH=${ANDROID_HOME}/build-tools/${ANDROID_BUILD_TOOLS_VERSION}
 ARG R8_VERSION=8.13.19
 
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.1.0 AS build
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.2.0 AS build
 
 ARG ANDROID_BUILD_TOOLS_VERSION
 ARG ANDROID_SDK_VERSION
@@ -46,6 +46,9 @@ RUN --mount=type=secret,id=DM_PACKAGES_URL,required=true \
     rm -rf "${ANDROID_NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/i686-linux-android" && \
     rm -rf "${ANDROID_NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-*" && \
     rm -rf "${ANDROID_NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/i686-linux-android" && \
+# legacy SDK tools (unused, ships vulnerable jars) and unused pip/setuptools in the NDK python
+    rm -rf "${ANDROID_HOME}/tools" && \
+    rm -rf "${ANDROID_NDK_PATH}"/toolchains/llvm/prebuilt/linux-x86_64/python3/lib/python3.9/site-packages/{pip,pip-*,setuptools,setuptools-*,pkg_resources,_distutils_hack} && \
 # create the .android folder and give read+write permissions (the Android Gradle plugin will write to the folder)
 # It is not enough to give 'user' and 'group'. We unfortunately also need 'others'
     mkdir "${ANDROID_SDK_HOME}" && \
@@ -65,7 +68,7 @@ RUN --mount=type=secret,id=DM_PACKAGES_URL,required=true \
 # R8 contains all classes of D8.
     wget -q -O "${ANDROID_SDK_BUILD_TOOLS_PATH}/lib/d8.jar" "https://storage.googleapis.com/r8-releases/raw/${R8_VERSION}/r8.jar"
 
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-android-env:1.8.0
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-android-env:1.9.0
 
 ARG ANDROID_BUILD_TOOLS_VERSION
 ARG ANDROID_SDK_VERSION
@@ -102,7 +105,7 @@ ENV ANDROID_ROOT=${ANDROID_ROOT} \
     ANDROID_NDK_BIN_PATH=${ANDROID_NDK_BIN_PATH} \
     ANDROID_NDK_SYSROOT=${ANDROID_NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/sysroot \
 # We specify it in build_input.yml by setting it the first in PATH
-    PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${ANDROID_SDK_BUILD_TOOLS_PATH}:${ANDROID_NDK_BIN_PATH} \
+    PATH=${PATH}:${ANDROID_HOME}/platform-tools:${ANDROID_SDK_BUILD_TOOLS_PATH}:${ANDROID_NDK_BIN_PATH} \
     ANDROID_R8=${ANDROID_SDK_BUILD_TOOLS_PATH}/lib/d8.jar \
     ANDROID_R8_VERSION=${R8_VERSION}
 

--- a/server/docker/Dockerfile.base-env
+++ b/server/docker/Dockerfile.base-env
@@ -6,7 +6,7 @@ ARG DOTNET_ROOT=/opt/dotnet
 ARG DOTNET_VERSION_FILE=${DOTNET_ROOT}/dotnet_version
 ARG NUGET_PACKAGES=/tmp/.nuget
 
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.1.0 AS build
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.2.0 AS build
 
 ARG PLATFORMSDK_DIR
 ARG TARGETARCH
@@ -61,7 +61,7 @@ RUN \
   echo "${DOTNET_VERSION}" > "${DOTNET_VERSION_FILE}"
 
 # ubuntu:22.04
-FROM ubuntu@sha256:0e0a0fc6d18feda9db1590da249ac93e8d5abfea8f4c3c0c849ce512b5ef8982
+FROM ubuntu@sha256:2edbbc5dc405e9612ba3584ce95480277e3eb374407b5505fe26f17df77c7dbc
 
 ARG PLATFORMSDK_DIR
 ARG TARGETARCH

--- a/server/docker/Dockerfile.build-env
+++ b/server/docker/Dockerfile.build-env
@@ -1,5 +1,5 @@
 # ubuntu:22.04
-FROM ubuntu@sha256:0e0a0fc6d18feda9db1590da249ac93e8d5abfea8f4c3c0c849ce512b5ef8982
+FROM ubuntu@sha256:2edbbc5dc405e9612ba3584ce95480277e3eb374407b5505fe26f17df77c7dbc
 
 RUN \
   apt-get update && \

--- a/server/docker/Dockerfile.emsdk.406-env
+++ b/server/docker/Dockerfile.emsdk.406-env
@@ -8,9 +8,10 @@ ARG EMSCRIPTEN_BIN=${EMSCRIPTEN_TARGET_DIR}/upstream/emscripten
 
 ARG EMSCRIPTEN_TEMP_DIR=/var/extender/ems_temp
 
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.1.0 AS build
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.2.0 AS build
 
 ARG EMSCRIPTEN_VERSION
+ARG NODE_VERSION
 ARG EMSCRIPTEN_TARGET_DIR
 ARG EMSCRIPTEN_TEMP_DIR
 ARG EMSCRIPTEN_CONFIG
@@ -32,13 +33,17 @@ RUN \
   "${EMSCRIPTEN_TARGET_DIR}/emsdk" activate sdk-${EMSCRIPTEN_VERSION}-64bit && \
   EM_CONFIG="${EMSCRIPTEN_CONFIG}" EM_CACHE="${EMSCRIPTEN_CACHE}" python3 "${EMSCRIPTEN_BIN}/embuilder.py" build SYSTEM MINIMAL && \
   rm -fr "${EMSCRIPTEN_TARGET_DIR}/upstream/emscripten/tests" && \
+# npm is not used by emscripten at build time; its bundled node_modules carry vulnerable packages
+  rm -fr "${EMSCRIPTEN_TARGET_DIR}/node/${NODE_VERSION}/lib/node_modules/npm" \
+         "${EMSCRIPTEN_TARGET_DIR}/node/${NODE_VERSION}/bin/npm" \
+         "${EMSCRIPTEN_TARGET_DIR}/node/${NODE_VERSION}/bin/npx" && \
 # The "sed" command below removes the /TEMP_DIR line from the generated configs
 # We replace it with a folder of our own
   sed '/TEMP_DIR =/d' "${EMSCRIPTEN_CONFIG}" && \
   echo TEMP_DIR = \'${EMSCRIPTEN_TEMP_DIR}\' >> ${EMSCRIPTEN_CONFIG}
 
 
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-base-env:1.7.0
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-base-env:1.8.0
 
 ARG EMSCRIPTEN_VERSION
 ARG NODE_VERSION

--- a/server/docker/Dockerfile.linux-env
+++ b/server/docker/Dockerfile.linux-env
@@ -1,4 +1,4 @@
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-base-env:1.7.0
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-base-env:1.8.0
 
 ENV CLANG_VERSION=20
 ENV CLANG_HOME=/usr/lib/llvm-${CLANG_VERSION}

--- a/server/docker/Dockerfile.nssdk.2143-env
+++ b/server/docker/Dockerfile.nssdk.2143-env
@@ -2,7 +2,7 @@ ARG PLATFORMSDK_DIR=/opt/platformsdk
 ARG NINTENDO_SDK_VERSION=21.4.3
 ARG NINTENDO_SDK_ROOT=${PLATFORMSDK_DIR}/nx-${NINTENDO_SDK_VERSION}
 
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.1.0 AS build
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.2.0 AS build
 
 ARG NINTENDO_SDK_VERSION
 ARG NINTENDO_SDK_ROOT
@@ -14,7 +14,7 @@ RUN --mount=type=secret,id=DM_PACKAGES_URL,required=true \
    mkdir -p "${NINTENDO_SDK_ROOT}" && \
    wget -q -O - "$(cat /run/secrets/DM_PACKAGES_URL)/${SWITCH_SDK_FILENAME}" | tar xz -C "${NINTENDO_SDK_ROOT}"
 
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-wine-env:1.9.0
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-wine-env:1.10.0
 
 ARG NINTENDO_SDK_VERSION
 ARG NINTENDO_SDK_ROOT

--- a/server/docker/Dockerfile.ps4.12500-env
+++ b/server/docker/Dockerfile.ps4.12500-env
@@ -2,7 +2,7 @@ ARG PLATFORMSDK_DIR=/opt/platformsdk
 ARG PS4_SDK_VERSION=12.500
 ARG PS4_SDK=${PLATFORMSDK_DIR}/ps4-sdk-${PS4_SDK_VERSION}
 
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.1.0 AS build
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.2.0 AS build
 
 ARG PS4_SDK_VERSION
 ARG PS4_SDK
@@ -14,7 +14,7 @@ RUN --mount=type=secret,id=DM_PACKAGES_URL,required=true \
   mkdir -p "${PS4_SDK}" && \
   wget -q -O - "$(cat /run/secrets/DM_PACKAGES_URL)/${PS4_SDK_FILENAME}" | tar xz -C "${PS4_SDK}" --strip-components=1
 
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-wine-env:1.9.0
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-wine-env:1.10.0
 
 ARG PS4_SDK_VERSION
 ARG PS4_SDK

--- a/server/docker/Dockerfile.ps5.12000-env
+++ b/server/docker/Dockerfile.ps5.12000-env
@@ -2,7 +2,7 @@ ARG PLATFORMSDK_DIR=/opt/platformsdk
 ARG PS5_SDK_VERSION=12.000
 ARG PS5_SDK=${PLATFORMSDK_DIR}/ps5-sdk-${PS5_SDK_VERSION}
 
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.1.0 AS build
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.2.0 AS build
 
 ARG PS5_SDK_VERSION
 ARG PS5_SDK
@@ -14,7 +14,7 @@ RUN --mount=type=secret,id=DM_PACKAGES_URL,required=true \
   mkdir -p "${PS5_SDK}" && \
   wget -q -O - "$(cat /run/secrets/DM_PACKAGES_URL)/${PS5_SDK_FILENAME}" | tar xz -C "${PS5_SDK}" --strip-components=1
 
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-wine-env:1.9.0
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-wine-env:1.10.0
 
 ARG PS5_SDK_VERSION
 ARG PS5_SDK

--- a/server/docker/Dockerfile.wine-env
+++ b/server/docker/Dockerfile.wine-env
@@ -1,4 +1,4 @@
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-base-env:1.7.0
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-base-env:1.8.0
 
 # Disable all debug messages
 ENV WINEDEBUG="-all"
@@ -41,7 +41,7 @@ RUN wget -q -O - https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor -o
 # Install winetricks
 RUN wget -nv -O /usr/bin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks \
     && chmod +x /usr/bin/winetricks && \
-  apt-get remove -y wget lsb-release software-properties-common gnupg wget && \
+  apt-get purge -y wget lsb-release software-properties-common gnupg ipp-usb && \
   apt-get autoremove -y && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \

--- a/server/docker/Dockerfile.winsdk.2026_145136231-env
+++ b/server/docker/Dockerfile.winsdk.2026_145136231-env
@@ -5,7 +5,7 @@ ARG WINDOWS_MSVC_VERSION=14.51.36231
 ARG WINDOWS_SDK_DIR=${PLATFORMSDK_WIN32}/WindowsKits/10
 ARG WINDOWS_MSVC_DIR="${PLATFORMSDK_WIN32}/MicrosoftVisualStudio2026/VC/Tools/MSVC/${WINDOWS_MSVC_VERSION}"
 
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.1.0 AS build
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.2.0 AS build
 
 ARG PLATFORMSDK_WIN32
 ARG WINDOWS_SDK_VERSION
@@ -74,7 +74,7 @@ RUN \
 
 WORKDIR /
 
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-wine-env:1.9.0
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-wine-env:1.10.0
 
 ARG PLATFORMSDK_WIN32
 ARG WINDOWS_SDK_VERSION

--- a/server/docker/Dockerfile.xbox.251002-env
+++ b/server/docker/Dockerfile.xbox.251002-env
@@ -1,7 +1,7 @@
 ARG XBOX_SDK_VERSION=251002
 ARG XBOX_SDK=${PLATFORMSDK_DIR}/xbox-sdk-${XBOX_SDK_VERSION}
 
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.1.0 AS build
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-build-env:1.2.0 AS build
 
 ARG XBOX_SDK_VERSION
 ARG XBOX_SDK
@@ -13,7 +13,7 @@ RUN --mount=type=secret,id=DM_PACKAGES_URL,required=true \
   mkdir -p "${XBOX_SDK}" && \
   wget -q -O - "$(cat /run/secrets/DM_PACKAGES_URL)/${XBOX_SDK_FILENAME}" | tar xz -C "${XBOX_SDK}" --strip-components=1
 
-FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-winsdk-2026_145136231-env:1.2.0
+FROM europe-west1-docker.pkg.dev/extender-426409/extender-public-registry/extender-winsdk-2026_145136231-env:1.3.0
 
 ARG XBOX_SDK_VERSION
 ARG XBOX_SDK

--- a/server/src/main/resources/template.build.gradle
+++ b/server/src/main/resources/template.build.gradle
@@ -22,7 +22,7 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion {{compile-sdk-version}}
+    compileSdk = {{compile-sdk-version}}
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
## Summary

Fixes the vulnerability findings GCP Artifact Registry reports on the runtime Extender images (every image referenced from `server/docker/docker-compose.yml`). All CRITICAL/HIGH findings trace to five causes, none of them the Ubuntu base itself:

| Cause | Images | Fix |
|---|---|---|
| `/usr/sbin/ipp-usb` (Go 1.18 binary pulled in by wine's `--install-recommends`; 77 CVEs, all 11 CRITICALs) | wine, winsdk-2026, nssdk, ps4, ps5, xbox | `apt-get purge ipp-usb` in `Dockerfile.wine-env` |
| Gradle 9.1.0 bundled jars (jackson 2.16.1, bcpg/bcprov 1.81, plexus-utils 3.5.1, jsoup 1.15.3, commons-lang3 3.17.0) | android-env, android-ndk25_sdk36 | Gradle 9.7.1 + Android Gradle Plugin 9.4.0 (AGP 8.x cannot run on Gradle ≥ 9.6) |
| Legacy Android SDK `tools/` dir (guava 22, protobuf 3.0.0, commons-compress 1.12, httpclient 4.2.6, jetty 8, bcprov 1.56) and pip/setuptools in the NDK python | android-ndk25_sdk36 | removed in the build stage; `tools/` was only on `PATH`, nothing uses it |
| npm bundled with emsdk's node 20.18.0 (tar CRITICAL, sigstore, pacote, glob, …) | emsdk-406 | removed in the build stage; emscripten does not invoke npm |
| Stale OS packages (openssl HIGH, glibc/krb5/pam/systemd/tar/curl/perl MEDIUM+LOW) | all | refreshed the pinned `ubuntu:22.04` digest in `build-env` and `base-env`; full rebuild cascade |

Image versions are bumped through the dependency chain (`build` 1.2.0, `base` 1.8.0, `wine` 1.10.0, `android` 1.9.0, `winsdk-2026_145136231` 1.3.0) in the Dockerfiles and `server/build-docker.sh`. `docker-compose.yml` uses `:latest`, so no change there.

`template.build.gradle` switches from the legacy `compileSdkVersion N` call to the `compileSdk = N` property for AGP 9; the internal `AndroidArtifacts` class it imports is still present in AGP 9.4.0.
